### PR TITLE
Fix query error on EventContentItem

### DIFF
--- a/hooks/useContentItem.js
+++ b/hooks/useContentItem.js
@@ -50,7 +50,7 @@ export const EVENT_ITEM_FRAGMENT = gql`
       }
       location
     }
-    labelText
+    label
     callsToAction {
       call
       action


### PR DESCRIPTION
This fixes this error that was thrown when you click the `Get Connected` item on the home screen. `labelText` should be `label`.

![image](https://user-images.githubusercontent.com/2528817/115451944-71926600-a1e3-11eb-9726-63d7e96ddea7.png)
![image](https://user-images.githubusercontent.com/2528817/115451984-7c4cfb00-a1e3-11eb-9277-5c11acb59b91.png)
