### PR TITLE
Tweak link active state

### DIFF
--- a/ui-kit/Button/Button.styles.js
+++ b/ui-kit/Button/Button.styles.js
@@ -30,7 +30,7 @@ const variant = ({ variant, active }) => props => {
       &:focus,
       &:hover {
         background: none;
-        color: ${themeGet('colors.primaryHover')};
+        color: ${themeGet('colors.neutrals.800')};
         outline: none;
       }
     `;
@@ -112,14 +112,14 @@ const active = ({ active, variant }) => props => {
   if (active && variant === 'link') {
     return css`
       background: none;
-      color: ${themeGet('colors.primaryHover')};
+      color: ${themeGet('colors.neutrals.800')};
       outline: none;
 
       &:active,
       &:focus,
       &:hover {
         background: none;
-        color: ${themeGet('colors.primaryHover')};
+        color: ${themeGet('colors.neutrals.800')};
         outline: none;
       }
     `;


### PR DESCRIPTION
This just changes the active color from primary to dark gray on button links for the about tabs.

![image](https://user-images.githubusercontent.com/2528817/115424824-a8a54f00-a1c4-11eb-9fa4-39d9ba63a5ac.png)
