### PR TITLE
Search Groups Pagination

### DIFF
--- a/components/GroupSearchFilters/GroupSearchFilters.js
+++ b/components/GroupSearchFilters/GroupSearchFilters.js
@@ -62,18 +62,23 @@ function GroupSearchFilters(props = {}) {
           />
         )}
       </Box>
+      {!props.loading && props.visibleResults > 0 && (
+        <Box as="h4">
+          Showing {props.visibleResults} of {props.totalResults} results
+        </Box>
+      )}
     </Box>
   );
 }
 
 GroupSearchFilters.propTypes = {
   loading: PropTypes.bool,
-  resultsCount: PropTypes.number,
+  visibleResults: PropTypes.number,
+  totalResults: PropTypes.number,
 };
 
 GroupSearchFilters.defaultProps = {
   loading: false,
-  resultsCount: 0,
 };
 
 export default GroupSearchFilters;

--- a/hooks/useSearchGroups.js
+++ b/hooks/useSearchGroups.js
@@ -3,6 +3,7 @@ import { gql, useLazyQuery } from '@apollo/client';
 export const SEARCH_GROUPS = gql`
   query searchGroups($query: SearchQueryInput!, $first: Int, $after: String) {
     searchGroups(query: $query, first: $first, after: $after) {
+      totalResults
       pageInfo {
         startCursor
         endCursor
@@ -39,7 +40,7 @@ export const SEARCH_GROUPS = gql`
       members: people(first: 1) {
         totalCount
       }
