### PR TITLE
Catch group content hook error when not authenticated

### DIFF
--- a/hooks/useGroupContentId.js
+++ b/hooks/useGroupContentId.js
@@ -51,18 +51,21 @@ function useGroupContentId({ title, id }) {
     if (!authenticated) router.push('/groups');
 
     async function getGroups() {
-      dispatch({ type: 'GROUPS_REQUESTED' });
-      const result = await apolloClient.query({ query: GET_GROUPS });
-      const groups = result?.data?.currentUser?.profile?.groups;
-      if (result.loading) dispatch({ type: 'GROUPS_REQUESTED' });
-      if (groups && state.status !== 'RECEIVED') {
-        dispatch({
-          type: 'GROUPS_RECEIVED',
-          payload: { groups },
-        });
+      try {
+        dispatch({ type: 'GROUPS_REQUESTED' });
+        const result = await apolloClient.query({ query: GET_GROUPS });
+        const groups = result?.data?.currentUser?.profile?.groups;
+        if (result.loading) dispatch({ type: 'GROUPS_REQUESTED' });
+        if (groups && state.status !== 'RECEIVED') {
+          dispatch({
+            type: 'GROUPS_RECEIVED',
+            payload: { groups },
+          });
+        }
+      } catch (error) {
+        console.error('useGroupContentId error: ', error);
       }
     }
-
     // We only want to fetch the user's groups when:
     // 1. There isn't an `id`.
     // 2. There isn't a `contentId`.


### PR DESCRIPTION
**DESCRIPTION**

When navigating to a group while not authenticated the `getGroups` was still getting triggered and throwing an error. Wrapped it in a try/catch so it just redirects you back to `/groups` and logs the error in the console. 

closes: #100 

**TO TEST:**

Go to`http://localhost:3000/groups/cfdp-testing-group` while not logged in. Make sure the runtime error modal doesn't pop up instead you should see the error logged in the console.

<img width="1370" alt="Screen Shot 2021-04-26 at 4 56 17 PM" src="https://user-images.githubusercontent.com/2528817/116156057-9b9acb00-a6b0-11eb-9344-2f2a9c1e9429.png">
<img width="1374" alt="Screen Shot 2021-04-26 at 4 55 10 PM" src="https://user-images.githubusercontent.com/2528817/116156063-9d648e80-a6b0-11eb-9437-435dbd15f5f5.png">

**FUTURE ENHANCEMENT**
Inform the user what went wrong and prompt them to log in to view their groups.
