### PR TITLE
Improve Group Search UX

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,23 +1,23 @@
 {
   "cSpell.ignoreWords": [
-    "CRDS",
+    "boynton",
     "cfri",
+    "CRDS",
     "cwed",
+    "daytona",
+    "desaturate",
     "iphone",
     "lifecycle",
+    "lucie",
     "onboarding",
     "ondevice",
     "overscroll",
     "overscrolling",
+    "picton",
     "refetch",
     "subviews",
     "swiper",
     "viewability",
     "wireframe"
-  ],
-  "cSpell.words": [
-    "boynton",
-    "daytona",
-    "lucie"
   ]
 }

--- a/components/FeatureFeed/FeatureFeed.js
+++ b/components/FeatureFeed/FeatureFeed.js
@@ -33,7 +33,7 @@ const FeatureFeed = (props = {}) => {
           },
         }}
       />
-      {isLastItem(i) && <Divider />}
+      {isLastItem(i) && <Divider maxWidth="50rem" mt="xl" />}
     </Box>
   ));
 };

--- a/components/FilterField/FilterField.js
+++ b/components/FilterField/FilterField.js
@@ -55,11 +55,19 @@ export default function FilterField(props = {}) {
               const { value } = event.target;
               props.onChange({ name: props.name, value });
             }}
-            defaultValue={props.values[0] || ''}
           >
-            <Select.Option value="">Select...</Select.Option>
+            <Select.Option
+              value=""
+              selected={props.values.length === 0 || props.values[0] === ''}
+            >
+              Select...
+            </Select.Option>
             {props.options.map(value => (
-              <Select.Option key={value} value={value}>
+              <Select.Option
+                key={value}
+                value={value}
+                selected={props.values[0] === value}
+              >
                 {value}
               </Select.Option>
             ))}

