### PR TITLE
Add a success step to the connect modal

### DIFF
--- a/components/Modals/ConnectModal/ConnectForm.js
+++ b/components/Modals/ConnectModal/ConnectForm.js
@@ -1,0 +1,69 @@
+import React, { useEffect } from 'react';
+import PropTypes from 'prop-types';
+
+import { showStep, useModalDispatch } from 'providers/ModalProvider';
+
+import { useForm } from 'hooks';
+
+import { Avatar, Box, Button, TextInput } from 'ui-kit';
+
+function ConnectForm(props = {}) {
+  const modalDispatch = useModalDispatch();
+
+  const { values, handleChange, handleSubmit, setValues } = useForm(() => {
+    console.log('Show me Results', values);
+    modalDispatch(showStep(1));
+  });
+
+  const defaultMessage = `Hey ${props.leaderName}, I’m interested in joining your Crew group!`;
+
+  useEffect(() => {
+    const initialValue = {
+      message: defaultMessage,
+    };
+    setValues(initialValue);
+  }, [setValues, defaultMessage]);
+
+  return (
+    <Box
+      as="form"
+      onSubmit={handleSubmit}
+      display="flex"
+      flexDirection="column"
+      pl="l"
+      pr="l"
+    >
+      <Box display="flex" alignItems="center" flexDirection="column" mb="base">
+        <Avatar src={props.leaderAvatar} height="100px" width="100px" />
+      </Box>
+
+      <Box textAlign="center" as="h2">
+        {`Connect with ${props.leaderName}`}
+      </Box>
+      <Box textAlign="center" as="p" mb="l">
+        Send a message to let the leader know you’re interested.
+      </Box>
+
+      <TextInput
+        as="textarea"
+        id="message"
+        label="Message"
+        placeholder={defaultMessage}
+        autoFocus
+        mb="base"
+        height="115px"
+        onChange={handleChange}
+      />
+      <Button type="submit" mb="base">
+        Send
+      </Button>
+    </Box>
+  );
+}
+
+ConnectForm.propTypes = {
+  initialValue: PropTypes.string,
+  leaderName: PropTypes.string,
+};
+
+export default ConnectForm;

--- a/components/Modals/ConnectModal/ConnectModal.js
+++ b/components/Modals/ConnectModal/ConnectModal.js
@@ -1,72 +1,29 @@
-import React, { useEffect } from 'react';
-import PropTypes from 'prop-types';
-import { useForm } from 'hooks';
+import React from 'react';
 
-import { Avatar, Modal, Box, Button, TextInput, Radio } from 'ui-kit';
+import { Modal } from 'ui-kit';
+import Form from './ConnectForm';
+import Success from './ConnectSuccess';
 
 function ConnectModal(props = {}) {
-  const { values, handleChange, handleSubmit, setValues } = useForm(() => {
-    console.log('Show me Results', values);
-  });
-
-  const defaultMessage = `Hey ${props.leaderName}, I’m interested in joining your Crew group!`;
-
-  useEffect(() => {
-    const initialValue = {
-      message: defaultMessage,
-    };
-    setValues(initialValue);
-  }, [setValues, defaultMessage]);
-
-  return (
-    <Modal {...props}>
-      {
-        <Box
-          as="form"
-          onSubmit={handleSubmit}
-          display="flex"
-          flexDirection="column"
-          pl="l"
-          pr="l"
-        >
-          <Box
-            display="flex"
-            alignItems="center"
-            flexDirection="column"
-            mb="base"
-          >
-            <Avatar src={props.leaderAvatar} height="100px" width="100px" />
-          </Box>
-
-          <Box textAlign="center" as="h2">
-            {`Connect with ${props.leaderName}`}
-          </Box>
-          <Box textAlign="center" as="p" mb="l">
-            Send a message to let the leader know you’re interested.
-          </Box>
-
-          <TextInput
-            as="textarea"
-            id="message"
-            label="Message"
-            placeholder={defaultMessage}
-            autoFocus
-            mb="base"
-            height="115px"
-            onChange={handleChange}
-          />
-          <Button type="submit" mb="base">
-            Send
-          </Button>
-        </Box>
+  function render(step) {
+    switch (step) {
+      case 0: {
+        return <Form {...props} />;
       }
-    </Modal>
-  );
+      case 1: {
+        return <Success />;
+      }
+      default: {
+        return <Form />;
+      }
+    }
+  }
+
+  return <Modal {...props}>{render}</Modal>;
 }
 
 ConnectModal.propTypes = {
   ...Modal.propTypes,
-  leaderName: PropTypes.string,
 };
 
 export default ConnectModal;

--- a/components/Modals/ConnectModal/ConnectSuccess.js
+++ b/components/Modals/ConnectModal/ConnectSuccess.js
@@ -1,0 +1,29 @@
+import React from 'react';
+
+import { hideModal, useModalDispatch } from 'providers/ModalProvider';
+
+import { Box, Button } from 'ui-kit';
+
+function ConnectSuccess() {
+  const dispatch = useModalDispatch();
+
+  function handleClose(event) {
+    event.preventDefault();
+    dispatch(hideModal());
+  }
+
+  return (
+    <Box textAlign="center" display="flex" flexDirection="column">
+      <Box as="p" fontSize="90px">
+        🚀
+      </Box>
+      <Box as="h1">Success!</Box>
+      <Box as="p" color="subdued" mb="l" px="120px">
+        Your message was sent. Someone will reach out to you soon.
+      </Box>
+      <Button onClick={handleClose}>Continue</Button>
+    </Box>
+  );
+}
+
+export default ConnectSuccess;


### PR DESCRIPTION
A first pass at a success modal when a user sends a message to the group leader. (Emoji is a placeholder)

TO TEST:
Click the `contact` button on one of your search results cards and send a message.

![image](https://user-images.githubusercontent.com/2528817/106940068-b29bd380-66e6-11eb-831a-276832b24011.png)
