### PR TITLE
LiveStream Pre/Live/Post state management

### DIFF
--- a/components/LiveStreamSingle/Live.js
+++ b/components/LiveStreamSingle/Live.js
@@ -12,40 +12,38 @@ function Live(props = {}) {
   //   'http://amssamples.streaming.mediaservices.windows.net/91492735-c523-432b-ba01-faba6c2206a2/AzureMediaServicesPromo.ism/manifest(format=m3u8-aapl)';
 
   return (
-    <>
-      <ContentLayout
-        title={props.data?.relatedNode?.title}
-        summary={props.data?.relatedNode?.summary}
-        renderA={() => (
-          <Box
-            mb="l"
-            background={`url(${props.data?.relatedNode?.coverImage?.sources[0]?.uri}) center center no-repeat`}
-            backgroundSize="cover"
-          >
-            <Video src={videoSrc} autoPlay={false} muted={true} />
-          </Box>
-        )}
-        renderC={() => (
-          <Box
-            as="h4"
-            display="inline-block"
-            bg="live"
-            color="white"
-            px="s"
-            borderRadius="s"
-            fontWeight="bold"
-          >
-            Live Now
-          </Box>
-        )}
-        renderD={() => (
-          <Box as="pre" fontSize="s">
-            {JSON.stringify(props.data, null, 2)}
-            {JSON.stringify(props.metaData, null, 2)}
-          </Box>
-        )}
-      />
-    </>
+    <ContentLayout
+      title={props.data?.relatedNode?.title}
+      summary={props.data?.relatedNode?.summary}
+      renderA={() => (
+        <Box
+          mb="l"
+          background={`url(${props.data?.relatedNode?.coverImage?.sources[0]?.uri}) center center no-repeat`}
+          backgroundSize="cover"
+        >
+          <Video src={videoSrc} />
+        </Box>
+      )}
+      renderC={() => (
+        <Box
+          as="h4"
+          display="inline-block"
+          bg="live"
+          color="white"
+          px="s"
+          borderRadius="s"
+          fontWeight="bold"
+        >
+          Live Now
+        </Box>
+      )}
+      renderD={() => (
+        <Box as="pre" fontSize="s">
+          {JSON.stringify(props.data, null, 2)}
+          {JSON.stringify(props.metaData, null, 2)}
+        </Box>
+      )}
+    />
   );
 }
 

--- a/components/LiveStreamSingle/Live.js
+++ b/components/LiveStreamSingle/Live.js
@@ -1,0 +1,66 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import { ContentLayout, Video } from 'components';
+import { Box } from 'ui-kit';
+
+function Live(props = {}) {
+  const videoSrc = props.data?.media?.sources[0].uri;
+
+  // 👇 OVERRIDE FOR TESTING
+  // const videoSrc =
+  //   'http://amssamples.streaming.mediaservices.windows.net/91492735-c523-432b-ba01-faba6c2206a2/AzureMediaServicesPromo.ism/manifest(format=m3u8-aapl)';
+
+  return (
+    <>
+      <ContentLayout
+        title={props.data?.relatedNode?.title}
+        summary={props.data?.relatedNode?.summary}
+        renderA={() => (
+          <Box
+            mb="l"
+            background={`url(${props.data?.relatedNode?.coverImage?.sources[0]?.uri}) center center no-repeat`}
+            backgroundSize="cover"
+          >
+            <Video src={videoSrc} autoPlay={false} muted={true} />
+          </Box>
+        )}
+        renderC={() => (
+          <Box
+            as="h4"
+            display="inline-block"
+            bg="live"
+            color="white"
+            px="s"
+            borderRadius="s"
+            fontWeight="bold"
+          >
+            Live Now
+          </Box>
+        )}
+        renderD={() => (
+          <Box as="pre" fontSize="s">
+            {JSON.stringify(props.data, null, 2)}
+            {JSON.stringify(props.metaData, null, 2)}
+          </Box>
+        )}
+      />
+    </>
+  );
+}
+
+Live.propTypes = {
+  data: PropTypes.object,
+  // @see `useLiveStream` hook
+  metaData: PropTypes.shape({
+    isLive: PropTypes.bool,
+    isBefore: PropTypes.bool,
+    isAfter: PropTypes.bool,
+    startTime: PropTypes.string,
+    endTime: PropTypes.string,
+    startDate: PropTypes.string,
+    endDate: PropTypes.string,
+  }),
+};
+
+export default Live;

