### PR TITLE
Get group search options from API

### DIFF
--- a/components/FilterField/FilterField.js
+++ b/components/FilterField/FilterField.js
@@ -4,6 +4,8 @@ import PropTypes from 'prop-types';
 import { Box, Button, Select } from 'ui-kit';
 
 export default function FilterField(props = {}) {
+  if (!props.options) return null;
+
   return (
     <Box mb={props.mb || 'xl'} textAlign="left">
       <Box

--- a/components/Modals/GroupFilterModal/GroupFilterPreferences.js
+++ b/components/Modals/GroupFilterModal/GroupFilterPreferences.js
@@ -13,7 +13,11 @@ function GroupFilterPreferences(props = {}) {
 
   const handleSubmit = event => {
     event.preventDefault();
-    modalDispatch(showStep(1));
+    if (filtersState.options.subPreferences.length !== 0) {
+      modalDispatch(showStep(1));
+    } else {
+      modalDispatch(showStep(2));
+    }
   };
 
   return (

--- a/hooks/useGroupFilterOptions.js
+++ b/hooks/useGroupFilterOptions.js
@@ -15,11 +15,7 @@ export const GET_GROUP_OPTIONS = gql`
 function useGroupFilterOptions(options = {}) {
   const query = useQuery(GET_GROUP_OPTIONS, options);
 
-  return {
-    campuses: query?.data?.groupSearchOptions?.campusName || [],
-    preferences: query?.data?.groupSearchOptions?.preference || [],
-    subPreferences: query?.data?.groupSearchOptions?.subPreference || [],
-  };
+  return query?.data?.groupSearchOptions;
 }
 
 export default useGroupFilterOptions;

--- a/hooks/useGroupFilterOptions.js
+++ b/hooks/useGroupFilterOptions.js
@@ -1,15 +1,24 @@
-import useCampuses from './useCampuses';
-import useGroupPreferences from './useGroupPreferences';
+import { gql, useQuery } from '@apollo/client';
+
+export const GET_GROUP_OPTIONS = gql`
+  query getGroupOptions {
+    groupSearchOptions {
+      day
+      preference
+      campusName
+      subPreference
+    }
+  }
+`;
 
 // NOTE: To be replaced by an API query that combines this data for us
-function useGroupFilterOptions() {
-  const { campuses } = useCampuses();
-  const { preferences, subPreferences } = useGroupPreferences();
+function useGroupFilterOptions(options = {}) {
+  const query = useQuery(GET_GROUP_OPTIONS, options);
 
   return {
-    campuses,
-    preferences,
-    subPreferences,
+    campuses: query?.data?.groupSearchOptions?.campusName || [],
+    preferences: query?.data?.groupSearchOptions?.preference || [],
+    subPreferences: query?.data?.groupSearchOptions?.subPreference || [],
   };
 }
 

--- a/providers/GroupFiltersProvider.js
+++ b/providers/GroupFiltersProvider.js
@@ -214,9 +214,9 @@ function reducer(state, action) {
 
 function GroupFiltersProvider(props = {}) {
   const router = useRouter();
+  const optionsData = useGroupFilterOptions();
 
   const [state, dispatch] = useReducer(reducer, initialState);
-  const optionsData = useGroupFilterOptions();
 
   // Next.js won't have the hydrated state query string available when
   // rendering server-side, so watch for changes to `router.query` and
@@ -230,29 +230,15 @@ function GroupFiltersProvider(props = {}) {
     }
   }, [router?.query, state.hydrated]);
 
-  // To be simplified/removed when we lift group options definitions to API
-  // ✂️ -------------------------------------------------------------------
   useEffect(() => {
-    if (optionsData.campuses?.length) {
       dispatch(
         updateOptions({
-          campuses: optionsData.campuses.map(({ name }) => name),
+        campuses: get(optionsData, 'campusName', []),
+        preferences: get(optionsData, 'preference', []),
+        subPreferences: get(optionsData, 'subPreference', []),
         })
       );
-    }
-  }, [optionsData.campuses]);
-
-  useEffect(() => {
-    if (optionsData.preferences?.length && optionsData.subPreferences?.length) {
-      dispatch(
-        updateOptions({
-          preferences: optionsData.preferences.map(({ title }) => title),
-          subPreferences: optionsData.subPreferences.map(({ title }) => title),
-        })
-      );
-    }
-  }, [optionsData.preferences, optionsData.subPreferences]);
-  // ✂️ -------------------------------------------------------------------
+  }, [optionsData]);
 
   return (
     <GroupFiltersProviderStateContext.Provider value={state}>

--- a/providers/GroupFiltersProvider.js
+++ b/providers/GroupFiltersProvider.js
@@ -2,6 +2,7 @@ import React, { createContext, useContext, useEffect, useReducer } from 'react';
 import PropTypes from 'prop-types';
 import useGroupFilterOptions from 'hooks/useGroupFilterOptions';
 import isEmpty from 'lodash/isEmpty';
+import get from 'lodash/get';
 import { useRouter } from 'next/router';
 
 const GroupFiltersProviderStateContext = createContext();
@@ -153,7 +154,6 @@ function reducer(state, action) {
   switch (action.type) {
     case actionTypes.hydrate: {
       return updateAndSerialize({
-        ...initialState,
         hydrated: true,
         values: {
           ...initialState.values,
@@ -231,13 +231,13 @@ function GroupFiltersProvider(props = {}) {
   }, [router?.query, state.hydrated]);
 
   useEffect(() => {
-      dispatch(
-        updateOptions({
+    dispatch(
+      updateOptions({
         campuses: get(optionsData, 'campusName', []),
         preferences: get(optionsData, 'preference', []),
         subPreferences: get(optionsData, 'subPreference', []),
-        })
-      );
+      })
+    );
   }, [optionsData]);
 
   return (


### PR DESCRIPTION
We are now getting search options from the API with `groupSearchOptions ` query. Algolia facets are feeding the data.

TO TEST: be on `add-group-search-options` branch in the api

![image](https://user-images.githubusercontent.com/2528817/107801368-98d14080-6d25-11eb-8ebf-a10ee619345c.png)
