### PR TITLE
Enhance theming

### DIFF
--- a/components/ContentLayout/ContentLayout.js
+++ b/components/ContentLayout/ContentLayout.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import { createMarkup } from 'utils';
-import { Box, Card, DefaultCard, Longform } from 'ui-kit';
+import { Box, Card, DefaultCard, Longform, ThemeProvider } from 'ui-kit';
 import { SEO } from 'components';
 
 function ContentLayout(props = {}) {
@@ -95,7 +95,7 @@ function ContentLayout(props = {}) {
   }
 
   return (
-    <>
+    <ThemeProvider mode={props.mode}>
       <SEO title={props.title} />
       {renderA()}
       <Box
@@ -115,7 +115,7 @@ function ContentLayout(props = {}) {
         {renderD()}
         {renderE()}
       </Box>
-    </>
+    </ThemeProvider>
   );
 }
 
@@ -124,10 +124,11 @@ ContentLayout.propTypes = {
   contentTitleE: PropTypes.string,
   coverImage: PropTypes.string,
   htmlContent: PropTypes.string,
+  mode: PropTypes.string,
   renderA: PropTypes.func,
   renderB: PropTypes.func,
-  renderContentB: PropTypes.func,
   renderC: PropTypes.func,
+  renderContentB: PropTypes.func,
   renderContentD: PropTypes.func,
   renderContentE: PropTypes.func,
   renderD: PropTypes.func,

--- a/components/ContentLayout/ContentLayout.js
+++ b/components/ContentLayout/ContentLayout.js
@@ -1,9 +1,20 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { themeGet } from '@styled-system/theme-get';
 
 import { createMarkup } from 'utils';
-import { Box, Card, DefaultCard, Longform, ThemeProvider } from 'ui-kit';
+import {
+  Box,
+  Card,
+  Cell,
+  DefaultCard,
+  Longform,
+  ThemeProvider,
+  utils,
+} from 'ui-kit';
 import { SEO } from 'components';
+
+const DEFAULT_CONTENT_WIDTH = utils.rem('1100px');
 
 function ContentLayout(props = {}) {
   function renderA() {
@@ -96,24 +107,33 @@ function ContentLayout(props = {}) {
 
   return (
     <ThemeProvider mode={props.mode}>
-      <SEO title={props.title} />
-      {renderA()}
-      <Box
-        alignItems="center"
-        display={{ lg: 'grid' }}
-        gridTemplateColumns="70% 30%"
-        mb="l"
-      >
-        {renderB()}
-        {renderC()}
-      </Box>
-      <Box
-        display={{ lg: 'grid' }}
-        gridTemplateColumns="65% 1fr"
-        gridColumnGap="l"
-      >
-        {renderD()}
-        {renderE()}
+      <Box backgroundColor={'bg'} color={'fg'}>
+        <Cell
+          as="main"
+          maxWidth={props.contentMaxWidth}
+          px={props.contentHorizontalPadding}
+          py={props.contentVerticalPadding}
+        >
+          <SEO title={props.title} />
+          {renderA()}
+          <Box
+            alignItems="center"
+            display={{ lg: 'grid' }}
+            gridTemplateColumns="70% 30%"
+            mb="l"
+          >
+            {renderB()}
+            {renderC()}
+          </Box>
+          <Box
+            display={{ lg: 'grid' }}
+            gridTemplateColumns="65% 1fr"
+            gridColumnGap="l"
+          >
+            {renderD()}
+            {renderE()}
+          </Box>
+        </Cell>
       </Box>
     </ThemeProvider>
   );
@@ -134,6 +154,12 @@ ContentLayout.propTypes = {
   renderD: PropTypes.func,
   renderE: PropTypes.func,
   title: PropTypes.string,
+};
+
+ContentLayout.defaultProps = {
+  contentMaxWidth: DEFAULT_CONTENT_WIDTH,
+  contentHorizontalPadding: 'base',
+  contentVerticalPadding: { _: 'l', lg: 'xl' },
 };
 
 export default ContentLayout;

--- a/components/ContentSingle/ContentSingle.js
+++ b/components/ContentSingle/ContentSingle.js
@@ -22,6 +22,7 @@ function ContentSingle(props = {}) {
 
   return (
     <ContentLayout
+      mode={props.data.mode}
       title={props.data.title}
       summary={props.data.schedule?.friendlyScheduleText || props.data.summary}
       coverImage={currentVideo ? null : coverImage}

--- a/components/EventSingle/EventSingle.js
+++ b/components/EventSingle/EventSingle.js
@@ -9,6 +9,7 @@ import EventGroupings from './EventGroupings';
 function EventSingle(props = {}) {
   return (
     <ContentLayout
+      mode={props.data.mode}
       title={props.data.title}
       summary={props.data.summary}
       coverImage={props.data?.coverImage?.sources[0]?.uri}

--- a/components/GroupSingle/GroupSingle.js
+++ b/components/GroupSingle/GroupSingle.js
@@ -31,6 +31,7 @@ function GroupSingle(props = {}) {
   return (
     <ChatConnectionProvider>
       <ContentLayout
+        mode={props.data.mode}
         title={props.data?.title}
         summary={props.data.schedule?.friendlyScheduleText}
         coverImage={props.data?.coverImage?.sources[0]?.uri}

--- a/components/Header/Header.styles.js
+++ b/components/Header/Header.styles.js
@@ -11,6 +11,7 @@ const Header = styled.header`
   justify-content: center;
   grid-template-columns: auto 1fr;
   padding: ${themeGet('space.base')};
+  z-index: 1;
 
   > *:last-child {
     justify-self: flex-end;

--- a/components/Layout/Layout.js
+++ b/components/Layout/Layout.js
@@ -1,10 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import { Box, Cell, utils } from 'ui-kit';
+import { Box } from 'ui-kit';
 import { Footer, Header, SEO } from 'components';
-
-const DEFAULT_CONTENT_WIDTH = utils.rem('1100px');
 
 function Layout(props = {}) {
   return (
@@ -12,16 +10,7 @@ function Layout(props = {}) {
       <SEO title={props.title} />
       <Box display="flex" flexDirection="column" height="100vh">
         <Header />
-        <Box flexGrow="1">
-          <Cell
-            as="main"
-            maxWidth={props.contentMaxWidth}
-            px={props.contentHorizontalPadding}
-            py={props.contentVerticalPadding}
-          >
-            {props.children}
-          </Cell>
-        </Box>
+        <Box flexGrow="1">{props.children}</Box>
         <Footer />
       </Box>
     </>
@@ -45,12 +34,6 @@ Layout.propTypes = {
     PropTypes.object,
   ]),
   title: PropTypes.string,
-};
-
-Layout.defaultProps = {
-  contentMaxWidth: DEFAULT_CONTENT_WIDTH,
-  contentHorizontalPadding: 'base',
-  contentVerticalPadding: { _: 'l', lg: 'xl' },
 };
 
 export default Layout;

--- a/components/LiveStreamSingle/LiveStreamSingle.js
+++ b/components/LiveStreamSingle/LiveStreamSingle.js
@@ -38,6 +38,7 @@ function LiveStreamSingle(props = {}) {
   return (
     <Cell px="base" pt={{ _: 'l', lg: 'xl' }}>
       <ContentLayout
+        mode={props.data.mode}
         title={props.data?.relatedNode?.title}
         summary={props.data?.relatedNode?.summary}
         coverImage={props.data?.relatedNode?.coverImage?.sources[0]?.uri}

--- a/components/LiveStreamSingle/PostLive.js
+++ b/components/LiveStreamSingle/PostLive.js
@@ -8,6 +8,7 @@ function PostLive(props = {}) {
   return (
     <Cell px="base" pt={{ _: 'l', lg: 'xl' }}>
       <ContentLayout
+        mode={props.data.mode}
         title={props.data?.relatedNode?.title}
         summary={'Thanks for joining us!'}
         coverImage={props.data?.relatedNode?.coverImage?.sources[0]?.uri}

--- a/components/LiveStreamSingle/PreLive.js
+++ b/components/LiveStreamSingle/PreLive.js
@@ -18,6 +18,7 @@ function PreLive(props = {}) {
   return (
     <Cell px="base" pt={{ _: 'l', lg: 'xl' }}>
       <ContentLayout
+        mode={props.data.mode}
         title={props.data?.relatedNode?.title}
         summary={`Scheduled for ${startFormatted} (${distance})`}
         coverImage={props.data?.relatedNode?.coverImage?.sources[0]?.uri}

--- a/pages/404.js
+++ b/pages/404.js
@@ -1,26 +1,35 @@
 import React from 'react';
 
-import { Box } from 'ui-kit';
+import { Box, Cell, utils } from 'ui-kit';
 import { Layout } from 'components';
 
 const NotFound = () => {
   return (
     <Layout title="404 Not Found">
-      <Box mt="xl" textAlign="center">
-        <Box
-          as="img"
-          alt="Error Image"
-          maxWidth={750}
-          src="/error.png"
-          margin="auto"
-        />
-        <Box as="h1" mt="base">Page Not Found</Box>
-        <Box as="p" fontSize="l" p="l">
-          The page you’re looking for doesn’t exist, or is unavailable.
+      <Cell
+        as="main"
+        maxWidth={utils.rem('1100px')}
+        px="base"
+        py={{ _: 'l', lg: 'xl' }}
+      >
+        <Box mt="xl" textAlign="center">
+          <Box
+            as="img"
+            alt="Error Image"
+            maxWidth={750}
+            src="/error.png"
+            margin="auto"
+          />
+          <Box as="h1" mt="base">
+            Page Not Found
+          </Box>
+          <Box as="p" fontSize="l" p="l">
+            The page you’re looking for doesn’t exist, or is unavailable.
+          </Box>
         </Box>
-      </Box>
+      </Cell>
     </Layout>
   );
-}
+};
 
-export default NotFound
+export default NotFound;

--- a/pages/community/[title].js
+++ b/pages/community/[title].js
@@ -7,7 +7,7 @@ import toLower from 'lodash/toLower';
 import { CommunitiesProvider } from 'providers';
 import { useGroupPreferences } from 'hooks';
 import { CommunitySingle, Layout } from 'components';
-import { Box, Loader } from 'ui-kit';
+import { Box, Cell, Loader, utils } from 'ui-kit';
 
 export default function Community(props) {
   const { preferences, subPreferences, loading } = useGroupPreferences();
@@ -30,9 +30,16 @@ export default function Community(props) {
 
     return (
       <Layout>
-        <Box mt="xl" mb="xxl" display="flex" justifyContent="center">
-          <Loader my="xl" />
-        </Box>
+        <Cell
+          as="main"
+          maxWidth={utils.rem('1100px')}
+          px="base"
+          py={{ _: 'l', lg: 'xl' }}
+        >
+          <Box mt="xl" mb="xxl" display="flex" justifyContent="center">
+            <Loader my="xl" />
+          </Box>
+        </Cell>
       </Layout>
     );
   }

--- a/pages/discover/[title].js
+++ b/pages/discover/[title].js
@@ -4,7 +4,7 @@ import startCase from 'lodash/startCase';
 import { getURLFromType } from 'utils';
 import { useDiscoverFilterCategoriesPreview } from 'hooks';
 
-import { Box, DefaultCard, CardGrid, Icon, Button } from 'ui-kit';
+import { Box, DefaultCard, CardGrid, Cell, Icon, Button, utils } from 'ui-kit';
 import { Layout, CustomLink } from 'components';
 
 export default function Content(props) {
@@ -21,35 +21,42 @@ export default function Content(props) {
 
   return (
     <Layout title={startCase(query?.title)}>
-      <Box
-        alignItems="center"
-        display="flex"
-        justifyContent="space-between"
-        mb="l"
+      <Cell
+        as="main"
+        maxWidth={utils.rem('1100px')}
+        px="base"
+        py={{ _: 'l', lg: 'xl' }}
       >
-        <Box as="h1" mb="0">
-          {startCase(query?.title)}
+        <Box
+          alignItems="center"
+          display="flex"
+          justifyContent="space-between"
+          mb="l"
+        >
+          <Box as="h1" mb="0">
+            {startCase(query?.title)}
+          </Box>
+          <Button variant="link" onClick={() => back()} pr="0">
+            <Icon name="angleLeft" /> Back
+          </Button>
         </Box>
-        <Button variant="link" onClick={() => back()} pr="0">
-          <Icon name="angleLeft" /> Back
-        </Button>
-      </Box>
-      <CardGrid columns="3" mb="xl">
-        {content.map((n, i) => (
-          <CustomLink
-            Component={DefaultCard}
-            as="a"
-            boxShadow="none"
-            coverImage={n?.coverImage?.sources[0]?.uri}
-            description={n?.summary}
-            href={getURLFromType(n, n?.title)}
-            key={n?.id}
-            scaleCard={false}
-            scaleCoverImage={true}
-            title={n?.title}
-          />
-        ))}
-      </CardGrid>
+        <CardGrid columns="3" mb="xl">
+          {content.map((n, i) => (
+            <CustomLink
+              Component={DefaultCard}
+              as="a"
+              boxShadow="none"
+              coverImage={n?.coverImage?.sources[0]?.uri}
+              description={n?.summary}
+              href={getURLFromType(n, n?.title)}
+              key={n?.id}
+              scaleCard={false}
+              scaleCoverImage={true}
+              title={n?.title}
+            />
+          ))}
+        </CardGrid>
+      </Cell>
     </Layout>
   );
 }

--- a/pages/discover/index.js
+++ b/pages/discover/index.js
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 
-import { Box, Loader, Button } from 'ui-kit';
+import { Box, Loader, Button, Cell, utils } from 'ui-kit';
 import {
   SearchField,
   Layout,
@@ -82,94 +82,101 @@ const Discover = () => {
 
   return (
     <Layout title="Discover">
-      <SearchField
-        handleChange={handleChange}
-        handleClear={handleClearAllClick}
-        handleClick={handleClick}
-        handleSubmit={handleSubmit}
-        mb="base"
-        placeholder="Search..."
-        value={values.text || ''}
+      <Cell
+        as="main"
+        maxWidth={utils.rem('1100px')}
+        px="base"
+        py={{ _: 'l', lg: 'xl' }}
       >
-        Search
-      </SearchField>
+        <SearchField
+          handleChange={handleChange}
+          handleClear={handleClearAllClick}
+          handleClick={handleClick}
+          handleSubmit={handleSubmit}
+          mb="base"
+          placeholder="Search..."
+          value={values.text || ''}
+        >
+          Search
+        </SearchField>
 
-      {showEmptyState && searchVisible && (
-        <Box my="xxl" pb="xxl" textAlign="center">
-          <Box as="h2">Looks like we couldn't find any results</Box>
-          <Box mb="base">Consider modifying your search criteria.</Box>
-          <Box
-            display="flex"
-            alignItems="center"
-            flexDirection="column"
-            mt="l"
-            textAlign="center"
-          >
-            <Button variant="secondary" onClick={handleClearAllClick} mb="s">
-              Clear Search
+        {showEmptyState && searchVisible && (
+          <Box my="xxl" pb="xxl" textAlign="center">
+            <Box as="h2">Looks like we couldn't find any results</Box>
+            <Box mb="base">Consider modifying your search criteria.</Box>
+            <Box
+              display="flex"
+              alignItems="center"
+              flexDirection="column"
+              mt="l"
+              textAlign="center"
+            >
+              <Button variant="secondary" onClick={handleClearAllClick} mb="s">
+                Clear Search
+              </Button>
+            </Box>
+          </Box>
+        )}
+        {hasResults && searchVisible && (
+          <ContentItemsSearchProvider
+            data={contentItems}
+            Component={DiscoverItemsList}
+          />
+        )}
+
+        {loading && (
+          <Box display="flex" justifyContent="center" my="xxl">
+            <Loader />
+          </Box>
+        )}
+        {!loading && hasMorePages && searchVisible && (
+          <Box display="flex" justifyContent="center" mt="xl">
+            <Button variant="tertiary" onClick={handleLoadMore}>
+              Load more
             </Button>
           </Box>
-        </Box>
-      )}
-      {hasResults && searchVisible && (
-        <ContentItemsSearchProvider
-          data={contentItems}
-          Component={DiscoverItemsList}
-        />
-      )}
+        )}
 
-      {loading && (
-        <Box display="flex" justifyContent="center" my="xxl">
-          <Loader />
-        </Box>
-      )}
-      {!loading && hasMorePages && searchVisible && (
-        <Box display="flex" justifyContent="center" mt="xl">
-          <Button variant="tertiary" onClick={handleLoadMore}>
-            Load more
-          </Button>
-        </Box>
-      )}
-
-      {!loading && !searchVisible && (
-        <Box>
-          <Box mb="l">
-            {filters?.map(filter => (
-              <Button
-                key={filter.id}
-                mb="s"
-                mr="xs"
-                onClick={event => {
-                  event.preventDefault();
-                  setFilterValues({
-                    title: setFilterTitle(filter.title),
-                    contentId: setFilterId(filter.id),
-                  });
-                  setSearchVisible(false);
-                  reset();
-                }}
-                rounded={true}
-                size="s"
-                status={
-                  filterValues.title === filter.title ? 'SELECTED' : 'IDLE'
-                }
-                variant="chip"
-              >
-                {filter.title}
-              </Button>
-            ))}
+        {!loading && !searchVisible && (
+          <Box>
+            <Box mb="l">
+              {filters?.map(filter => (
+                <Button
+                  key={filter.id}
+                  mb="s"
+                  mr="xs"
+                  onClick={event => {
+                    event.preventDefault();
+                    setFilterValues({
+                      title: setFilterTitle(filter.title),
+                      contentId: setFilterId(filter.id),
+                    });
+                    setSearchVisible(false);
+                    reset();
+                  }}
+                  rounded={true}
+                  size="s"
+                  status={
+                    filterValues.title === filter.title ? 'SELECTED' : 'IDLE'
+                  }
+                  variant="chip"
+                >
+                  {filter.title}
+                </Button>
+              ))}
+            </Box>
+            <DiscoverFiltersCategoriesProvider
+              options={{
+                variables: {
+                  id: filterValues?.contentId || filters[0]?.id,
+                },
+                fetchPolicy: 'cache-and-network',
+              }}
+              Component={DiscoverFiltersMap}
+            />
           </Box>
-          <DiscoverFiltersCategoriesProvider
-            options={{
-              variables: {
-                id: filterValues?.contentId || filters[0]?.id,
-              },
-              fetchPolicy: 'cache-and-network',
-            }}
-            Component={DiscoverFiltersMap}
-          />
-        </Box>
-      )}
+        )}
+      </Cell>
     </Layout>
   );
 };

--- a/pages/events/index.js
+++ b/pages/events/index.js
@@ -1,16 +1,23 @@
 import { initializeApollo } from 'lib/apolloClient';
 import { EventsFeedProvider } from 'providers';
 import { GET_EVENTS } from 'hooks/useEvents';
-import { Box } from 'ui-kit';
+import { Box, Cell, utils } from 'ui-kit';
 import { Layout, FeatureFeed } from 'components';
 
 export default function Events() {
   return (
     <Layout title="Events">
-      <Box as="h1" mb="l">
-        Events
-      </Box>
-      <EventsFeedProvider Component={FeatureFeed} />
+      <Cell
+        as="main"
+        maxWidth={utils.rem('1100px')}
+        px="base"
+        py={{ _: 'l', lg: 'xl' }}
+      >
+        <Box as="h1" mb="l">
+          Events
+        </Box>
+        <EventsFeedProvider Component={FeatureFeed} />
+      </Cell>
     </Layout>
   );
 }

--- a/pages/groups/index.js
+++ b/pages/groups/index.js
@@ -1,14 +1,21 @@
 import { GroupsProvider } from 'providers';
-import { Box } from 'ui-kit';
+import { Box, Cell, utils } from 'ui-kit';
 import { GroupsList, Layout } from 'components';
 
 export default function Groups() {
   return (
     <Layout title="Groups">
-      <Box as="h1" mb="l">
-        Groups
-      </Box>
-      <GroupsProvider Component={GroupsList} />
+      <Cell
+        as="main"
+        maxWidth={utils.rem('1100px')}
+        px="base"
+        py={{ _: 'l', lg: 'xl' }}
+      >
+        <Box as="h1" mb="l">
+          Groups
+        </Box>
+        <GroupsProvider Component={GroupsList} />
+      </Cell>
     </Layout>
   );
 }

--- a/pages/index.js
+++ b/pages/index.js
@@ -5,11 +5,19 @@ import { GET_FEATURE_FEED } from 'hooks/useFeatureFeed';
 import { GET_FEATURE } from 'hooks/useFeature';
 import { FeatureFeedProvider } from 'providers';
 import { Layout, FeatureFeed } from 'components';
+import { Cell, utils } from 'ui-kit';
 
 export default function Home(props = {}) {
   return (
     <Layout title="Home">
-      <FeatureFeedProvider Component={FeatureFeed} />
+      <Cell
+        as="main"
+        maxWidth={utils.rem('1100px')}
+        px="base"
+        py={{ _: 'l', lg: 'xl' }}
+      >
+        <FeatureFeedProvider Component={FeatureFeed} />
+      </Cell>
     </Layout>
   );
 }

--- a/pages/live/index.js
+++ b/pages/live/index.js
@@ -3,7 +3,7 @@ import { format } from 'date-fns';
 import { useLiveStreamsQuery } from 'hooks';
 import { slugify, parseLiveStreamDates } from 'utils';
 
-import { Box, CardGrid, DefaultCard, Loader } from 'ui-kit';
+import { Box, CardGrid, Cell, DefaultCard, Loader, utils } from 'ui-kit';
 import { CustomLink, Layout } from 'components';
 
 function getDescription(liveStream) {
@@ -28,37 +28,46 @@ export default function Live(props = {}) {
 
   return (
     <Layout title="Live">
-      <Box as="h1" mb="l">
-        Live Events
-      </Box>
-
-      {loading && (
-        <Box display="flex" justifyContent="center" pt="xl">
-          <Loader />
+      <Cell
+        as="main"
+        maxWidth={utils.rem('1100px')}
+        px="base"
+        py={{ _: 'l', lg: 'xl' }}
+      >
+        <Box as="h1" mb="l">
+          Live Events
         </Box>
-      )}
-      {!loading && !liveStreamsData.length && (
-        <Box as="p">No livestreams scheduled</Box>
-      )}
-      {liveStreamsData.length > 0 && (
-        <CardGrid columns="2" mb="xl">
-          {liveStreamsData.map(liveStream => {
-            return (
-              <CustomLink
-                key={liveStream.id}
-                as="a"
-                href={`/live/${slugify(liveStream.relatedNode?.title)}`}
-                Component={DefaultCard}
-                coverImage={liveStream.relatedNode?.coverImage?.sources[0]?.uri}
-                title={liveStream.relatedNode?.title}
-                description={getDescription(liveStream)}
-                coverImageLabel={liveStream.isLive ? 'Live' : null}
-                coverImageLabelBgColor={liveStream.isLive ? 'live' : null}
-              />
-            );
-          })}
-        </CardGrid>
-      )}
+
+        {loading && (
+          <Box display="flex" justifyContent="center" pt="xl">
+            <Loader />
+          </Box>
+        )}
+        {!loading && !liveStreamsData.length && (
+          <Box as="p">No livestreams scheduled</Box>
+        )}
+        {liveStreamsData.length > 0 && (
+          <CardGrid columns="2" mb="xl">
+            {liveStreamsData.map(liveStream => {
+              return (
+                <CustomLink
+                  key={liveStream.id}
+                  as="a"
+                  href={`/live/${slugify(liveStream.relatedNode?.title)}`}
+                  Component={DefaultCard}
+                  coverImage={
+                    liveStream.relatedNode?.coverImage?.sources[0]?.uri
+                  }
+                  title={liveStream.relatedNode?.title}
+                  description={getDescription(liveStream)}
+                  coverImageLabel={liveStream.isLive ? 'Live' : null}
+                  coverImageLabelBgColor={liveStream.isLive ? 'live' : null}
+                />
+              );
+            })}
+          </CardGrid>
+        )}
+      </Cell>
     </Layout>
   );
 }

--- a/pages/locations.js
+++ b/pages/locations.js
@@ -1,13 +1,20 @@
-import { Box } from 'ui-kit';
+import { Box, Cell, utils } from 'ui-kit';
 import { Layout } from 'components';
 
 export default function Locations() {
   return (
     <Layout title="Locations">
-      <Box as="h1">Locations</Box>
-      <Box as="p" fontSize="l">
-        This is where the page content will go&hellip;
-      </Box>
+      <Cell
+        as="main"
+        maxWidth={utils.rem('1100px')}
+        px="base"
+        py={{ _: 'l', lg: 'xl' }}
+      >
+        <Box as="h1">Locations</Box>
+        <Box as="p" fontSize="l">
+          This is where the page content will go&hellip;
+        </Box>
+      </Cell>
     </Layout>
   );
 }

--- a/pages/privacy-policy.js
+++ b/pages/privacy-policy.js
@@ -1,4 +1,4 @@
-import { Box } from 'ui-kit';
+import { Box, Cell, utils } from 'ui-kit';
 import { Layout } from 'components';
 
 import { htmlToReactParser } from 'utils';
@@ -71,11 +71,18 @@ const policy = `<div><h3>Introduction to Our Privacy Policy
 export default function PrivacyPolicy() {
   return (
     <Layout title="Privacy Policy">
-      <Box mb="base" textAlign="center">
-        <Box as="h1">Privacy Policy</Box>
-        <Box as="i">Last Updated: September 12th 2019</Box>
-      </Box>
-      <Box>{htmlToReactParser.parse(policy)}</Box>
+      <Cell
+        as="main"
+        maxWidth={utils.rem('1100px')}
+        px="base"
+        py={{ _: 'l', lg: 'xl' }}
+      >
+        <Box mb="base" textAlign="center">
+          <Box as="h1">Privacy Policy</Box>
+          <Box as="i">Last Updated: September 12th 2019</Box>
+        </Box>
+        <Box>{htmlToReactParser.parse(policy)}</Box>
+      </Cell>
     </Layout>
   );
 }

--- a/pages/profile.js
+++ b/pages/profile.js
@@ -1,10 +1,18 @@
 import { Layout, UserProfile } from 'components';
 import { CurrentPersonProvider } from 'providers';
+import { Cell, utils } from 'ui-kit';
 
 export default function Profile(props = {}) {
   return (
     <Layout title="Profile">
-      <CurrentPersonProvider Component={UserProfile} />
+      <Cell
+        as="main"
+        maxWidth={utils.rem('1100px')}
+        px="base"
+        py={{ _: 'l', lg: 'xl' }}
+      >
+        <CurrentPersonProvider Component={UserProfile} />
+      </Cell>
     </Layout>
   );
 }

--- a/pages/terms-of-use.js
+++ b/pages/terms-of-use.js
@@ -1,4 +1,4 @@
-import { Box } from 'ui-kit';
+import { Box, Cell, utils } from 'ui-kit';
 import { Layout } from 'components';
 
 import { htmlToReactParser } from 'utils';
@@ -88,11 +88,18 @@ const policy = `<div><div>
 export default function Terms() {
   return (
     <Layout title="Terms of Use">
-      <Box mb="base" textAlign="center">
-        <Box as="h1">Terms of Use</Box>
-        <Box as="i">Last Modified: September 20, 2019</Box>
-      </Box>
-      <Box>{htmlToReactParser.parse(policy)}</Box>
+      <Cell
+        as="main"
+        maxWidth={utils.rem('1100px')}
+        px="base"
+        py={{ _: 'l', lg: 'xl' }}
+      >
+        <Box mb="base" textAlign="center">
+          <Box as="h1">Terms of Use</Box>
+          <Box as="i">Last Modified: September 20, 2019</Box>
+        </Box>
+        <Box>{htmlToReactParser.parse(policy)}</Box>
+      </Cell>
     </Layout>
   );
 }

--- a/ui-kit/Card/Card.styles.js
+++ b/ui-kit/Card/Card.styles.js
@@ -55,7 +55,7 @@ const removeBoxShadow = ({ boxShadow }) => props => {
 };
 
 const Card = styled.div`
-  background-color: ${themeGet('colors.white')};
+  background-color: ${themeGet('colors.paper')};
   border-radius: ${themeGet('radii.base')};
   box-shadow: ${themeGet('shadows.xl')};
   color: ${themeGet('colors.fg')};


### PR DESCRIPTION
WIP

Working on enhancing the theming in the app. Currently, we can create a global theme that everything gets and now this PR allows any single piece of content to include a theme `mode` in their data and will use that for the page's color values.

For example, I've created a `christmas` theme object in `colors.js` and forcing the group single pages to use that on top of the base global theme colors. Ugly, but shows that it works as intended.

![image](https://user-images.githubusercontent.com/2528817/115626388-0ddf6a00-a2c3-11eb-9dba-dd7bfc4c73d8.png)
![image](https://user-images.githubusercontent.com/2528817/115626501-336c7380-a2c3-11eb-8155-1d1ed1080ed4.png)
![image](https://user-images.githubusercontent.com/2528817/115626529-3f583580-a2c3-11eb-8f9b-bf82cfadcebd.png)

