### PR TITLE
Update Group Search query params shape

### DIFF
--- a/components/GroupSearchFilters/FilterButton.js
+++ b/components/GroupSearchFilters/FilterButton.js
@@ -9,7 +9,6 @@ export default function FilterButton(props = {}) {
       mr="s"
       onClick={props.onClick}
       rounded={true}
-      size="s"
       variant="chip"
       {...props}
     >

--- a/components/GroupSearchFilters/GroupSearchFilters.js
+++ b/components/GroupSearchFilters/GroupSearchFilters.js
@@ -64,7 +64,9 @@ function GroupSearchFilters(props = {}) {
             />
           )}
         </Box>
-        <Box as="p" fontWeight="bold">{`${props.resultsCount} groups`}</Box>
+        <Box as="p" fontWeight="bold">{`${props.resultsCount} ${
+          props.resultsCount === 1 ? 'group' : 'groups'
+        }`}</Box>
       </Box>
 
       <Divider mt="s" mb="l" />

--- a/hooks/useSearchGroups.js
+++ b/hooks/useSearchGroups.js
@@ -1,8 +1,8 @@
 import { gql, useLazyQuery } from '@apollo/client';
 
 export const SEARCH_GROUPS = gql`
-  query searchGroups($query: SearchGroupsInput!) {
-    searchGroups(query: $query) {
+  query searchGroups($query: SearchQueryInput!, $first: Int, $after: String) {
+    searchGroups(query: $query, first: $first, after: $after) {
       pageInfo {
         startCursor
         endCursor

--- a/pages/community/search/index.js
+++ b/pages/community/search/index.js
@@ -21,10 +21,10 @@ export default function CommunitySearch() {
 
     searchGroups({
       variables: {
-        query: filtersState.queryParams,
+        query: filtersState.queryData,
       },
     });
-  }, [searchGroups, filtersState.hydrated, filtersState.queryParams]);
+  }, [searchGroups, filtersState.hydrated, filtersState.queryData]);
 
   return (
     <>

--- a/providers/GroupFiltersProvider.js
+++ b/providers/GroupFiltersProvider.js
@@ -24,7 +24,9 @@ const initialState = {
     preferences: [],
     subPreferences: [],
   },
-  queryParams: {},
+  queryData: {
+    attributes: [],
+  },
 };
 
 const actionTypes = {
@@ -114,15 +116,19 @@ function parseFilterValues(string) {
   return values;
 }
 
-function getQueryParams(options, values) {
+function getQueryData(values) {
   const getValidValues = filterName =>
     values[filterName].filter(string => !isEmpty(string));
 
+  const attributes = [
+    { key: 'campusNames', values: getValidValues('campuses') },
+    { key: 'preferences', values: getValidValues('preferences') },
+    { key: 'subPreferences', values: getValidValues('subPreferences') },
+    { key: 'days', values: getValidValues('days') },
+  ].filter(({ values }) => values.length > 0);
+
   return {
-    campusNames: getValidValues('campuses'),
-    preferences: getValidValues('preferences'),
-    subPreferences: getValidValues('subPreferences'),
-    days: getValidValues('days'),
+    attributes,
   };
 }
 
@@ -135,7 +141,7 @@ function updateAndSerialize(state) {
   const newState = {
     ...state,
     valuesSerialized: serializeFilterValues(state.values),
-    queryParams: getQueryParams(state.options, state.values),
+    queryData: getQueryData(state.values),
   };
 
   console.log('[GroupFiltersProvider] newState: ', newState);


### PR DESCRIPTION
## Description
The shape of the `searchGroups` query was updated in [these commits](https://github.com/christfellowshipchurch/apollos-api/pull/197/files/9abe09f0b9495479caa678c36f6d37d450e97c11..e42be21b6ac9dc0b45bfb3523053569924097c2c) on the API `search-groups` branch.

This updates the `GroupFiltersProvider` to store current query values in the appropriate shape.

The API change is:
![CleanShot 2021-02-09 at 11 52 47](https://user-images.githubusercontent.com/1812955/107398280-7644ea80-6acd-11eb-972d-d3b5aab6f52d.jpg)

So, where we used to invoke the query like:
```javascript
searchGroups({
  variables: {
    query: {
      campusNames: ["Royal Palm Beach"],
      preferences: ["Crew (Men)", "Co-ed"]
    },
  },
});
```

We now need to send:
```javascript
searchGroups({
  variables: {
    query: {
      attributes: [
        { key: "campusNames", values: ["Royal Palm Beach"] },
        { key: "preferences", values: ["Crew (Men)", "Co-ed"] },
      ]
    },
  },
});
```

Also includes two minor style changes:
- Shrink size of `FilterButton` component
- Update pluralization to prevent "1 groups"

## Testing
Verify search generally still works. Even if you don't see results, verify that the shape of `filtersState.queryData` in logging looks correct.

Empty filters should be omitted, so a full "wildcard" search would implicitly be: `{ attributes: [] }`