### PR TITLE
Setup google analytics without dependencies

### DIFF
--- a/lib/gtag/gtag.js
+++ b/lib/gtag/gtag.js
@@ -1,0 +1,24 @@
+// https://developers.google.com/analytics/devguides/collection/gtagjs/pages
+const pageview = url => {
+  if (typeof window !== 'undefined') {
+    window.gtag('config', process.env.NEXT_PUBLIC_GA_CODE, {
+      page_path: url,
+    });
+  }
+};
+
+// https://developers.google.com/analytics/devguides/collection/gtagjs/events
+const trackEvent = ({ action, category, label, value }) => {
+  window.gtag('event', action, {
+    event_category: category,
+    event_label: label,
+    value: value,
+  });
+};
+
+const gtag = {
+  pageview,
+  trackEvent,
+};
+
+export default gtag;

--- a/lib/gtag/index.js
+++ b/lib/gtag/index.js
@@ -1,0 +1,3 @@
+import gtag from './gtag';
+
+export default gtag;

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,12 +1,53 @@
+import { useEffect } from 'react';
 import Head from 'next/head';
+import { useRouter } from 'next/router';
 
 import configureNProgress from 'config/nprogress';
 import { AppProvider } from 'providers';
+import gtag from 'lib/gtag';
 
 // Tracks the route changes and adds a bar to the top.
 configureNProgress();
 
 function App({ Component, pageProps }) {
+  const router = useRouter();
+
+  useEffect(() => {
+    // Do not run Google Analytics unless traffic is coming from a browser
+    const _isNotBrowser =
+      typeof window === 'undefined' || typeof document === 'undefined';
+
+    if (_isNotBrowser) return null;
+
+    // Only run Google Analytics in production
+    if (!process.env.NODE_ENV === 'production') return null;
+
+    // NEXT_PUBLIC_GA_CODE  needs to be set in the .env
+    if (!process.env.NEXT_PUBLIC_GA_CODE) {
+      console.warn(
+        'GoogleAnalytics tracking code is required to initialize GoogleAnalytics'
+      );
+      return null;
+    }
+
+    if (!window.gtag) {
+      console.warn(
+        'GoogleAnalytics should be loaded manually before gtag is called.'
+      );
+      return null;
+    }
+
+    const handleRouteChange = url => {
+      gtag.pageview(url);
+    };
+
+    router.events.on('routeChangeComplete', handleRouteChange);
+
+    return () => {
+      router.events.off('routeChangeComplete', handleRouteChange);
+    };
+  }, [router.events]);
+
   return (
     <>
       <Head>
@@ -18,6 +59,29 @@ function App({ Component, pageProps }) {
           href="https://cloud.typography.com/7426316/6701612/css/fonts.css"
         />
         <link rel="stylesheet" type="text/css" href="/nprogress.css" />
+        {/* Global site tag (gtag.js) - Google Analytics */}
+        {process.env.NODE_ENV === 'production' &&
+        process.env.NEXT_PUBLIC_GA_CODE ? (
+          <>
+            <script
+              async
+              src={`https://www.googletagmanager.com/gtag/js?id=${process.env.NEXT_PUBLIC_GA_CODE}`}
+            />
+            <script
+              // eslint-disable-next-line react/no-danger
+              dangerouslySetInnerHTML={{
+                __html: `
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+        gtag('config', '${process.env.NEXT_PUBLIC_GA_CODE}', {
+          page_path: window.location.pathname,
+        });
+      `,
+              }}
+            />
+          </>
+        ) : null}
       </Head>
       <AppProvider initialApolloState={pageProps.initialApolloState}>
         <Component {...pageProps} />


### PR DESCRIPTION
This PR sets up Google analytics without the need of any extra dependences. I've added a few checks to make sure the analytics are only initialized in production, in a browser, and the correct environment tracking id is set in the .env

TO TEST: Add a tracking id and kill the check for production. You should see your traffic reflected in the realtime analytics.

![image](https://user-images.githubusercontent.com/2528817/113173207-c65b4600-920e-11eb-8a58-4514845ef1ce.png)
