### PR TITLE
Handle updateResourceUrl 500 error

### DIFF
--- a/components/GroupManage/AddResourceLink.js
+++ b/components/GroupManage/AddResourceLink.js
@@ -5,7 +5,10 @@ import { useForm, useUpdateGroupResourceUrl } from 'hooks';
 import { Box, Button, TextInput } from 'ui-kit';
 
 function AddResourceLink(props = {}) {
-  const [{ resourceStatus: status, groupData }, dispatch] = useGroupManage();
+  const [
+    { resourceStatus: status, groupData, message },
+    dispatch,
+  ] = useGroupManage();
   const setStatus = s => dispatch(update({ resourceStatus: s }));
   const [updateResourceUrl] = useUpdateGroupResourceUrl();
 
@@ -18,16 +21,24 @@ function AddResourceLink(props = {}) {
 
     setStatus('SAVING_LINK');
 
-    await updateResourceUrl({
-      variables: {
-        url,
-        title,
-        groupId: groupData.id,
-      },
-      refetchQueries: ['getGroup'],
-    });
-
-    setStatus('IDLE');
+    try {
+      await updateResourceUrl({
+        variables: {
+          url,
+          title,
+          groupId: groupData.id,
+        },
+        refetchQueries: ['getGroup'],
+      });
+      setStatus('IDLE');
+    } catch (error) {
+      dispatch(
+        update({
+          message: 'Uh oh! Something went wrong.',
+          resourceStatus: 'ADD_LINK',
+        })
+      );
+    }
   });
 
   function handleBackClick(event) {
@@ -37,6 +48,11 @@ function AddResourceLink(props = {}) {
 
   return (
     <Box as="form" onSubmit={handleLinkSubmit}>
+      {message && (
+        <Box as="p" color="alert" fontSize="s" mb="base">
+          {message}
+        </Box>
+      )}
       <Box mb="base">
         <TextInput
           label="Title"


### PR DESCRIPTION
Closes #108 by checking to see if another resource `url` and `title` match the current one.

<img width="1161" alt="CleanShot 2021-04-26 at 12 49 27@2x" src="https://user-images.githubusercontent.com/30208/116120991-261e0300-a68e-11eb-962c-38460e9da1ab.png">

### To test
- Add a resource URL that is identical (same title and URL) as another one.
- **You should see the error message.**
- Add a resource URL that is _not_ the same as another (unique).
- **It should be added.**