### PR TITLE
Rename preference hook and fix query spread issue

### DIFF
--- a/hooks/index.js
+++ b/hooks/index.js
@@ -15,7 +15,7 @@ import useForm from './useForm';
 import useGroup from './useGroup';
 import useGroupContentId from './useGroupContentId';
 import useGroups from './useGroups';
-import usePreferences from './usePreferences';
+import useGroupPreferences from './useGroupPreferences';
 import useRegisterWithEmail from './useRegisterWithEmail';
 import useRegisterWithSms from './useRegisterWithSms';
 import useRequestPin from './useRequestPin';
@@ -42,7 +42,7 @@ export {
   useGroup,
   useGroupContentId,
   useGroups,
-  usePreferences,
+  useGroupPreferences,
   useRegisterWithEmail,
   useRegisterWithSms,
   useRequestPin,

--- a/hooks/useGroupPreferences.js
+++ b/hooks/useGroupPreferences.js
@@ -36,15 +36,13 @@ export const GET_SUB_PREFERENCES = gql`
   }
 `;
 
-function usePreferences(options = {}) {
+function useGroupPreferences(options = {}) {
   const queryPreferences = useQuery(GET_PREFERENCES, options);
   const querySubPreferences = useQuery(GET_SUB_PREFERENCES, options);
   return {
     preferences: queryPreferences?.data?.allPreferences || [],
     subPreferences: querySubPreferences?.data?.allSubPreferences || [],
-    ...queryPreferences,
-    ...querySubPreferences,
   };
 }
 
-export default usePreferences;
+export default useGroupPreferences;

--- a/pages/community/[title].js
+++ b/pages/community/[title].js
@@ -5,11 +5,11 @@ import kebabCase from 'lodash/kebabCase';
 import toLower from 'lodash/toLower';
 
 import { CommunitiesProvider } from 'providers';
-import { usePreferences } from 'hooks';
+import { useGroupPreferences } from 'hooks';
 import { CommunitySingle, Layout } from 'components';
 
 export default function Community(props) {
-  const { preferences, subPreferences } = usePreferences();
+  const { preferences, subPreferences } = useGroupPreferences();
   const router = useRouter();
   const { title } = router.query;
   const formatTitleAsUrl = title => kebabCase(toLower(title));

--- a/providers/CommunitiesProvider.js
+++ b/providers/CommunitiesProvider.js
@@ -1,10 +1,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import { usePreferences } from 'hooks';
+import { useGroupPreferences } from 'hooks';
 
 function CommunitiesProvider({ Component, options, ...props }) {
-  const { loading, error, preferences } = usePreferences(options);
+  const { loading, error, preferences } = useGroupPreferences(options);
   return (
     <Component data={preferences} loading={loading} error={error} {...props} />
   );


### PR DESCRIPTION
Simple clean up PR that renames usePreference hook to `useGroupPreference` and also removes unnecessary spreading on the hook return. No functionality should change with this PR. 

Ref: https://github.com/christfellowshipchurch/web-app-v2/pull/10#discussion_r567121466