--- a/components/FilterField/FilterField.js
+++ b/components/FilterField/FilterField.js
@@ -5,19 +5,39 @@ import { Box, Button, Select } from 'ui-kit';
 
 export default function FilterField(props = {}) {
   return (
-    <Box mb="l" textAlign="left" {...props}>
-      <Box as="h4" mb="base">
-        {props.label}
+    <Box mb={props.mb || 'xl'} textAlign="left">
+      <Box
+        display="flex"
+        flexDirection="row"
+        justifyContent="space-between"
+        mb="base"
+      >
+        <Box as="h4" mb="0">
+          {props.label}
+        </Box>
+        {props.values.length > 0 && (
+          <Button
+            name={props.name}
+            variant="link"
+            size="s"
+            lineHeight={1.2}
+            onClick={props.onClear}
+          >
+            Clear
+          </Button>
+        )}
       </Box>
       <Box>
         {props.filterType === 'multi-select' ? (
           props.options.map(value => (
             <Button
               key={value}
-              label={value}
-              mr="xs"
               mb="s"
-              onClick={() => props.onChange({ name: props.name, value })}
+              mr="xs"
+              onClick={event => {
+                event.preventDefault();
+                props.onChange({ name: props.name, value });
+              }}
               rounded={true}
               size="s"
               status={props.values.includes(value) ? 'SELECTED' : 'IDLE'}
@@ -30,7 +50,11 @@ export default function FilterField(props = {}) {
           <Select
             id={props.name}
             name={props.name}
-            onChange={props.onChange}
+            onChange={event => {
+              event.persist();
+              const { value } = event.target;
+              props.onChange({ name: props.name, value });
+            }}
             defaultValue={props.values[0] || ''}
           >
             <Select.Option value="">Select...</Select.Option>
@@ -56,6 +80,7 @@ FilterField.propTypes = {
   values: PropTypes.arrayOf(PropTypes.string).isRequired,
   // Will be given an object with a `name` and `value` prop
   onChange: PropTypes.func.isRequired,
+  onClear: PropTypes.func.isRequired,
 };
 
 FilterField.defaultProps = {

--- a/components/FilterField/FilterField.js
+++ b/components/FilterField/FilterField.js
@@ -1,0 +1,63 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import { Box, Button, Select } from 'ui-kit';
+
+export default function FilterField(props = {}) {
+  return (
+    <Box mb="l" textAlign="left" {...props}>
+      <Box as="h4" mb="base">
+        {props.label}
+      </Box>
+      <Box>
+        {props.filterType === 'multi-select' ? (
+          props.options.map(value => (
+            <Button
+              key={value}
+              label={value}
+              mr="xs"
+              mb="s"
+              onClick={() => props.onChange({ name: props.name, value })}
+              rounded={true}
+              size="s"
+              status={props.values.includes(value) ? 'SELECTED' : 'IDLE'}
+              variant="chip"
+            >
+              {value}
+            </Button>
+          ))
+        ) : (
+          <Select
+            id={props.name}
+            name={props.name}
+            onChange={props.onChange}
+            defaultValue={props.values[0] || ''}
+          >
+            <Select.Option value="">Select...</Select.Option>
+            {props.options.map(value => (
+              <Select.Option key={value} value={value}>
+                {value}
+              </Select.Option>
+            ))}
+          </Select>
+        )}
+      </Box>
+    </Box>
+  );
+}
+
+FilterField.propTypes = {
+  filterType: PropTypes.oneOf(['select', 'multi-select']),
+  label: PropTypes.string.isRequired,
+  name: PropTypes.string,
+  // Possible Options
+  options: PropTypes.arrayOf(PropTypes.string).isRequired,
+  // Currently selected options
+  values: PropTypes.arrayOf(PropTypes.string).isRequired,
+  // Will be given an object with a `name` and `value` prop
+  onChange: PropTypes.func.isRequired,
+};
+
+FilterField.defaultProps = {
+  filterType: 'multi-select',
+};

--- a/components/FilterField/FilterField.stories.js
+++ b/components/FilterField/FilterField.stories.js
@@ -1,0 +1,50 @@
+import React, { useState } from 'react';
+
+import FilterField from './FilterField';
+
+export default {
+  title: 'components/FilterField',
+  component: FilterField,
+};
+
+export const MultiSelect = () => {
+  const [values, setValues] = useState(['Lettuce', 'Onions']);
+
+  const handleChange = ({ name, value }) => {
+    if (values.includes(value)) {
+      setValues(values.filter(v => v !== value));
+    } else {
+      setValues(values.concat(value));
+    }
+  };
+
+  return (
+    <FilterField
+      filterType="multi-select"
+      label="Toppings"
+      name="Toppings"
+      options={['Lettuce', 'Mayo', 'Tomato', 'Onions', 'Jalapeños', 'Pickles']}
+      values={values}
+      onChange={handleChange}
+    />
+  );
+};
+
+export const SingleSelect = () => {
+  const [value, setValue] = useState([]);
+
+  const handleChange = ({ name, value }) => {
+    setValue([value]);
+  };
+
+  return (
+    <FilterField
+      filterType="select"
+      label="Protein"
+      name="Protein"
+      options={['Chicken', 'Beef', 'Pork', 'Vegan']}
+      values={value}
+      onChange={handleChange}
+    />
+  );
+};

--- a/components/FilterField/FilterField.stories.js
+++ b/components/FilterField/FilterField.stories.js
@@ -18,14 +18,31 @@ export const MultiSelect = () => {
     }
   };
 
+  const handleClear = event => {
+    event.preventDefault();
+    setValues([]);
+  };
+
   return (
     <FilterField
       filterType="multi-select"
       label="Toppings"
       name="Toppings"
-      options={['Lettuce', 'Mayo', 'Tomato', 'Onions', 'Jalapeños', 'Pickles']}
+      options={[
+        'Lettuce',
+        'Mayo',
+        'Tomato',
+        'Onions',
+        'Jalapeños',
+        'Pickles',
+        'Mushrooms',
+        'Hot Sauce',
+        'Ketchup',
+        'Mustard',
+      ]}
       values={values}
       onChange={handleChange}
+      onClear={handleClear}
     />
   );
 };
@@ -37,6 +54,11 @@ export const SingleSelect = () => {
     setValue([value]);
   };
 
+  const handleClear = event => {
+    event.preventDefault();
+    setValue([]);
+  };
+
   return (
     <FilterField
       filterType="select"
@@ -45,6 +67,7 @@ export const SingleSelect = () => {
       options={['Chicken', 'Beef', 'Pork', 'Vegan']}
       values={value}
       onChange={handleChange}
+      onClear={handleClear}
     />
   );
 };

--- a/components/FilterField/index.js
+++ b/components/FilterField/index.js
@@ -1,0 +1,3 @@
+import FilterField from './FilterField';
+
+export default FilterField;

--- a/components/GroupSearchFilters/FilterButton.js
+++ b/components/GroupSearchFilters/FilterButton.js
@@ -3,21 +3,7 @@ import PropTypes from 'prop-types';
 
 import { Box, Button } from 'ui-kit';
 
-const GroupSearchFilters = {};
-
-const Divider = (props = {}) => (
-  <Box
-    as="hr"
-    mt="s"
-    mb="base"
-    border="none"
-    bg="neutrals.200"
-    height={2}
-    {...props}
-  />
-);
-
-function FilterButton(props = {}) {
+export default function FilterButton(props = {}) {
   return (
     <Button
       mr="s"
@@ -53,8 +39,3 @@ FilterButton.propTypes = {
   labelDetail: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   onClick: PropTypes.func,
 };
-
-GroupSearchFilters.Divider = Divider;
-GroupSearchFilters.FilterButton = FilterButton;
-
-export default GroupSearchFilters;

--- a/components/GroupSearchFilters/GroupSearchFilters.js
+++ b/components/GroupSearchFilters/GroupSearchFilters.js
@@ -10,7 +10,6 @@ function GroupSearchFilters(props = {}) {
   const [filtersState, filtersDispatch] = useGroupFilters();
   const modalDispatch = useModalDispatch();
   const { campuses, preferences, subPreferences, days } = filtersState.values;
-  console.log('filtersState:', filtersState);
 
   function handleChangeClick() {
     modalDispatch(showModal('GroupFilter', { step: 2 }));

--- a/components/GroupSearchFilters/GroupSearchFilters.js
+++ b/components/GroupSearchFilters/GroupSearchFilters.js
@@ -1,92 +1,74 @@
 import PropTypes from 'prop-types';
-import isEmpty from 'lodash/isEmpty';
+
 import { useModalDispatch, showModal } from 'providers/ModalProvider';
 import { useGroupFilters, resetValues } from 'providers/GroupFiltersProvider';
 import { Box, Button } from 'ui-kit';
 
-function CurrentFiltersList(props = {}) {
-  return (
-    <Box fontSize="s">
-      {Object.entries(props.filters).map(([key, values]) => {
-        if (isEmpty(values)) {
-          return null;
-        }
-
-        let label = key;
-        switch (key) {
-          case 'campusNames':
-            label = 'Campuses';
-            break;
-          case 'preferences':
-            label = 'Group Types';
-            break;
-          case 'subPreferences':
-            label = 'Lineups';
-            break;
-          default:
-            break;
-        }
-
-        return (
-          <Box key={key} mb="base">
-            <Box as="span" fontWeight="bold">
-              {`${label}: `}
-            </Box>
-            {values.map(value => (
-              <Box
-                as="span"
-                bg="neutrals.200"
-                borderColor="neutrals.300"
-                borderStyle="solid"
-                borderWidth={1}
-                borderRadius="s"
-                display="inline-block"
-                ml="xs"
-                px="base"
-              >
-                {value}
-              </Box>
-            ))}
-          </Box>
-        );
-      })}
-    </Box>
-  );
-}
+import Styled from './GroupSearchFilters.styles';
 
 function GroupSearchFilters(props = {}) {
   const [filtersState, filtersDispatch] = useGroupFilters();
   const modalDispatch = useModalDispatch();
+  const { campuses, preferences, subPreferences, days } = filtersState.values;
+  console.log('filtersState:', filtersState);
 
   function handleChangeClick() {
-    modalDispatch(showModal('GroupFilter'));
+    modalDispatch(showModal('GroupFilter', { step: 2 }));
   }
 
   function handleClearClick() {
     filtersDispatch(resetValues());
   }
 
-  console.log(
-    '📡 Current search params',
-    Object.entries(filtersState.queryParams)
-  );
-
   return (
-    <Box mb="l">
-      <Box as="p" mb="l">
-        {props.loading && 'Finding groups…'}
-        {!props.loading &&
-          (props.resultsCount >= 1
-            ? `Found ${props.resultsCount} groups that meet your search criteria.`
-            : 'Could not find any groups that meet your search criteria.')}
-      </Box>
-      <Box mb="base">
+    <Box>
+      <Box mb="l">
         <Button onClick={handleChangeClick}>Change Filters</Button>
         <Button variant="secondary" ml="s" onClick={handleClearClick}>
-          Reset
+          Clear
         </Button>
       </Box>
-      <CurrentFiltersList filters={filtersState.queryParams} />
+      <Box
+        display="flex"
+        flexDirection="row"
+        justifyContent="space-between"
+        alignItems="flex-end"
+        mb="base"
+      >
+        <Box>
+          {campuses.length > 0 && (
+            <Styled.FilterButton
+              label="Campus"
+              labelDetail={campuses[0]}
+              onClick={handleChangeClick}
+            />
+          )}
+          {preferences.length > 0 && (
+            <Styled.FilterButton
+              label="Group Types"
+              labelDetail={preferences.length}
+              onClick={handleChangeClick}
+            />
+          )}
+          {subPreferences.length > 0 && (
+            <Styled.FilterButton
+              label="Lineups"
+              labelDetail={subPreferences.length}
+              onClick={handleChangeClick}
+            />
+          )}
+          {days.length > 0 && (
+            <Styled.FilterButton
+              label="Meeting Days"
+              labelDetail={days.length}
+              onClick={handleChangeClick}
+            />
+          )}
+        </Box>
+        <Box as="p" fontWeight="bold">{`${props.resultsCount} groups`}</Box>
+      </Box>
+
+      <Styled.Divider />
     </Box>
   );
 }

--- a/components/GroupSearchFilters/GroupSearchFilters.js
+++ b/components/GroupSearchFilters/GroupSearchFilters.js
@@ -2,9 +2,9 @@ import PropTypes from 'prop-types';
 
 import { useModalDispatch, showModal } from 'providers/ModalProvider';
 import { useGroupFilters, resetValues } from 'providers/GroupFiltersProvider';
-import { Box, Button } from 'ui-kit';
+import { Box, Button, Divider } from 'ui-kit';
 
-import Styled from './GroupSearchFilters.styles';
+import FilterButton from './FilterButton';
 
 function GroupSearchFilters(props = {}) {
   const [filtersState, filtersDispatch] = useGroupFilters();
@@ -36,28 +36,28 @@ function GroupSearchFilters(props = {}) {
       >
         <Box>
           {campuses.length > 0 && (
-            <Styled.FilterButton
+            <FilterButton
               label="Campus"
               labelDetail={campuses[0]}
               onClick={handleChangeClick}
             />
           )}
           {preferences.length > 0 && (
-            <Styled.FilterButton
+            <FilterButton
               label="Group Types"
               labelDetail={preferences.length}
               onClick={handleChangeClick}
             />
           )}
           {subPreferences.length > 0 && (
-            <Styled.FilterButton
+            <FilterButton
               label="Lineups"
               labelDetail={subPreferences.length}
               onClick={handleChangeClick}
             />
           )}
           {days.length > 0 && (
-            <Styled.FilterButton
+            <FilterButton
               label="Meeting Days"
               labelDetail={days.length}
               onClick={handleChangeClick}
@@ -67,7 +67,7 @@ function GroupSearchFilters(props = {}) {
         <Box as="p" fontWeight="bold">{`${props.resultsCount} groups`}</Box>
       </Box>
 
-      <Styled.Divider />
+      <Divider mt="s" mb="l" />
     </Box>
   );
 }

--- a/components/GroupSearchFilters/GroupSearchFilters.styles.js
+++ b/components/GroupSearchFilters/GroupSearchFilters.styles.js
@@ -1,0 +1,60 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import { Box, Button } from 'ui-kit';
+
+const GroupSearchFilters = {};
+
+const Divider = (props = {}) => (
+  <Box
+    as="hr"
+    mt="s"
+    mb="base"
+    border="none"
+    bg="neutrals.200"
+    height={2}
+    {...props}
+  />
+);
+
+function FilterButton(props = {}) {
+  return (
+    <Button
+      mr="s"
+      onClick={props.onClick}
+      rounded={true}
+      size="s"
+      variant="chip"
+      {...props}
+    >
+      {props.label}
+      {typeof props.labelDetail === 'number' ? (
+        <Box
+          as="span"
+          bg="primary"
+          borderRadius="xl"
+          color="paper"
+          ml="xs"
+          px="xs"
+        >
+          {props.labelDetail}
+        </Box>
+      ) : (
+        <Box as="span" color="primary" ml="xs">
+          {props.labelDetail}
+        </Box>
+      )}
+    </Button>
+  );
+}
+
+FilterButton.propTypes = {
+  label: PropTypes.string,
+  labelDetail: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  onClick: PropTypes.func,
+};
+
+GroupSearchFilters.Divider = Divider;
+GroupSearchFilters.FilterButton = FilterButton;
+
+export default GroupSearchFilters;

--- a/components/Modals/GroupFilterModal/GroupFilterAll.js
+++ b/components/Modals/GroupFilterModal/GroupFilterAll.js
@@ -2,7 +2,11 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { useRouter } from 'next/router';
 
-import { useGroupFilters, toggleValue } from 'providers/GroupFiltersProvider';
+import {
+  useGroupFilters,
+  toggleValue,
+  update,
+} from 'providers/GroupFiltersProvider';
 import { useModalDispatch, hideModal } from 'providers/ModalProvider';
 import { Box, Button } from 'ui-kit';
 
@@ -15,6 +19,14 @@ function GroupFilterAll(props = {}) {
 
   const handleMultiSelectChange = ({ name, value }) => {
     filtersDispatch(toggleValue({ name, value }));
+  };
+
+  const handleClear = event => {
+    event.preventDefault();
+
+    const { name } = event.target;
+    console.log('🚦 name:', name);
+    filtersDispatch(update({ [name]: [] }));
   };
 
   const handleSubmit = event => {
@@ -39,7 +51,7 @@ function GroupFilterAll(props = {}) {
       <Box as="h2" mb="l">
         Find your Community
       </Box>
-      <Box overflow="scroll" maxHeight="40vh" mb="base">
+      <Box overflow="scroll" maxHeight="50vh" mb="base">
         <FilterField
           filterType="select"
           label="Campus"
@@ -47,20 +59,23 @@ function GroupFilterAll(props = {}) {
           options={filtersState.options.campuses}
           values={filtersState.values.campuses}
           onChange={handleMultiSelectChange}
+          onClear={handleClear}
         />
         <FilterField
-          label="Group Types (Preferences)"
+          label="Group Types"
           name="preferences"
           options={filtersState.options.preferences}
           values={filtersState.values.preferences}
           onChange={handleMultiSelectChange}
+          onClear={handleClear}
         />
         <FilterField
-          label="Lineups (Sub-Preferences)"
+          label="Lineups"
           name="subPreferences"
           options={filtersState.options.subPreferences}
           values={filtersState.values.subPreferences}
           onChange={handleMultiSelectChange}
+          onClear={handleClear}
         />
         <FilterField
           label="Meeting Days"
@@ -68,7 +83,8 @@ function GroupFilterAll(props = {}) {
           options={filtersState.options.days}
           values={filtersState.values.days}
           onChange={handleMultiSelectChange}
-          mb="none"
+          onClear={handleClear}
+          mb="base"
         />
       </Box>
       <Button type="submit">Continue</Button>

--- a/components/Modals/GroupFilterModal/GroupFilterAll.js
+++ b/components/Modals/GroupFilterModal/GroupFilterAll.js
@@ -1,0 +1,84 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { useRouter } from 'next/router';
+
+import { useGroupFilters, toggleValue } from 'providers/GroupFiltersProvider';
+import { useModalDispatch, hideModal } from 'providers/ModalProvider';
+import { Box, Button } from 'ui-kit';
+
+import { FilterField } from 'components';
+
+function GroupFilterAll(props = {}) {
+  const router = useRouter();
+  const modalDispatch = useModalDispatch();
+  const [filtersState, filtersDispatch] = useGroupFilters();
+
+  const handleMultiSelectChange = ({ name, value }) => {
+    filtersDispatch(toggleValue({ name, value }));
+  };
+
+  const handleSubmit = event => {
+    event.preventDefault();
+
+    // Go to Search page
+    router.push({
+      pathname: `/community/search`,
+      query: filtersState.valuesSerialized,
+    });
+    modalDispatch(hideModal());
+  };
+
+  return (
+    <Box
+      as="form"
+      onSubmit={handleSubmit}
+      display="flex"
+      flexDirection="column"
+      textAlign="center"
+    >
+      <Box as="h2" mb="l">
+        Find your Community
+      </Box>
+      <Box overflow="scroll" maxHeight="40vh" mb="base">
+        <FilterField
+          filterType="select"
+          label="Campus"
+          name="campuses"
+          options={filtersState.options.campuses}
+          values={filtersState.values.campuses}
+          onChange={handleMultiSelectChange}
+        />
+        <FilterField
+          label="Group Types (Preferences)"
+          name="preferences"
+          options={filtersState.options.preferences}
+          values={filtersState.values.preferences}
+          onChange={handleMultiSelectChange}
+        />
+        <FilterField
+          label="Lineups (Sub-Preferences)"
+          name="subPreferences"
+          options={filtersState.options.subPreferences}
+          values={filtersState.values.subPreferences}
+          onChange={handleMultiSelectChange}
+        />
+        <FilterField
+          label="Meeting Days"
+          name="days"
+          options={filtersState.options.days}
+          values={filtersState.values.days}
+          onChange={handleMultiSelectChange}
+          mb="none"
+        />
+      </Box>
+      <Button type="submit">Continue</Button>
+    </Box>
+  );
+}
+
+GroupFilterAll.propTypes = {
+  initialValue: PropTypes.string,
+  onChange: PropTypes.func,
+};
+
+export default GroupFilterAll;

--- a/components/Modals/GroupFilterModal/GroupFilterModal.js
+++ b/components/Modals/GroupFilterModal/GroupFilterModal.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Modal } from 'ui-kit';
 
+import GroupFilterAll from './GroupFilterAll';
 import GroupFilterSubPreferences from './GroupFilterSubPreferences';
 import GroupFilterWhereWhen from './GroupFilterWhereWhen';
 
@@ -12,6 +13,9 @@ function GroupFilterModal(props = {}) {
       }
       case 1: {
         return <GroupFilterWhereWhen />;
+      }
+      case 2: {
+        return <GroupFilterAll />;
       }
       default: {
         return <GroupFilterSubPreferences />;

--- a/components/Modals/GroupFilterModal/GroupFilterModal.stories.js
+++ b/components/Modals/GroupFilterModal/GroupFilterModal.stories.js
@@ -1,0 +1,41 @@
+import React from 'react';
+
+import { AppProvider } from 'providers';
+import GroupFilterModal from './GroupFilterModal';
+
+export default {
+  title: 'components/GroupFilterModal',
+  component: GroupFilterModal,
+};
+
+export const Default = () => {
+  return (
+    <AppProvider>
+      <GroupFilterModal />
+    </AppProvider>
+  );
+};
+
+export const SubPreferences = () => {
+  return (
+    <AppProvider>
+      <GroupFilterModal step={0} />
+    </AppProvider>
+  );
+};
+
+export const WhereAndWhen = () => {
+  return (
+    <AppProvider>
+      <GroupFilterModal step={1} />
+    </AppProvider>
+  );
+};
+
+export const AllFilters = () => {
+  return (
+    <AppProvider>
+      <GroupFilterModal step={2} />
+    </AppProvider>
+  );
+};

--- a/components/index.js
+++ b/components/index.js
@@ -10,6 +10,7 @@ import CustomLink from './CustomLink';
 import EventSingle from './EventSingle';
 import EventsList from './EventsList';
 import FeatureFeed from './FeatureFeed';
+import FilterField from './FilterField';
 import Footer from './Footer';
 import GenderField from './GenderField';
 import GroupSearchFilters from './GroupSearchFilters';
@@ -38,6 +39,7 @@ export {
   CustomLink,
   EventSingle,
   EventsList,
+  FilterField,
   FeatureFeed,
   Footer,
   GenderField,

--- a/pages/community/search/index.js
+++ b/pages/community/search/index.js
@@ -66,9 +66,9 @@ export default function CommunitySearch() {
                   <GroupCard
                     key={group.node?.id}
                     callToAction={callToAction}
-                    campus={group.node?.campus.name}
+                    campus={group.node?.campus?.name}
                     coverImage={group.coverImage?.sources[0]?.uri}
-                    dateTime={group.node?.dateTime.start}
+                    dateTime={group.node?.dateTime?.start}
                     groupType={group.type}
                     heroAvatars={group.node?.leaders?.edges}
                     preference={group.node?.preference}

--- a/pages/community/search/index.js
+++ b/pages/community/search/index.js
@@ -37,16 +37,11 @@ export default function CommunitySearch() {
           px="base"
           py={{ _: 'l', lg: 'xl' }}
         >
-          <Box as="h1">Find your Community</Box>
+          <Box as="h1" mb="l">
+            Find your Community
+          </Box>
           <GroupSearchFilters loading={loading} resultsCount={groups?.length} />
-          <Box
-            as="hr"
-            mt="s"
-            mb="l"
-            border="none"
-            bg="neutrals.200"
-            height={2}
-          />
+
           {loading && (
             <Box>
               <Loader />
@@ -55,7 +50,7 @@ export default function CommunitySearch() {
           {!loading && Boolean(groups?.length) && (
             <CardGrid>
               {groups.map((group, index) => {
-                const DEFAULT_GROUP_CALL_TO_ACTION = {
+                const callToAction = {
                   call: 'Contact',
                   action: () =>
                     modalDispatch(
@@ -70,7 +65,7 @@ export default function CommunitySearch() {
                 return (
                   <GroupCard
                     key={group.node?.id}
-                    callToAction={DEFAULT_GROUP_CALL_TO_ACTION}
+                    callToAction={callToAction}
                     campus={group.node?.campus.name}
                     coverImage={group.coverImage?.sources[0]?.uri}
                     dateTime={group.node?.dateTime.start}

--- a/providers/GroupFiltersProvider.js
+++ b/providers/GroupFiltersProvider.js
@@ -10,7 +10,7 @@ const GroupFiltersProviderDispatchContext = createContext();
 // Frozen to convey that these are static.
 const options = Object.freeze({
   campuses: [],
-  days: ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'],
+  days: ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'],
   preferences: [],
   subPreferences: [],
 });

--- a/providers/GroupFiltersProvider.js
+++ b/providers/GroupFiltersProvider.js
@@ -217,13 +217,13 @@ function GroupFiltersProvider(props = {}) {
   // rendering server-side, so watch for changes to `router.query` and
   // hydrate when it becomes available.
   useEffect(() => {
-    if (!isEmpty(router.query) && !state.hydrated) {
+    if (!isEmpty(router?.query) && !state.hydrated) {
       // Next's dynamic page route mechanism for routes like `[title].js`
       // will get appended in router.query as `title`. Remove those.
-      const { title, ...rest } = router.query;
+      const { title, ...rest } = router?.query;
       dispatch(hydrate({ ...rest }));
     }
-  }, [router.query, state.hydrated]);
+  }, [router?.query, state.hydrated]);
 
   // To be simplified/removed when we lift group options definitions to API
   // ✂️ -------------------------------------------------------------------

--- a/ui-kit/Button/Button.js
+++ b/ui-kit/Button/Button.js
@@ -24,4 +24,8 @@ Button.propTypes = {
   variant: PropTypes.oneOf(['link', 'secondary', 'tertiary', 'chip']),
 };
 
+Button.defaultProps = {
+  status: 'IDLE',
+};
+
 export default Button;

--- a/ui-kit/Button/Button.js
+++ b/ui-kit/Button/Button.js
@@ -20,8 +20,8 @@ function Button(props = {}) {
 Button.propTypes = {
   ...systemPropTypes,
   size: PropTypes.oneOf(['s', 'l']),
-  status: PropTypes.oneOf(['IDLE', 'LOADING', 'ERROR', 'SUCCESS']),
-  variant: PropTypes.oneOf(['link', 'secondary', 'tertiary']),
+  status: PropTypes.oneOf(['IDLE', 'LOADING', 'ERROR', 'SUCCESS', 'SELECTED']),
+  variant: PropTypes.oneOf(['link', 'secondary', 'tertiary', 'chip']),
 };
 
 export default Button;

--- a/ui-kit/Button/Button.stories.js
+++ b/ui-kit/Button/Button.stories.js
@@ -30,9 +30,6 @@ export const Variants = () => (
     <Button variant="tertiary" mr="s">
       Tertiary
     </Button>
-    <Button variant="chip" mr="s">
-      Chip
-    </Button>
   </Box>
 );
 
@@ -78,9 +75,6 @@ export const Rounded = () => (
     </Button>
     <Button rounded={true} variant="tertiary" mr="s">
       Rounded Tertiary
-    </Button>
-    <Button rounded={true} variant="tertiary" mr="s">
-      Rounded Chip
     </Button>
   </Box>
 );

--- a/ui-kit/Button/Button.stories.js
+++ b/ui-kit/Button/Button.stories.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Box } from 'ui-kit';
 
 import Button from './Button';
 
@@ -9,8 +10,41 @@ export default {
 
 export const Default = () => <Button>Button</Button>;
 
-export const Sizes = () => <Button size="l">Button</Button>;
+export const Sizes = () => (
+  <Box>
+    <Button size="l" mr="s">
+      Large (Default)
+    </Button>
+    <Button size="s">Small</Button>
+  </Box>
+);
 
-export const Variants = () => <Button variant="secondary">Button</Button>;
+export const Variants = () => (
+  <Box>
+    <Button variant="primary" mr="s">
+      Primary
+    </Button>
+    <Button variant="secondary" mr="s">
+      Secondary
+    </Button>
+    <Button variant="tertiary" mr="s">
+      Tertiary
+    </Button>
+  </Box>
+);
+
+export const Rounded = () => (
+  <Box>
+    <Button rounded={true} variant="primary" mr="s">
+      Rounded Primary
+    </Button>
+    <Button rounded={true} variant="secondary" mr="s">
+      Rounded Secondary
+    </Button>
+    <Button rounded={true} variant="tertiary" mr="s">
+      Rounded Tertiary
+    </Button>
+  </Box>
+);
 
 export const Loading = () => <Button status="LOADING">Button</Button>;

--- a/ui-kit/Button/Button.stories.js
+++ b/ui-kit/Button/Button.stories.js
@@ -30,6 +30,41 @@ export const Variants = () => (
     <Button variant="tertiary" mr="s">
       Tertiary
     </Button>
+    <Button variant="chip" mr="s">
+      Chip
+    </Button>
+  </Box>
+);
+
+export const Chip = () => (
+  <Box flexDirection="column" bg="white" padding="l">
+    <Box mb="l">
+      <Box as="h5">Default</Box>
+      <Button variant="chip" mr="s">
+        Chip
+      </Button>
+      <Button variant="chip" status="SELECTED" mr="s">
+        Selected Chip
+      </Button>
+    </Box>
+    <Box mb="l">
+      <Box as="h5">Rounded</Box>
+      <Button rounded={true} variant="chip" mr="s">
+        Chip (Rounded)
+      </Button>
+      <Button rounded={true} variant="chip" status="SELECTED" mr="s">
+        Selected Chip (Rounded)
+      </Button>
+    </Box>
+    <Box mb="l">
+      <Box as="h5">Small &amp; Rounded</Box>
+      <Button rounded={true} variant="chip" size="s" mr="s">
+        Chip (Small, Rounded)
+      </Button>
+      <Button rounded={true} variant="chip" size="s" status="SELECTED" mr="s">
+        Selected Chip (Small, Rounded)
+      </Button>
+    </Box>
   </Box>
 );
 
@@ -43,6 +78,9 @@ export const Rounded = () => (
     </Button>
     <Button rounded={true} variant="tertiary" mr="s">
       Rounded Tertiary
+    </Button>
+    <Button rounded={true} variant="tertiary" mr="s">
+      Rounded Chip
     </Button>
   </Box>
 );

--- a/ui-kit/Button/Button.styles.js
+++ b/ui-kit/Button/Button.styles.js
@@ -37,6 +37,13 @@ const variant = ({ variant }) => props => {
       color: ${themeGet('colors.secondary')};
     `;
   }
+  if (variant === 'chip') {
+    return css`
+      background-color: ${themeGet('colors.screen')};
+      color: ${themeGet('colors.tertiary')};
+      border-color: ${themeGet('colors.tertiary')};
+    `;
+  }
 };
 
 const size = ({ size }) => props => {
@@ -67,6 +74,14 @@ const status = ({ status }) => props => {
       > *:first-child {
         margin-right: ${themeGet('space.s')};
       }
+    `;
+  }
+
+  if (status === 'SELECTED') {
+    return css`
+      color: ${themeGet('colors.primaryHover')};
+      background-color: ${themeGet('colors.primarySubdued')};
+      border-color: ${themeGet('colors.primary')};
     `;
   }
 };
@@ -100,8 +115,8 @@ const Button = styled.button`
   }
 
   ${size}
-  ${status}
   ${variant}
+  ${status}
   ${rounded}
   ${system}
 `;

--- a/ui-kit/Button/Button.styles.js
+++ b/ui-kit/Button/Button.styles.js
@@ -10,6 +10,33 @@ const rounded = ({ rounded }) => props => {
     `;
   }
 };
+
+const chipPseudoStyles = ({ status }) => props => {
+  if (status === 'IDLE') {
+    return css`
+      &:active,
+      &:focus,
+      &:hover {
+        background-color: ${themeGet('colors.neutrals.200')};
+        border-color: ${themeGet('colors.fg')};
+        color: ${themeGet('colors.fg')};
+      }
+    `;
+  }
+
+  if (status === 'SELECTED') {
+    return css`
+      &:active,
+      &:focus,
+      &:hover {
+        background-color: ${themeGet('colors.primarySubduedHover')};
+        border-color: ${themeGet('colors.primaryHover')};
+        color: ${themeGet('colors.primaryHover')};
+      }
+    `;
+  }
+};
+
 const variant = ({ variant }) => props => {
   if (variant === 'secondary') {
     return css`
@@ -18,10 +45,12 @@ const variant = ({ variant }) => props => {
       color: ${themeGet('colors.fg')};
     `;
   }
+
   if (variant === 'link') {
     return css`
       background-color: transparent;
       color: ${themeGet('colors.primary')};
+
       &:active,
       &:focus,
       &:hover {
@@ -31,17 +60,20 @@ const variant = ({ variant }) => props => {
       }
     `;
   }
+
   if (variant === 'tertiary') {
     return css`
       background-color: ${themeGet('colors.paper')};
       color: ${themeGet('colors.secondary')};
     `;
   }
+
   if (variant === 'chip') {
     return css`
       background-color: ${themeGet('colors.screen')};
       color: ${themeGet('colors.tertiary')};
       border-color: ${themeGet('colors.tertiary')};
+      ${chipPseudoStyles}
     `;
   }
 };
@@ -79,7 +111,7 @@ const status = ({ status }) => props => {
 
   if (status === 'SELECTED') {
     return css`
-      color: ${themeGet('colors.primaryHover')};
+      color: ${themeGet('colors.primary')};
       background-color: ${themeGet('colors.primarySubdued')};
       border-color: ${themeGet('colors.primary')};
     `;

--- a/ui-kit/Divider/Divider.styles.js
+++ b/ui-kit/Divider/Divider.styles.js
@@ -9,8 +9,6 @@ const Divider = styled.hr`
   height: 1px;
   margin-left: auto;
   margin-right: auto;
-  margin-top: ${themeGet('space.xl')};
-  max-width: 50rem;
 
   ${system}
 `;

--- a/ui-kit/GroupCard/GroupCard.js
+++ b/ui-kit/GroupCard/GroupCard.js
@@ -121,7 +121,7 @@ GroupCard.propTypes = {
   avatars: PropTypes.array,
   callToAction: PropTypes.shape({
     call: PropTypes.string,
-    action: PropTypes.string,
+    action: PropTypes.func,
   }),
   campus: PropTypes.string,
   preference: PropTypes.string,

--- a/ui-kit/GroupCard/GroupCard.js
+++ b/ui-kit/GroupCard/GroupCard.js
@@ -52,11 +52,9 @@ const GroupCard = (props = {}) => {
           <Styled.GroupCardSubTitle>{props.groupType}</Styled.GroupCardSubTitle>
         )}
         {props.preference && (
-          <Styled.GroupCardTitle>
-            <Box as="p" fontSize="s">
-              {props.preference}
-            </Box>
-          </Styled.GroupCardTitle>
+          <Styled.GroupCardSubTitle>
+            {props.preference}
+          </Styled.GroupCardSubTitle>
         )}
       </Box>
       <Styled.GroupCardContent>
@@ -83,10 +81,11 @@ const GroupCard = (props = {}) => {
           </Box>
         )}
         <Box as="h5" mt="base">
-          <Box as="span">{props.totalAvatars}</Box> Group Members
+          <Box as="span">{props.totalAvatars}</Box>{' '}
+          {props.totalAvatars === 1 ? `Group Member` : 'Group Members'}
         </Box>
         {props.avatars?.length > 0 && (
-          <Box display="flex">
+          <Box display="flex" mb="l">
             {props.avatars.slice(0, maxAvatars).map((n, i = 2) => (
               <SquareAvatar
                 height="90px"
@@ -105,7 +104,7 @@ const GroupCard = (props = {}) => {
         {props.callToAction && (
           <Button
             onClick={props?.callToAction?.action}
-            mt="l"
+            mt="base"
             size="l"
             width="100%"
           >

--- a/ui-kit/GroupCard/GroupCard.js
+++ b/ui-kit/GroupCard/GroupCard.js
@@ -10,10 +10,12 @@ import { textTrimmer } from 'utils';
 const GroupCard = (props = {}) => {
   const summaryLength = props?.summary?.length || 0;
   const maxChar = 130;
+  const maxAvatars = 4;
 
   // Option if we want to add a Avatar Count label for leaders
   // const heroAvatarsDiff = props.totalHeroAvatars - props.heroAvatars.length;
-  const avatarsDiff = props.totalAvatars - props.avatars.length;
+  const avatarsDiff =
+    props.totalAvatars - Math.min(props.avatars.length, maxAvatars);
 
   return (
     <Styled {...props}>
@@ -47,11 +49,7 @@ const GroupCard = (props = {}) => {
           <Box as="h4">{props.title}</Box>
         </Styled.GroupCardTitle>
         {props.groupType && (
-          <Styled.GroupCardTitle>
-            <Box as="p" fontSize="s">
-              {props.groupType}
-            </Box>
-          </Styled.GroupCardTitle>
+          <Styled.GroupCardSubTitle>{props.groupType}</Styled.GroupCardSubTitle>
         )}
         {props.preference && (
           <Styled.GroupCardTitle>
@@ -67,7 +65,7 @@ const GroupCard = (props = {}) => {
         )}
         {props.dateTime && (
           <Styled.DateTimeLabel>
-            🗓️ {format(new Date(props.dateTime), "EEE 'at' h:mm")}
+            🗓️ {format(new Date(props.dateTime), "EEEE 'at' h:mm a")}
           </Styled.DateTimeLabel>
         )}
         {props.summary && (
@@ -85,11 +83,11 @@ const GroupCard = (props = {}) => {
           </Box>
         )}
         <Box as="h5" mt="base">
-          <Box as="span">👥 {props.totalAvatars}</Box> Members
+          <Box as="span">{props.totalAvatars}</Box> Group Members
         </Box>
         {props.avatars?.length > 0 && (
           <Box display="flex">
-            {props.avatars.slice(0, 4).map((n, i = 2) => (
+            {props.avatars.slice(0, maxAvatars).map((n, i = 2) => (
               <SquareAvatar
                 height="90px"
                 key={i}

--- a/ui-kit/GroupCard/GroupCard.stories.js
+++ b/ui-kit/GroupCard/GroupCard.stories.js
@@ -109,7 +109,7 @@ export const Default = () => (
     summary={groupSummary}
     heroAvatars={heroAvatars}
     avatars={avatars}
-    dateTime="Wednesdays at 6:30pm"
+    dateTime={new Date()}
     coverImage="https://source.unsplash.com/random/1000x1000"
     totalAvatars={100}
   />
@@ -123,7 +123,7 @@ export const GridView = () => (
       summary={groupSummary}
       heroAvatars={heroAvatars}
       avatars={avatars}
-      dateTime="Wednesdays at 6:30pm"
+      dateTime={new Date()}
       coverImage="https://source.unsplash.com/random/1000x1000"
       totalAvatars={100}
     />
@@ -139,7 +139,7 @@ export const GridView = () => (
       title="No Leaders in Group"
       summary={groupSummary}
       avatars={avatars}
-      dateTime="Wednesdays at 6:30pm"
+      dateTime={new Date()}
       coverImage="https://source.unsplash.com/random/1000x1000"
       totalAvatars={100}
     />

--- a/ui-kit/GroupCard/GroupCard.stories.js
+++ b/ui-kit/GroupCard/GroupCard.stories.js
@@ -111,7 +111,7 @@ export const Default = () => (
     avatars={avatars}
     dateTime={new Date()}
     coverImage="https://source.unsplash.com/random/1000x1000"
-    totalAvatars={100}
+    totalAvatars={10}
   />
 );
 
@@ -125,7 +125,7 @@ export const GridView = () => (
       avatars={avatars}
       dateTime={new Date()}
       coverImage="https://source.unsplash.com/random/1000x1000"
-      totalAvatars={100}
+      totalAvatars={17}
     />
     <GroupCard
       title="A Group That Does Not Contain Summary Text"
@@ -141,7 +141,7 @@ export const GridView = () => (
       avatars={avatars}
       dateTime={new Date()}
       coverImage="https://source.unsplash.com/random/1000x1000"
-      totalAvatars={100}
+      totalAvatars={512}
     />
   </CardGrid>
 );

--- a/ui-kit/GroupCard/GroupCard.stories.js
+++ b/ui-kit/GroupCard/GroupCard.stories.js
@@ -120,6 +120,7 @@ export const GridView = () => (
     <GroupCard
       title="Group Title"
       groupType="Group Type"
+      campus="Orlando"
       summary={groupSummary}
       heroAvatars={heroAvatars}
       avatars={avatars}
@@ -130,18 +131,24 @@ export const GridView = () => (
     <GroupCard
       title="A Group That Does Not Contain Summary Text"
       groupType="Group Type"
+      preference="Preference"
+      campus="Royal Palm Beach"
       heroAvatars={heroAvatars}
       avatars={blankAvatars}
       coverImage="https://source.unsplash.com/random/1000x1000"
       totalAvatars={100}
+      callToAction={{
+        call: 'Contact Group Leaders',
+        action: () => alert('Call to Action clicked'),
+      }}
     />
     <GroupCard
       title="No Leaders in Group"
       summary={groupSummary}
-      avatars={avatars}
+      avatars={avatars.slice(0, 3)}
       dateTime={new Date()}
       coverImage="https://source.unsplash.com/random/1000x1000"
-      totalAvatars={512}
+      totalAvatars={3}
     />
   </CardGrid>
 );

--- a/ui-kit/GroupCard/GroupCard.styles.js
+++ b/ui-kit/GroupCard/GroupCard.styles.js
@@ -59,11 +59,22 @@ const GroupCardTitle = styled.div`
   padding-left: ${themeGet('space.base')};
   padding-right: ${themeGet('space.base')};
 `;
+const GroupCardSubTitle = styled.div`
+  display: flex;
+  justify-content: center;
+  text-align: center;
+  padding-left: ${themeGet('space.base')};
+  padding-right: ${themeGet('space.base')};
+  font-size: ${themeGet('fontSizes.s')};
+  font-weight: ${themeGet('fontWeights.bold')};
+  color: ${themeGet('colors.subdued')};
+`;
 
 GroupCard.AvatarCount = AvatarCount;
 GroupCard.DateTimeLabel = DateTimeLabel;
 GroupCard.GradientBackground = GradientBackground;
 GroupCard.GroupCardContent = GroupCardContent;
 GroupCard.GroupCardTitle = GroupCardTitle;
+GroupCard.GroupCardSubTitle = GroupCardSubTitle;
 
 export default GroupCard;

--- a/ui-kit/__stories__/Colors.stories.js
+++ b/ui-kit/__stories__/Colors.stories.js
@@ -31,6 +31,11 @@ export const Light = () => (
       <Swatch color="tertiary" label="Tertiary" />
     </Box>
     <Box display="flex">
+      <Swatch color="primaryHover" label="Primary (Hover)" />
+      <Swatch color="primarySubdued" label="Primary (Subdued)" />
+      <Swatch color="primarySubduedHover" label="Primary (Subdued Hover)" />
+    </Box>
+    <Box display="flex">
       <Swatch color="neutrals.100" label="Neutral 100" borderColor="border" />
       <Swatch color="neutrals.200" label="Neutral 200" />
       <Swatch color="neutrals.300" label="Neutral 300" />

--- a/ui-kit/_config/colors.js
+++ b/ui-kit/_config/colors.js
@@ -9,8 +9,9 @@ const colors = {
   // LIGHT THEME
   light: {
     primary: PICTON,
-    primaryHover: Color(PICTON).darken(0.2),
-    primarySubdued: Color(PICTON).desaturate(0.2).lighten(0.9),
+    primaryHover: Color(PICTON).darken(0.25),
+    primarySubdued: Color(PICTON).desaturate(0.25).lighten(0.98),
+    primarySubduedHover: Color(PICTON).desaturate(0.1).lighten(0.85),
     secondary: TUATARA,
     secondaryHover: Color(TUATARA).darken(0.2),
     tertiary: BATTLESHIP,

--- a/ui-kit/_config/colors.js
+++ b/ui-kit/_config/colors.js
@@ -10,6 +10,7 @@ const colors = {
   light: {
     primary: PICTON,
     primaryHover: Color(PICTON).darken(0.2),
+    primarySubdued: Color(PICTON).desaturate(0.2).lighten(0.9),
     secondary: TUATARA,
     secondaryHover: Color(TUATARA).darken(0.2),
     tertiary: BATTLESHIP,


### PR DESCRIPTION
Refine the design and UX for Group Finder search results page.

**Details:**
- Create `GroupFilterAll` modal screen to put all filters in one view
- Create stories for `GroupFilterModal`
- Add `chip` variant and styles to `<Button>`
- Create `FilterField` component to abstract Group Filter form field needs
- Fix warnings in `<GroupCard>` and update how overflow members count is determined
- Add a few colors (open to feedback!) => `primarySubdued`, `primarySubduedHover`

### Screenshots

|Caption|Screenshot/Gif|
|---|---|
|`<GroupFilterAll>` screen|<img src="https://user-images.githubusercontent.com/1812955/107248156-0288dc00-6a00-11eb-84cc-66068d7fadfe.jpg" width="450" />
|Search Results UX|<img src="https://user-images.githubusercontent.com/1812955/107248196-0e749e00-6a00-11eb-8ac1-9a74c2058acf.gif" width="450" />
|`<GroupFilterModal>` Stories|<img src="https://user-images.githubusercontent.com/1812955/107248377-3e23a600-6a00-11eb-8f14-a0fb64e121b6.gif" width="450" />
|`<Button`> Stories|<img src="https://user-images.githubusercontent.com/1812955/107248743-978bd500-6a00-11eb-8aee-d43fd45ec579.gif" width="450" />
|`<GroupCard>` Stories|<img src="https://user-images.githubusercontent.com/1812955/107248694-8b077c80-6a00-11eb-9c2c-7c8699121480.jpg" width="450" />
|`<FilterField>` Stories|<img src="https://user-images.githubusercontent.com/1812955/107248961-d91c8000-6a00-11eb-9ade-2734093b629e.gif" width="450" />
|Colors Stories|<img src="https://user-images.githubusercontent.com/1812955/107249086-fcdfc600-6a00-11eb-9cf1-9032f76f200e.jpg" width="450" />
