### PR TITLE
Set up connect modal

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,11 +1,17 @@
 import React from 'react';
 import { addDecorator } from '@storybook/react';
 
+import { ModalProvider } from 'providers';
+import { ModalManager } from 'providers/ModalProvider';
+import modals from 'config/modals';
 import { Box, GlobalStyles, ThemeProvider } from 'ui-kit';
 
 addDecorator(story => (
   <ThemeProvider>
-    <GlobalStyles />
-    {story()}
+    <ModalProvider modals={modals}>
+      <GlobalStyles />
+      {story()}
+      <ModalManager />
+    </ModalProvider>
   </ThemeProvider>
 ));

--- a/components/Modals/ConnectModal/ConnectModal.js
+++ b/components/Modals/ConnectModal/ConnectModal.js
@@ -1,0 +1,64 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import { Avatar, Modal, Box, Button, TextInput, Radio } from 'ui-kit';
+
+function ConnectModal(props = {}) {
+  return (
+    <Modal {...props}>
+      {
+        <Box display="flex" flexDirection="column" pl="l" pr="l">
+          <Box
+            display="flex"
+            alignItems="center"
+            flexDirection="column"
+            mb="base"
+          >
+            <Avatar
+              src="https://source.unsplash.com/random/200x200"
+              height="100px"
+              width="100px"
+            />
+          </Box>
+
+          <Box textAlign="center" as="h2">
+            Connect with Juan
+          </Box>
+          <Box textAlign="center" as="p" mb="l">
+            Send a message to let the leader know you’re interested.
+          </Box>
+          <TextInput
+            id="body"
+            multiline
+            placeholder={'Hey Juan, I’m interested in joining your Crew group!'}
+            autoFocus
+            mb="base"
+            height="115px"
+          />
+          <Box as="p" mb="base">
+            The leader will respond with the next steps. How would you like to
+            be reached?
+          </Box>
+          <Box display="flex" mb="l">
+            <Radio
+              id="email"
+              label="Email"
+              containerProps={{ marginRight: 'base' }}
+            />
+            <Radio id="phone" label="Phone" />
+          </Box>
+          <Button type="submit" mb="base">
+            Send
+          </Button>
+        </Box>
+      }
+    </Modal>
+  );
+}
+
+ConnectModal.propTypes = {
+  ...Modal.propTypes,
+  leaderName: PropTypes.string,
+};
+
+export default ConnectModal;

--- a/components/Modals/ConnectModal/ConnectModal.stories.js
+++ b/components/Modals/ConnectModal/ConnectModal.stories.js
@@ -1,0 +1,12 @@
+import React from 'react';
+
+import ConnectModal from './ConnectModal';
+
+export default {
+  title: 'components/ConnectModal',
+  component: ConnectModal,
+};
+
+export const Default = () => {
+  return <ConnectModal />;
+};

--- a/components/Modals/ConnectModal/index.js
+++ b/components/Modals/ConnectModal/index.js
@@ -1,0 +1,3 @@
+import ConnectModal from './ConnectModal';
+
+export default ConnectModal;

--- a/components/Modals/index.js
+++ b/components/Modals/index.js
@@ -1,3 +1,4 @@
 import AuthModal from './AuthModal';
+import ConnectModal from './ConnectModal';
 
-export { AuthModal };
+export { AuthModal, ConnectModal };

--- a/config/modals.js
+++ b/config/modals.js
@@ -1,5 +1,5 @@
 import DefaultModal from 'ui-kit/Modal';
-import { AuthModal } from 'components/Modals';
+import { AuthModal, ConnectModal } from 'components/Modals';
 
 const modals = [
   {
@@ -9,6 +9,10 @@ const modals = [
   {
     title: 'Auth',
     component: AuthModal,
+  },
+  {
+    title: 'ConnectModal',
+    component: ConnectModal,
   },
 ];
 

--- a/ui-kit/TextInput/TextInput.js
+++ b/ui-kit/TextInput/TextInput.js
@@ -17,7 +17,7 @@ function TextInput(props = {}) {
           ) : null}
         </FormLabel>
       ) : null}
-      <Styled.Input id={props.id} name={props.id} {...props} />
+      <Styled.Field id={props.id} name={props.id} {...props} />
     </Styled>
   );
 }
@@ -32,10 +32,12 @@ TextInput.propTypes = {
   }),
   id: PropTypes.string.isRequired,
   label: PropTypes.string,
+  tag: PropTypes.string,
 };
 
 TextInput.defaultProps = {
   type: 'text',
+  tag: 'input',
 };
 
 export default TextInput;

--- a/ui-kit/TextInput/TextInput.styles.js
+++ b/ui-kit/TextInput/TextInput.styles.js
@@ -1,3 +1,5 @@
+import React from 'react';
+
 import styled from 'styled-components';
 import { themeGet } from '@styled-system/theme-get';
 
@@ -9,7 +11,13 @@ const TextInput = styled.div`
   ${system}
 `;
 
-const Input = styled.input`
+const e = React.createElement;
+
+const getTag = ({ multiline }) => (multiline ? 'textarea' : 'input');
+
+const Field = styled(({ tag = 'input', children, ...props }) =>
+  e(getTag(props), props, children)
+)`
   border: 2px solid ${themeGet('colors.border')};
   border-radius: ${themeGet('radii.s')};
   font-family: ${themeGet('fonts.base')};
@@ -25,6 +33,6 @@ const Input = styled.input`
   ${system}
 `;
 
-TextInput.Input = Input;
+TextInput.Field = Field;
 
 export default TextInput;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/2528817/105097558-6dcd3700-5a6e-11eb-875e-c9999add9f8b.png)
Sets up the connect modal component and modifies the `TextInput` to allow for text-area elements when you pass a `multiline` prop. 

To see this component you can check out the story. The content is all static currently, and will be wired up later.