### PR TITLE
Add back button to discover

### DIFF
--- a/pages/discover/[title].js
+++ b/pages/discover/[title].js
@@ -13,7 +13,7 @@ export default function Content(props) {
   const contentId = type.concat(':', query?.id);
 
   const { categories } = useDiscoverFilterCategoriesPreview({
-    variables: { id: contentId },
+    variables: { id: contentId, first: 21 },
     fetchPolicy: 'cache-and-network',
   });
 
@@ -28,8 +28,8 @@ export default function Content(props) {
         mb="l"
       >
         <Box as="h1" mb="0">
-        {startCase(query?.title)}
-      </Box>
+          {startCase(query?.title)}
+        </Box>
         <Button variant="link" onClick={() => back()} pr="0">
           <Icon name="angleLeft" /> Back
         </Button>

--- a/pages/discover/[title].js
+++ b/pages/discover/[title].js
@@ -4,11 +4,11 @@ import startCase from 'lodash/startCase';
 import { getURLFromType } from 'utils';
 import { useDiscoverFilterCategoriesPreview } from 'hooks';
 
-import { Box, DefaultCard, CardGrid } from 'ui-kit';
+import { Box, DefaultCard, CardGrid, Icon, Button } from 'ui-kit';
 import { Layout, CustomLink } from 'components';
 
 export default function Content(props) {
-  const { query } = useRouter();
+  const { query, back } = useRouter();
   const type = 'UniversalContentItem';
   const contentId = type.concat(':', query?.id);
 
@@ -21,8 +21,18 @@ export default function Content(props) {
 
   return (
     <Layout title={startCase(query?.title)}>
-      <Box as="h1" mb="l">
+      <Box
+        alignItems="center"
+        display="flex"
+        justifyContent="space-between"
+        mb="l"
+      >
+        <Box as="h1" mb="0">
         {startCase(query?.title)}
+      </Box>
+        <Button variant="link" onClick={() => back()} pr="0">
+          <Icon name="angleLeft" /> Back
+        </Button>
       </Box>
       <CardGrid columns="3" mb="xl">
         {content.map((n, i) => (


### PR DESCRIPTION
Adds back button to the 'see more' discover pages. This also limits the query for these pages since pagination is not implemented here.

![image](https://user-images.githubusercontent.com/2528817/115054519-e7c26000-9ea5-11eb-9628-25052db34a4a.png)