-      leaders: people(first: 20, isLeader: true) {
+      leaders: people(first: 3, isLeader: true) {
         totalCount
         edges {
           node {

--- a/lib/apolloClient/apolloClient.js
+++ b/lib/apolloClient/apolloClient.js
@@ -17,6 +17,18 @@ function createApolloClient() {
     version: '5.4.0',
   });
 
+  // For local dev, expose the apolloClient in console by attaching
+  // it to the`window`. Mainly for quick-access to cache clear methods:
+  // --> client.cache.reset()
+  // --> client.clearStore()
+  // @see https://www.apollographql.com/docs/react/caching/advanced-topics/#resetting-the-store
+  const isLocalClient =
+    typeof window !== 'undefined' && window.location.port === '3000';
+
+  if (isLocalClient) {
+    window.apolloClient = client;
+  }
+
   client.onResetStore(() => cache.writeData({ data: {} }));
 
   return client;

--- a/lib/apolloClient/initCache.js
+++ b/lib/apolloClient/initCache.js
@@ -7,6 +7,29 @@ import introspectionToPossibleTypes from './introspectionToPossibleTypes';
 const initCache = initialState => {
   const cache = new InMemoryCache({
     possibleTypes: introspectionToPossibleTypes(fragmentTypes),
+    typePolicies: {
+      Query: {
+        fields: {
+          // Merge results when loading more group search results
+          searchGroups: {
+            // Make sure to separate search queries results when filters change
+            keyArgs: ['query'],
+            merge(existing, incoming) {
+              if (!existing) {
+                return incoming;
+              }
+
+              return {
+                ...existing,
+                totalResults: incoming.totalResults,
+                pageInfo: incoming.pageInfo,
+                edges: existing.edges.concat(incoming.edges),
+              };
+            },
+          },
+        },
+      },
+    },
   }).restore(initialState || {});
 
   if (typeof window !== 'undefined') {

--- a/pages/community/search/index.js
+++ b/pages/community/search/index.js
@@ -15,13 +15,19 @@ import { useSearchGroups } from 'hooks';
 import { useModalDispatch, showModal } from 'providers/ModalProvider';
 
 const DEFAULT_CONTENT_WIDTH = utils.rem('1100px');
+const PAGE_SIZE = 21;
 
 export default function CommunitySearch() {
   const [filtersState] = useGroupFilters();
   const modalDispatch = useModalDispatch();
-  const [searchGroups, { loading, groups }] = useSearchGroups({
-    fetchPolicy: 'cache-and-network',
+  const [searchGroups, { loading, groups, data, fetchMore }] = useSearchGroups({
+    notifyOnNetworkStatusChange: true,
   });
+
+  // Logical shorthands
+  const hasResults = groups?.length > 0;
+  const showEmptyState = !loading && !hasResults;
+  const hasMorePages = groups?.length < data?.searchGroups?.totalResults;
 
   useEffect(() => {
     if (!filtersState.hydrated) {
@@ -31,9 +37,21 @@ export default function CommunitySearch() {
     searchGroups({
       variables: {
         query: filtersState.queryData,
+        first: PAGE_SIZE,
       },
     });
   }, [searchGroups, filtersState.hydrated, filtersState.queryData]);
+
+  const handleLoadMore = () => {
+    if (!loading && hasMorePages) {
+      fetchMore({
+        variables: {
+          first: PAGE_SIZE,
+          after: data?.searchGroups?.pageInfo?.endCursor,
+        },
+      });
+    }
+  };
 
   return (
     <>
@@ -63,17 +81,24 @@ export default function CommunitySearch() {
               Need help?
             </Button>
           </Box>
-          <Divider mb="l" />
-          <GroupSearchFilters loading={loading} resultsCount={groups?.length} />
 
-          {loading && (
-            <Box>
-              <Loader />
+          <Divider mb="l" />
+
+          <GroupSearchFilters
+            loading={loading}
+            visibleResults={groups?.length}
+            totalResults={data?.searchGroups?.totalResults}
+          />
+
+          {showEmptyState && (
+            <Box display="flex" justifyContent="center" my="xxl" pb="xxl">
+              <Box>No Groups matched your search criteria.</Box>
             </Box>
           )}
-          {!loading && Boolean(groups?.length) && (
+
+          {hasResults && (
             <CardGrid>
-              {groups.map((group, index) => {
+              {groups.map(group => {
                 const callToAction = {
                   call: 'Contact',
                   action: () =>
@@ -105,11 +130,22 @@ export default function CommunitySearch() {
               })}
             </CardGrid>
           )}
-          {!loading && !Boolean(groups?.length) && (
-            <Box>No Groups matched your search criteria.</Box>
+
+          {loading && (
+            <Box display="flex" justifyContent="center" my="xxl">
+              <Loader />
+            </Box>
+          )}
+
+          {!loading && hasMorePages && (
+            <Box display="flex" justifyContent="center" mt="xl">
+              <Button variant="tertiary" onClick={handleLoadMore}>
+                Load more
+              </Button>
+            </Box>
           )}
         </Cell>
-        <Footer />
+        <Footer mt="xxl" />
       </Box>
     </>
   );

--- a/providers/GroupFiltersProvider.js
+++ b/providers/GroupFiltersProvider.js
@@ -217,7 +217,6 @@ function GroupFiltersProvider(props = {}) {
   const optionsData = useGroupFilterOptions();
 
   const [state, dispatch] = useReducer(reducer, initialState);
-  const optionsData = useGroupFilterOptions();
   const isClient = typeof window !== 'undefined';
 
   // 👇 This effect hydrates the state from URL search params on page load.


### PR DESCRIPTION
## About
⚠️ **Depends on API PR:** 🛰️ [[Group Finder] Add SearchResultsConnection.totalResults resolver #208](https://github.com/christfellowshipchurch/apollos-api/pull/208)

- Adds **Load More** button to Group Finder results
- Cleans up loading and empty states when searching
- Updates total results count message to be **Showing X of Y results** (I'm iffy on wording)
- Fixes problem when loading `/community/search` with no URL params (now does a wide-open search)

## Testing
- Open `/community/search` directly (no URL params) and verify a wide-open search is performed.
  - As of writing, there should be 51 results
- Verify **Load More** button shows and works when it should
- Verify **Showing X of Y results** message is accurate
- Play with the filters, copy URL and deep link to a specific search, etc. Everything should work as expected.

## Screenshots
![2021-02-10 23 33 00 2](https://user-images.githubusercontent.com/1812955/107602750-a1782880-6bf8-11eb-8734-5679911c82cb.gif)



