### PR TITLE
Remove extra loading component on discover

### DIFF
--- a/components/DiscoverFiltersMap/DiscoverFiltersMap.js
+++ b/components/DiscoverFiltersMap/DiscoverFiltersMap.js
@@ -1,11 +1,8 @@
 import React from 'react';
 
-import { Loader } from 'ui-kit';
 import { DiscoverFilterSection } from 'components';
 
 const DiscoverFiltersMap = props => {
-  if (props.loading) return <Loader justifyContent="center" />;
-
   return props.data
     .map(edge => edge.node)
     .map((node, i) => (


### PR DESCRIPTION
Remove extra loading component to stop weird loading flashing on discover page. Loading state could be improved more, but I feel like this is a good quick fix.
![2021-04-19 16 13 05](https://user-images.githubusercontent.com/2528817/115304304-6af3e800-a12a-11eb-9f39-74e9a2a61b95.gif)

