### PR TITLE
Finder filter options refactor

### DIFF
--- a/components/GroupSearchFilters/GroupSearchFilters.js
+++ b/components/GroupSearchFilters/GroupSearchFilters.js
@@ -12,7 +12,7 @@ function CurrentFiltersList(props = {}) {
           return null;
         }
 
-        let label;
+        let label = key;
         switch (key) {
           case 'campusNames':
             label = 'Campuses';
@@ -24,7 +24,7 @@ function CurrentFiltersList(props = {}) {
             label = 'Lineups';
             break;
           default:
-            return null;
+            break;
         }
 
         return (

--- a/components/Modals/GroupFilterModal/GroupFilterModal.js
+++ b/components/Modals/GroupFilterModal/GroupFilterModal.js
@@ -1,12 +1,10 @@
 import React from 'react';
-import { GroupFiltersProvider } from 'providers';
 import { Modal } from 'ui-kit';
 
 import GroupFilterSubPreferences from './GroupFilterSubPreferences';
 import GroupFilterWhereWhen from './GroupFilterWhereWhen';
 
 function GroupFilterModal(props = {}) {
-  console.log('<GroupFilterModal> props:', props);
   function render(step) {
     switch (step) {
       case 0: {
@@ -21,23 +19,13 @@ function GroupFilterModal(props = {}) {
     }
   }
 
-  return (
-    <GroupFiltersProvider
-      preferences={props.preferences}
-      subPreferences={props.subPreferences}
-    >
-      <Modal {...props}>{render}</Modal>
-    </GroupFiltersProvider>
-  );
+  return <Modal {...props}>{render}</Modal>;
 }
 
 GroupFilterModal.propTypes = {
   ...Modal.propTypes,
 };
 
-GroupFilterModal.defaultProps = {
-  preferences: [],
-  subPreferences: [],
-};
+GroupFilterModal.defaultProps = {};
 
 export default GroupFilterModal;

--- a/components/Modals/GroupFilterModal/GroupFilterModal.js
+++ b/components/Modals/GroupFilterModal/GroupFilterModal.js
@@ -1,10 +1,12 @@
 import React from 'react';
+import { GroupFiltersProvider } from 'providers';
 import { Modal } from 'ui-kit';
 
 import GroupFilterSubPreferences from './GroupFilterSubPreferences';
 import GroupFilterWhereWhen from './GroupFilterWhereWhen';
 
 function GroupFilterModal(props = {}) {
+  console.log('<GroupFilterModal> props:', props);
   function render(step) {
     switch (step) {
       case 0: {
@@ -19,11 +21,23 @@ function GroupFilterModal(props = {}) {
     }
   }
 
-  return <Modal {...props}>{render}</Modal>;
+  return (
+    <GroupFiltersProvider
+      preferences={props.preferences}
+      subPreferences={props.subPreferences}
+    >
+      <Modal {...props}>{render}</Modal>
+    </GroupFiltersProvider>
+  );
 }
 
 GroupFilterModal.propTypes = {
   ...Modal.propTypes,
+};
+
+GroupFilterModal.defaultProps = {
+  preferences: [],
+  subPreferences: [],
 };
 
 export default GroupFilterModal;

--- a/components/Modals/GroupFilterModal/GroupFilterSubPreferences.js
+++ b/components/Modals/GroupFilterModal/GroupFilterSubPreferences.js
@@ -33,11 +33,11 @@ function GroupFilterSubPreference(props = {}) {
         Select the types of Crew groups you’re interested in.
       </Box>
       <Box mb="l">
-        {filtersState.options.subPreferences.map(({ label, value }) => (
+        {filtersState.options.subPreferences.map(value => (
           <Checkbox
             key={value}
             id={value}
-            label={label}
+            label={value}
             value={value}
             name="subPreferences"
             onChange={handleChange}

--- a/components/Modals/GroupFilterModal/GroupFilterWhereWhen.js
+++ b/components/Modals/GroupFilterModal/GroupFilterWhereWhen.js
@@ -1,11 +1,13 @@
 import React from 'react';
 import { useRouter } from 'next/router';
+
 import {
   useGroupFilters,
   update,
   toggleValue,
 } from 'providers/GroupFiltersProvider';
 import { hideModal, useModalDispatch } from 'providers/ModalProvider';
+
 import { Box, Button, Checkbox, Select } from 'ui-kit';
 
 function GroupFilterWhereWhen(props = {}) {
@@ -56,9 +58,9 @@ function GroupFilterWhereWhen(props = {}) {
           defaultValue={filtersState.values.campuses[0] || ''}
         >
           <Select.Option value="">Select...</Select.Option>
-          {filtersState.options.campuses.map(({ label, value }) => (
+          {filtersState.options.campuses.map(value => (
             <Select.Option key={value} value={value}>
-              {label}
+              {value}
             </Select.Option>
           ))}
         </Select>
@@ -67,11 +69,11 @@ function GroupFilterWhereWhen(props = {}) {
         <Box as="p" color="subdued" mb="s">
           Preferred meeting days
         </Box>
-        {filtersState.options.days.map(({ label, value }) => (
+        {filtersState.options.days.map(value => (
           <Checkbox
             key={value}
             id={value}
-            label={label}
+            label={value}
             value={value}
             name="days"
             onChange={handleChange}

--- a/hooks/useGroupFilterOptions.js
+++ b/hooks/useGroupFilterOptions.js
@@ -1,10 +1,10 @@
 import useCampuses from './useCampuses';
-import usePreferences from './usePreferences';
+import useGroupPreferences from './useGroupPreferences';
 
 // NOTE: To be replaced by an API query that combines this data for us
 function useGroupFilterOptions() {
   const { campuses } = useCampuses();
-  const { preferences, subPreferences } = usePreferences();
+  const { preferences, subPreferences } = useGroupPreferences();
 
   return {
     campuses,

--- a/hooks/useGroupFilterOptions.js
+++ b/hooks/useGroupFilterOptions.js
@@ -1,0 +1,16 @@
+import useCampuses from './useCampuses';
+import usePreferences from './usePreferences';
+
+// NOTE: To be replaced by an API query that combines this data for us
+function useGroupFilterOptions() {
+  const { campuses } = useCampuses();
+  const { preferences, subPreferences } = usePreferences();
+
+  return {
+    campuses,
+    preferences,
+    subPreferences,
+  };
+}
+
+export default useGroupFilterOptions;

--- a/pages/community/index.js
+++ b/pages/community/index.js
@@ -1,7 +1,5 @@
 import { Box, Button, Cell, utils } from 'ui-kit';
 import { CommunityList, Footer, Header, SEO } from 'components';
-import { GET_PREFERENCES, GET_SUB_PREFERENCES } from 'hooks/usePreferences';
-import { initializeApollo } from 'lib/apolloClient';
 import { CommunitiesProvider } from 'providers';
 import { update as updateAuth, useAuth } from 'providers/AuthProvider';
 import { useModalDispatch, showModal } from 'providers/ModalProvider';
@@ -13,8 +11,6 @@ const DEFAULT_CONTENT_WIDTH = utils.rem('1100px');
 export default function Community(props = {}) {
   const [{ authenticated }, authDispatch] = useAuth();
   const modalDispatch = useModalDispatch();
-
-  // console.log('📄 <Community> props:', props);
 
   function handleOnClick() {
     if (!authenticated) {

--- a/pages/community/index.js
+++ b/pages/community/index.js
@@ -13,7 +13,6 @@ const DEFAULT_CONTENT_WIDTH = utils.rem('1100px');
 export default function Community(props = {}) {
   const [{ authenticated }, authDispatch] = useAuth();
   const modalDispatch = useModalDispatch();
-  const { preferences, subPreferences } = props;
 
   // console.log('📄 <Community> props:', props);
 
@@ -22,14 +21,11 @@ export default function Community(props = {}) {
       modalDispatch(showModal('Auth'));
       authDispatch(
         updateAuth({
-          onSuccess: () =>
-            modalDispatch(
-              showModal('GroupFilter', { preferences, subPreferences })
-            ),
+          onSuccess: () => modalDispatch(showModal('GroupFilter')),
         })
       );
     } else {
-      modalDispatch(showModal('GroupFilter', { preferences, subPreferences }));
+      modalDispatch(showModal('GroupFilter'));
     }
   }
 
@@ -86,29 +82,4 @@ export default function Community(props = {}) {
       </Box>
     </>
   );
-}
-
-export async function getServerSideProps(context) {
-  console.log('🛰️ getServerSideProps()');
-  const apolloClient = initializeApollo();
-
-  console.log('--> ⏳ Fetching preferences and subPreferences in parallel...');
-  const [queryPreferences, querySubPreferences] = await Promise.all([
-    apolloClient.query({ query: GET_PREFERENCES }),
-    apolloClient.query({ query: GET_SUB_PREFERENCES }),
-    // apolloClient.query({ query: GET_CAMPUSES }),
-  ]);
-
-  const preferences = queryPreferences?.data?.allPreferences || [];
-  const subPreferences = querySubPreferences?.data?.allSubPreferences || [];
-  console.log(
-    `--> ✅ Fetched (${preferences.length}) preferences and (${subPreferences.length}) subPreferences`
-  );
-
-  return {
-    props: {
-      preferences: queryPreferences?.data?.allPreferences || [],
-      subPreferences: querySubPreferences?.data?.allSubPreferences || [],
-    },
-  };
 }

--- a/pages/community/search/index.js
+++ b/pages/community/search/index.js
@@ -10,7 +10,7 @@ const DEFAULT_CONTENT_WIDTH = utils.rem('1100px');
 export default function CommunitySearch() {
   const [filtersState] = useGroupFilters();
   const modalDispatch = useModalDispatch();
-  const [searchGroups, { loading, groups, error }] = useSearchGroups({
+  const [searchGroups, { loading, groups }] = useSearchGroups({
     fetchPolicy: 'cache-and-network',
   });
 

--- a/providers/AppProvider.js
+++ b/providers/AppProvider.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { ApolloProvider } from '@apollo/client';
 
 import { useApollo } from 'lib/apolloClient';
-import { AuthProvider, GroupFiltersProvider, ModalProvider } from 'providers';
+import { AuthProvider, ModalProvider } from 'providers';
 import { ModalManager } from 'providers/ModalProvider';
 import modals from 'config/modals';
 import { ThemeProvider } from 'ui-kit';
@@ -14,12 +14,10 @@ function AppProvider(props = {}) {
     <ApolloProvider client={apolloClient}>
       <AuthProvider>
         <ThemeProvider>
-          <GroupFiltersProvider>
-            <ModalProvider modals={modals}>
-              {props.children}
-              <ModalManager />
-            </ModalProvider>
-          </GroupFiltersProvider>
+          <ModalProvider modals={modals}>
+            {props.children}
+            <ModalManager />
+          </ModalProvider>
         </ThemeProvider>
       </AuthProvider>
     </ApolloProvider>

--- a/providers/AppProvider.js
+++ b/providers/AppProvider.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { ApolloProvider } from '@apollo/client';
 
 import { useApollo } from 'lib/apolloClient';
-import { AuthProvider, ModalProvider } from 'providers';
+import { AuthProvider, ModalProvider, GroupFiltersProvider } from 'providers';
 import { ModalManager } from 'providers/ModalProvider';
 import modals from 'config/modals';
 import { ThemeProvider } from 'ui-kit';
@@ -14,10 +14,12 @@ function AppProvider(props = {}) {
     <ApolloProvider client={apolloClient}>
       <AuthProvider>
         <ThemeProvider>
-          <ModalProvider modals={modals}>
-            {props.children}
-            <ModalManager />
-          </ModalProvider>
+          <GroupFiltersProvider>
+            <ModalProvider modals={modals}>
+              {props.children}
+              <ModalManager />
+            </ModalProvider>
+          </GroupFiltersProvider>
         </ThemeProvider>
       </AuthProvider>
     </ApolloProvider>


### PR DESCRIPTION
# About
Dynamically populates the filter options for `campuses`, `preferences`, and `subPreferences` from the API instead of statically defined in the `<GroupFiltersProvider>.

A new hook `useGroupFilterOptions` fetches and consolidates that data. This will be imminently refactored to use 1 query from the API instead of zippering together a few sub-hooks/queries.

# Testing
Initiate the Finder flow from the root Community page, a CommunitySingle page, and the Search Results page.
Globally, the filters state should be shared/consistent across.
The `preference` option should be pre-populated from the routes like `/community/sisterhood`.
All selected/applied filters should display on the Search Results page, even if they didn't affect the results/get processed (i.e. days).