### PR TITLE
Fix <CustomLink> component

### DIFF
--- a/components/CustomLink/CustomLink.js
+++ b/components/CustomLink/CustomLink.js
@@ -5,8 +5,8 @@ import { Box } from 'ui-kit';
 function CustomLink({ Component: _Component, href, ...props }) {
   if (!_Component) {
     return (
-      <Link href={href}>
-        <Box as="a" cursor="pointer" {...props}>
+      <Link href={href} passHref={true}>
+        <Box as="a" cursor="pointer" textDecoration="none" {...props}>
           {props.children}
         </Box>
       </Link>


### PR DESCRIPTION
Regular `<a>` links weren't always working when used with `CustomLink`, because the `href` wasn't being passed down or handled properly. This fixes that.

The link I discovered the bug on was the `/community` pages like:
http://local.christfellowship.church:3000/community/sisterhood

Specifically, the **Need help?** links.

But smoke test other text based links and clickable cards across the site, as this is a bit of a core change.