### PR TITLE
Quick GroupFiltersProvider fixes

### DIFF
--- a/components/CommunitySingle/CommunitySingle.js
+++ b/components/CommunitySingle/CommunitySingle.js
@@ -24,8 +24,10 @@ function CommunitySingle(props = {}) {
   }, [filtersState.values.preferences, filtersDispatch, props.data?.title]);
 
   function showGroupFilterModal() {
-    // Skip the Preference screen, go one after
-    modalDispatch(showModal('GroupFilter', { step: 1 }));
+    // If there are subPreferences available, show that step.
+    // Else skip it and go to the one after.
+    const step = filtersState.options.subPreferences.length > 0 ? 1 : 2;
+    modalDispatch(showModal('GroupFilter', { step }));
   }
 
   function handleOnClick() {

--- a/components/Modals/GroupFilterModal/GroupFilterSubPreferences.js
+++ b/components/Modals/GroupFilterModal/GroupFilterSubPreferences.js
@@ -3,7 +3,7 @@ import { useGroupFilters, toggleValue } from 'providers/GroupFiltersProvider';
 import { showStep, useModalDispatch } from 'providers/ModalProvider';
 import { Box, Button, Loader } from 'ui-kit';
 
-function GroupFilterSubPreference(props = {}) {
+function GroupFilterSubPreferences(props = {}) {
   const modalDispatch = useModalDispatch();
   const [filtersState, filtersDispatch] = useGroupFilters();
 
@@ -57,6 +57,6 @@ function GroupFilterSubPreference(props = {}) {
   );
 }
 
-GroupFilterSubPreference.propTypes = {};
+GroupFilterSubPreferences.propTypes = {};
 
-export default GroupFilterSubPreference;
+export default GroupFilterSubPreferences;

--- a/providers/GroupFiltersProvider.js
+++ b/providers/GroupFiltersProvider.js
@@ -2,7 +2,6 @@ import React, { createContext, useContext, useEffect, useReducer } from 'react';
 import PropTypes from 'prop-types';
 import useGroupFilterOptions from 'hooks/useGroupFilterOptions';
 import isEmpty from 'lodash/isEmpty';
-import get from 'lodash/get';
 import { useRouter } from 'next/router';
 
 const GroupFiltersProviderStateContext = createContext();
@@ -154,6 +153,7 @@ function reducer(state, action) {
   switch (action.type) {
     case actionTypes.hydrate: {
       return updateAndSerialize({
+        ...state,
         hydrated: true,
         values: {
           ...initialState.values,
@@ -233,9 +233,9 @@ function GroupFiltersProvider(props = {}) {
   useEffect(() => {
     dispatch(
       updateOptions({
-        campuses: get(optionsData, 'campusName', []),
-        preferences: get(optionsData, 'preference', []),
-        subPreferences: get(optionsData, 'subPreference', []),
+        campuses: optionsData?.campusName || [],
+        preferences: optionsData?.preference || [],
+        subPreferences: optionsData?.subPreference || [],
       })
     );
   }, [optionsData]);


### PR DESCRIPTION
A few small fixes around `<GroupFiltersProvider>`

- During `hydrate` action, we need to retain the existing state, to avoid losing root properties like `options` etc
- The lodash `get` function was still allowing `null` values to be set, so switched to nullish coalescing operator and `|| []`
- From `CommunitySingle` page, we were showing the `subPreferences` modal step even when there were none to show
- Component name for `GroupFiltersSubPreferences` didn't match the file name 

**To test**
- Open the filters modal from a `CommunitySingle` page and verify it skips to the `WhereWhen` filters step
- Can't really test the `subPreferences` since there are no values currently... but just double check my code 🤷‍♂️