--- a/components/LiveStreamSingle/LiveStreamSingle.js
+++ b/components/LiveStreamSingle/LiveStreamSingle.js
@@ -1,53 +1,26 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import { ContentLayout, Video } from 'components';
-import { Box } from 'ui-kit';
+import PreLive from './PreLive';
+import Live from './Live';
+import PostLive from './PostLive';
 
 function LiveStreamSingle(props = {}) {
-  const videoSrc = props.data?.media?.sources[0].uri;
+  if (props.metaData?.isLive) {
+    return <Live {...props} />;
+  }
 
-  // 👇 OVERRIDE FOR TESTING
-  // const videoSrc =
-  //   'http://amssamples.streaming.mediaservices.windows.net/91492735-c523-432b-ba01-faba6c2206a2/AzureMediaServicesPromo.ism/manifest(format=m3u8-aapl)';
+  if (props.metaData?.isBefore) {
+    return <PreLive {...props} />;
+  }
 
-  return (
-    <>
-      <ContentLayout
-        title={props.data?.relatedNode?.title}
-        summary={props.data?.relatedNode?.summary}
-        renderA={() => (
-          <Box
-            mb="l"
-            background={`url(${props.data?.relatedNode?.coverImage?.sources[0]?.uri}) center center no-repeat`}
-            backgroundSize="cover"
-          >
-            <Video autoPlay={true} src={videoSrc} muted={true} />
-          </Box>
-        )}
-        renderC={() =>
-          props.data?.isLive ? (
-            <Box
-              as="h4"
-              display="inline-block"
-              bg="live"
-              color="white"
-              px="s"
-              borderRadius="s"
-              fontWeight="bold"
-            >
-              Live Now
-            </Box>
-          ) : null
-        }
-        renderD={() => (
-          <Box as="pre" fontSize="s">
-            {JSON.stringify(props.data, null, 2)}
-          </Box>
-        )}
-      />
-    </>
-  );
+  if (props.metaData?.isAfter) {
+    return <PostLive {...props} />;
+  }
+
+  // Most likely an error?
+  // Redirect to somewhere else ?
+  return null;
 }
 
 LiveStreamSingle.propTypes = {

--- a/components/LiveStreamSingle/LiveStreamSingle.js
+++ b/components/LiveStreamSingle/LiveStreamSingle.js
@@ -1,13 +1,14 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
+import { ContentLayout } from 'components';
+import { Box } from 'ui-kit';
+
 import PreLive from './PreLive';
 import Live from './Live';
 import PostLive from './PostLive';
 
 function LiveStreamSingle(props = {}) {
-  console.log('🔬 <LiveStreamSingle> props:', props);
-
   if (props.metaData?.isLive) {
     return <Live {...props} />;
   }
@@ -20,9 +21,34 @@ function LiveStreamSingle(props = {}) {
     return <PostLive {...props} />;
   }
 
+  if (!props.data) {
+    return null;
+  }
+
   // Most likely an error?
   // Redirect to somewhere else ?
-  return null;
+  return (
+    <ContentLayout
+      title={props.data?.relatedNode?.title}
+      summary={props.data?.relatedNode?.summary}
+      coverImage={props.data?.relatedNode?.coverImage?.sources[0]?.uri}
+      renderD={() => (
+        <Box>
+          <Box as="p" color="alert" mb="l">
+            ⚠️ Unhandled livestream state. It is not currently live, upcoming,
+            or recently ended.
+            <br />
+            This most likely means one or both of the <code>
+              start
+            </code> and <code>end</code> dates were <code>null</code>.
+          </Box>
+          <Box as="pre" fontSize="xs">
+            {JSON.stringify(props, null, 2)}
+          </Box>
+        </Box>
+      )}
+    />
+  );
 }
 
 LiveStreamSingle.propTypes = {

--- a/components/LiveStreamSingle/LiveStreamSingle.js
+++ b/components/LiveStreamSingle/LiveStreamSingle.js
@@ -6,6 +6,8 @@ import Live from './Live';
 import PostLive from './PostLive';
 
 function LiveStreamSingle(props = {}) {
+  console.log('🔬 <LiveStreamSingle> props:', props);
+
   if (props.metaData?.isLive) {
     return <Live {...props} />;
   }

--- a/components/LiveStreamSingle/LiveStreamSingle.js
+++ b/components/LiveStreamSingle/LiveStreamSingle.js
@@ -5,11 +5,11 @@ import { ContentLayout, Video } from 'components';
 import { Box } from 'ui-kit';
 
 function LiveStreamSingle(props = {}) {
-  // const videoSrc = props.data?.media?.sources[0].uri;
+  const videoSrc = props.data?.media?.sources[0].uri;
 
   // 👇 OVERRIDE FOR TESTING
-  const videoSrc =
-    'http://amssamples.streaming.mediaservices.windows.net/91492735-c523-432b-ba01-faba6c2206a2/AzureMediaServicesPromo.ism/manifest(format=m3u8-aapl)';
+  // const videoSrc =
+  //   'http://amssamples.streaming.mediaservices.windows.net/91492735-c523-432b-ba01-faba6c2206a2/AzureMediaServicesPromo.ism/manifest(format=m3u8-aapl)';
 
   return (
     <>
@@ -22,7 +22,27 @@ function LiveStreamSingle(props = {}) {
             background={`url(${props.data?.relatedNode?.coverImage?.sources[0]?.uri}) center center no-repeat`}
             backgroundSize="cover"
           >
-            <Video autoPlay={true} src={videoSrc} />
+            <Video autoPlay={true} src={videoSrc} muted={true} />
+          </Box>
+        )}
+        renderC={() =>
+          props.data?.isLive ? (
+            <Box
+              as="h4"
+              display="inline-block"
+              bg="live"
+              color="white"
+              px="s"
+              borderRadius="s"
+              fontWeight="bold"
+            >
+              Live Now
+            </Box>
+          ) : null
+        }
+        renderD={() => (
+          <Box as="pre" fontSize="s">
+            {JSON.stringify(props.data, null, 2)}
           </Box>
         )}
       />

--- a/components/LiveStreamSingle/PostLive.js
+++ b/components/LiveStreamSingle/PostLive.js
@@ -10,11 +10,7 @@ function PostLive(props = {}) {
       title={props.data?.relatedNode?.title}
       summary={props.data?.relatedNode?.summary}
       coverImage={props.data?.relatedNode?.coverImage?.sources[0]?.uri}
-      renderD={() => (
-        <Box as="p" fontSize="s">
-          Thanks for Watching!
-        </Box>
-      )}
+      renderD={() => <Box as="p">Thanks for Watching!</Box>}
     />
   );
 }

--- a/components/LiveStreamSingle/PostLive.js
+++ b/components/LiveStreamSingle/PostLive.js
@@ -6,18 +6,16 @@ import { Box } from 'ui-kit';
 
 function PostLive(props = {}) {
   return (
-    <>
-      <ContentLayout
-        title={props.data?.relatedNode?.title}
-        summary={props.data?.relatedNode?.summary}
-        coverImage={props.data?.relatedNode?.coverImage?.sources[0]?.uri}
-        renderD={() => (
-          <Box as="p" fontSize="s">
-            Thanks for Watching!
-          </Box>
-        )}
-      />
-    </>
+    <ContentLayout
+      title={props.data?.relatedNode?.title}
+      summary={props.data?.relatedNode?.summary}
+      coverImage={props.data?.relatedNode?.coverImage?.sources[0]?.uri}
+      renderD={() => (
+        <Box as="p" fontSize="s">
+          Thanks for Watching!
+        </Box>
+      )}
+    />
   );
 }
 

--- a/components/LiveStreamSingle/PostLive.js
+++ b/components/LiveStreamSingle/PostLive.js
@@ -1,0 +1,28 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import { ContentLayout } from 'components';
+import { Box } from 'ui-kit';
+
+function PostLive(props = {}) {
+  return (
+    <>
+      <ContentLayout
+        title={props.data?.relatedNode?.title}
+        summary={props.data?.relatedNode?.summary}
+        coverImage={props.data?.relatedNode?.coverImage?.sources[0]?.uri}
+        renderD={() => (
+          <Box as="p" fontSize="s">
+            Thanks for Watching!
+          </Box>
+        )}
+      />
+    </>
+  );
+}
+
+PostLive.propTypes = {
+  data: PropTypes.object,
+};
+
+export default PostLive;

--- a/components/LiveStreamSingle/PreLive.js
+++ b/components/LiveStreamSingle/PreLive.js
@@ -1,19 +1,31 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { format } from 'date-fns';
 
+import { parseLiveStreamDates } from 'utils';
 import { ContentLayout } from 'components';
 import { Box } from 'ui-kit';
 
 function PreLive(props = {}) {
+  const parsed = parseLiveStreamDates(props.data);
+  let startFormatted = parsed.startDate
+    ? format(parsed.startDate, `EEEE, MMMM dd 'at' h:mm a`)
+    : 'null';
+  let endFormatted = parsed.endDate
+    ? format(parsed.endDate, `EEEE, MMMM dd 'at' h:mm a`)
+    : 'null';
+
   return (
     <>
       <ContentLayout
         title={props.data?.relatedNode?.title}
-        summary={props.data?.relatedNode?.summary}
+        summary="Coming Soon"
         coverImage={props.data?.relatedNode?.coverImage?.sources[0]?.uri}
         renderD={() => (
-          <Box as="p" fontSize="s">
-            Coming soon
+          <Box as="p">
+            <b>Starts:</b> {startFormatted}
+            <br />
+            <b>Ends:</b> {endFormatted}
           </Box>
         )}
       />

--- a/components/LiveStreamSingle/PreLive.js
+++ b/components/LiveStreamSingle/PreLive.js
@@ -1,0 +1,28 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import { ContentLayout } from 'components';
+import { Box } from 'ui-kit';
+
+function PreLive(props = {}) {
+  return (
+    <>
+      <ContentLayout
+        title={props.data?.relatedNode?.title}
+        summary={props.data?.relatedNode?.summary}
+        coverImage={props.data?.relatedNode?.coverImage?.sources[0]?.uri}
+        renderD={() => (
+          <Box as="p" fontSize="s">
+            Coming soon
+          </Box>
+        )}
+      />
+    </>
+  );
+}
+
+PreLive.propTypes = {
+  data: PropTypes.object,
+};
+
+export default PreLive;

--- a/components/LiveStreamSingle/PreLive.js
+++ b/components/LiveStreamSingle/PreLive.js
@@ -16,20 +16,18 @@ function PreLive(props = {}) {
     : 'null';
 
   return (
-    <>
-      <ContentLayout
-        title={props.data?.relatedNode?.title}
-        summary="Coming Soon"
-        coverImage={props.data?.relatedNode?.coverImage?.sources[0]?.uri}
-        renderD={() => (
-          <Box as="p">
-            <b>Starts:</b> {startFormatted}
-            <br />
-            <b>Ends:</b> {endFormatted}
-          </Box>
-        )}
-      />
-    </>
+    <ContentLayout
+      title={props.data?.relatedNode?.title}
+      summary="Coming Soon"
+      coverImage={props.data?.relatedNode?.coverImage?.sources[0]?.uri}
+      renderD={() => (
+        <Box as="p">
+          <b>Starts:</b> {startFormatted}
+          <br />
+          <b>Ends:</b> {endFormatted}
+        </Box>
+      )}
+    />
   );
 }
 

--- a/hooks/useLiveStream.js
+++ b/hooks/useLiveStream.js
@@ -89,37 +89,35 @@ const useLiveStream = ({ liveStreamId }) => {
   const [nextRefetch, setNextRefetch] = useState(null);
 
   // Fetch
-  const { data, loading, error, refetch } =
-    useQuery(GET_LIVE_STREAM, {
-      variables: { id: liveStreamId || '' },
-      skip,
-      fetchPolicy: 'network-only',
+  const { data, loading, error, refetch } = useQuery(GET_LIVE_STREAM, {
+    variables: { id: liveStreamId || '' },
+    skip,
+    fetchPolicy: 'network-only',
 
-      onCompleted: ({ data }) => {
-        const startDate = data?.node?.eventStartTime
-          ? parseISO(data?.node?.eventStartTime)
-          : null;
-        const endDate = data?.node?.eventEndTime
-          ? parseISO(data?.node?.eventEndTime)
-          : null;
+    onCompleted: data => {
+      const startDate = data?.node?.eventStartTime
+        ? parseISO(data?.node?.eventStartTime)
+        : null;
+      const endDate = data?.node?.eventEndTime
+        ? parseISO(data?.node?.eventEndTime)
+        : null;
 
-        if (startDate) setNowIsBefore(isBefore(new Date(), startDate));
-        if (endDate) {
-          setNowIsAfter(isAfter(new Date(), endDate));
+      if (startDate) setNowIsBefore(isBefore(new Date(), startDate));
+      if (endDate) {
+        setNowIsAfter(isAfter(new Date(), endDate));
 
-          /**
-           * If right now is more than 5 minutes out from the end of the stream, set the next refetch of data to be 5 minutes before the stream ends
-           */
-
-          if (differenceInSeconds(endDate, new Date()) >= fiveMins) {
-            const fiveMinsBeforeEnd = subSeconds(endDate, fiveMins);
-            setNextRefetch(
-              differenceInMilliseconds(fiveMinsBeforeEnd, new Date())
-            );
-          }
+        /**
+         * If right now is more than 5 minutes out from the end of the stream, set the next refetch of data to be 5 minutes before the stream ends
+         */
+        if (differenceInSeconds(endDate, new Date()) >= fiveMins) {
+          const fiveMinsBeforeEnd = subSeconds(endDate, fiveMins);
+          setNextRefetch(
+            differenceInMilliseconds(fiveMinsBeforeEnd, new Date())
+          );
         }
-      },
-    }) || {};
+      }
+    },
+  });
 
   // Effects
   useEffect(() => {
@@ -172,6 +170,11 @@ const useLiveStream = ({ liveStreamId }) => {
     };
   }, [nowIsBefore, nowIsAfter, data?.node]);
 
+  const __DEV_OVERRIDES__ = {
+    // isLive: false,
+    // isBefore: true,
+  };
+
   return {
     loading,
     error,
@@ -190,6 +193,7 @@ const useLiveStream = ({ liveStreamId }) => {
       endDate: data?.node?.eventEndTime
         ? parseISO(data?.node?.eventEndTime)
         : null,
+      ...__DEV_OVERRIDES__,
     },
   };
 };

--- a/pages/live/index.js
+++ b/pages/live/index.js
@@ -1,11 +1,34 @@
+import { format } from 'date-fns';
+
 import { useLiveStreamsQuery } from 'hooks';
-import { slugify } from 'utils';
+import { slugify, parseLiveStreamDates } from 'utils';
 
 import { Box, DefaultCard } from 'ui-kit';
 import { CustomLink, Layout } from 'components';
 
+function getDescription(liveStream) {
+  const parsed = parseLiveStreamDates(liveStream);
+
+  let startFormatted = parsed.startDate
+    ? format(parsed.startDate, `EEE M/dd 'from' h:mm a`)
+    : 'null';
+
+  let endFormatted = parsed.endDate ? format(parsed.endDate, `h:mm a`) : 'null';
+  let status;
+
+  if (parsed.isBefore) {
+    status = 'Upcoming';
+  } else if (liveStream.isLive) {
+    status = 'LIVE';
+  } else if (parsed.isAfter) {
+    status = 'After';
+  }
+
+  return `DATE: ${startFormatted} – ${endFormatted} (${status})`;
+}
+
 export default function Live() {
-  const { liveStreams = [] } = useLiveStreamsQuery();
+  const { liveStreams: liveStreamsData } = useLiveStreamsQuery();
 
   return (
     <Layout title="Live">
@@ -13,23 +36,26 @@ export default function Live() {
         LiveStreams
       </Box>
       <Box display="grid" gridTemplateColumns={{ __: '1fr', md: '1fr 1fr' }}>
-        {!liveStreams.length && <Box as="p">No livestreams</Box>}
-        {liveStreams.map(liveStream => (
-          <CustomLink
-            key={liveStream.id}
-            as="a"
-            href={`/live/${slugify(liveStream.relatedNode?.title)}`}
-            Component={DefaultCard}
-            coverImage={liveStream.relatedNode?.coverImage?.sources[0]?.uri}
-            coverImageOverlay={true}
-            coverImageTitle={liveStream.relatedNode?.title}
-            coverImageDescription={liveStream.relatedNode?.summary}
-            m="base"
-            display="block"
-            height={{ __: 256, md: 384 }}
-            maxWidth={{ __: 384, md: 512 }}
-          />
-        ))}
+        {!liveStreamsData.length && <Box as="p">No livestreams</Box>}
+        {liveStreamsData.length &&
+          liveStreamsData.map(liveStream => {
+            return (
+              <CustomLink
+                key={liveStream.id}
+                as="a"
+                href={`/live/${slugify(liveStream.relatedNode?.title)}`}
+                Component={DefaultCard}
+                coverImage={liveStream.relatedNode?.coverImage?.sources[0]?.uri}
+                coverImageOverlay={true}
+                coverImageTitle={liveStream.relatedNode?.title}
+                coverImageDescription={getDescription(liveStream)}
+                m="base"
+                display="block"
+                height={{ __: 256, md: 384 }}
+                maxWidth={{ __: 384, md: 512 }}
+              />
+            );
+          })}
       </Box>
     </Layout>
   );

--- a/ui-kit/_config/colors.js
+++ b/ui-kit/_config/colors.js
@@ -4,6 +4,7 @@ const BATTLESHIP = '#818181';
 const PICTON = '#00aeef';
 const TUATARA = '#353535';
 const WHITE_SMOKE = '#f6f6f6';
+const RUBY = '#cb045b';
 
 const colors = {
   // LIGHT THEME
@@ -29,9 +30,10 @@ const colors = {
       900: TUATARA,
     },
 
-    alert: '#fe5f55',
+    alert: RUBY,
     warning: '#ffc527',
     success: '#8acb88',
+    live: RUBY,
     wordOfChrist: TUATARA,
 
     screen: WHITE_SMOKE,
@@ -65,9 +67,10 @@ const colors = {
       900: TUATARA,
     },
 
-    alert: '#fe5f55',
+    alert: RUBY,
     warning: '#ffc527',
     success: '#8acb88',
+    live: RUBY,
     wordOfChrist: TUATARA,
 
     screen: TUATARA,

--- a/utils/index.js
+++ b/utils/index.js
@@ -5,8 +5,9 @@ import getAge from './getAge';
 import getComponent from './getComponent';
 import getURLFromType from './getURLFromType';
 import normalizeUserData from './normalizeUserData';
+import parseLiveStreamDates from './parseLiveStreamDates';
 import slugify from './slugify';
-import textTrimmer from './textTrimmer'
+import textTrimmer from './textTrimmer';
 import validateEmail from './validateEmail';
 import validatePhoneNumber from './validatePhoneNumber';
 
@@ -18,6 +19,7 @@ export {
   getComponent,
   getURLFromType,
   normalizeUserData,
+  parseLiveStreamDates,
   slugify,
   textTrimmer,
   validateEmail,

--- a/utils/parseLiveStreamDates.js
+++ b/utils/parseLiveStreamDates.js
@@ -1,0 +1,19 @@
+import { isAfter, isBefore, parseISO } from 'date-fns';
+
+export default function parseLiveStreamDates(liveStream) {
+  if (!liveStream) {
+    return null;
+  }
+  const { isLive, eventStartTime, eventEndTime } = liveStream;
+
+  const startDate = eventStartTime ? parseISO(eventStartTime) : null;
+  const endDate = eventEndTime ? parseISO(eventEndTime) : null;
+
+  return {
+    startDate,
+    endDate,
+    isLive,
+    isBefore: startDate ? isBefore(new Date(), startDate) : false,
+    isAfter: endDate ? isAfter(new Date(), endDate) : false,
+  };
+}


### PR DESCRIPTION
# About
Scaffolds out the data mechanisms for determining a LiveStream state: `pre`, `live`, or `post`.
The hooks were borrowed from the mobile app Apollos 2.0 work, but had to be slightly adapted due some data fetching differences.

# Tradeoffs / Caveats
The hooks from mobile app weren't 100% drop in, but there is definitely room for 1:1 sharing as a follow up task.
There was some subtle difference with the data input structure, i.e. essentially instead of `data.node?` the details were on `data?`.

This PR also does **not** fully address layout or visual concerns. It focuses on the bones, not the skin.
There is development code data displayed on screen, that will be removed tomorrow (or imminently).

The quality overall of our test livestreams isn't great right now — we can refine this for better internal testing.
There are duplicate livestreams, multiple livestreams per event, etc.

# Testing
To get more test livestream data to work with, make a quick tweak to your local API.
Open `src/data/live-stream/data-source.js` and:
- Replace **line 137** with `if (false) {` (it should currently say `if (!anonymously) {`
- Comment out **lines 177–178**, the `.filter()` steps for `isLive` and `filterByPersona`

Open http://local.christfellowship.church:3000/live and play with the data.
To test the `Post` live state (recently ended livestream), you most likely need to modify `components/LiveStreamSingle/LiveStreamSingle.js` so that the `<PostLive>` conditional is `true` and comment out the others.

# Screenshots/Gifs

|Caption|Screenshot/Gif|
|---|---|
|All LiveStreams path `/live`|<img src="https://user-images.githubusercontent.com/1812955/110386870-dbd5b980-802e-11eb-8c21-081b85833dd5.png" alt="CleanShot 2021-03-08 at 15 20 24@2x" width="450px" />|
|Pre-Live (Upcoming)|<img src="https://user-images.githubusercontent.com/1812955/110386888-e001d700-802e-11eb-8e83-2c2ef3db7173.png" alt="CleanShot 2021-03-08 at 15 20 19@2x" width="450px" />|
|Live|<img src="https://user-images.githubusercontent.com/1812955/110386864-d9735f80-802e-11eb-91f8-d8cbb5c9706a.png" alt="CleanShot 2021-03-08 at 15 20 45@2x" width="450px" />|
|Post-Live (recently ended)|<img src="https://user-images.githubusercontent.com/1812955/110387963-623ecb00-8030-11eb-88e6-3846bcb552e4.png" alt="CleanShot 2021-03-08 at 16 57 57@2x" width="450px" />|
|Invalid state we'll need to better handle|<img src="https://user-images.githubusercontent.com/1812955/110386853-d5dfd880-802e-11eb-9fdc-72ba4c960cdc.png" alt="CleanShot 2021-03-08 at 16 10 56@2x" width="450px" />|