### PR TITLE
Group Finder Feature Flag

### DIFF
--- a/config/flags.js
+++ b/config/flags.js
@@ -1,0 +1,5 @@
+const flags = {
+  GROUP_FINDER: true,
+};
+
+export default flags;

--- a/config/navigation.js
+++ b/config/navigation.js
@@ -1,5 +1,7 @@
 import { links } from './metadata';
 
+import flags from './flags';
+
 const navigation = {
   menuLinks: [
     {
@@ -14,11 +16,6 @@ const navigation = {
       action: '/groups',
       call: 'Groups',
     },
-    // Hide link until find a group launch
-    // {
-    //   action: '/community',
-    //   call: 'Community',
-    // },
   ],
   navigationLinks: [
     {
@@ -43,5 +40,12 @@ const navigation = {
     call: 'Watch Online',
   },
 };
+
+if (flags.GROUP_FINDER) {
+  navigation.menuLinks.push({
+    action: '/community',
+    call: 'Community',
+  });
+}
 
 export default navigation;

--- a/next.config.js
+++ b/next.config.js
@@ -15,16 +15,18 @@ module.exports = {
         destination: '/discover',
         permanent: true,
       },
-      {
-        source: '/community',
-        destination: '/',
-        permanent: false,
-      },
-      {
-        source: '/community/search',
-        destination: '/',
-        permanent: false,
-      },
+      // TODO: Uncomment these lines to hide Group Finder.
+      // NOTE: We can't get `config/flags` in this file.
+      // {
+      //   source: '/community',
+      //   destination: '/',
+      //   permanent: false,
+      // },
+      // {
+      //   source: '/community/search',
+      //   destination: '/',
+      //   permanent: false,
+      // },
     ];
   },
 };

--- a/pages/community/[title].js
+++ b/pages/community/[title].js
@@ -5,6 +5,7 @@ import find from 'lodash/find';
 import kebabCase from 'lodash/kebabCase';
 import toLower from 'lodash/toLower';
 
+import flags from 'config/flags';
 import { CommunitiesProvider } from 'providers';
 import { useGroupPreferences } from 'hooks';
 import { CommunitySingle, Layout } from 'components';
@@ -13,12 +14,9 @@ import { Box, Cell, Loader, utils } from 'ui-kit';
 export default function Community(props) {
   const router = useRouter();
 
-  // Redirect and return null until find a group launch
   useEffect(() => {
-    router.push('/');
+    if (!flags.GROUP_FINDER) router.push('/');
   }, [router]);
-
-  return null;
 
   const { preferences, subPreferences, loading } = useGroupPreferences();
 
@@ -32,6 +30,8 @@ export default function Community(props) {
     n => formatTitleAsUrl(get(n, 'title', '')) === slug
   );
   const unknownPreference = !loading && !preference;
+
+  if (!flags.GROUP_FINDER) return null;
 
   if (loading || unknownPreference) {
     if (unknownPreference) {

--- a/pages/community/index.js
+++ b/pages/community/index.js
@@ -1,6 +1,7 @@
 import { useEffect } from 'react';
 import { useRouter } from 'next/router';
 
+import flags from 'config/flags';
 import { Box, Button, Cell, utils } from 'ui-kit';
 import {
   CommunityActionSection,
@@ -24,13 +25,11 @@ import Styled from './Community.styles';
 const DEFAULT_CONTENT_WIDTH = utils.rem('1100px');
 
 export default function Community(props = {}) {
-  // Redirect and return null until find a group launch
   const router = useRouter();
-  useEffect(() => {
-    router.push('/');
-  }, [router]);
 
-  return null;
+  useEffect(() => {
+    if (!flags.GROUP_FINDER) router.push('/');
+  }, [router]);
 
   const [{ authenticated }, authDispatch] = useAuth();
   const modalDispatch = useModalDispatch();
@@ -54,6 +53,8 @@ export default function Community(props = {}) {
       showGroupFilterModal();
     }
   }
+
+  if (!flags.GROUP_FINDER) return null;
 
   return (
     <>

--- a/pages/community/search/index.js
+++ b/pages/community/search/index.js
@@ -1,6 +1,7 @@
 import { useEffect } from 'react';
 import { useRouter } from 'next/router';
 
+import flags from 'config/flags';
 import { Button, Box, Cell, Divider, Loader, utils } from 'ui-kit';
 import {
   Footer,
@@ -27,12 +28,9 @@ const PAGE_SIZE = 21;
 export default function CommunitySearch() {
   const router = useRouter();
 
-  // Redirect and return null until find a group launch
   useEffect(() => {
-    router.push('/');
+    if (!flags.GROUP_FINDER) router.push('/');
   }, [router]);
-
-  return null;
 
   const modalState = useModalState();
   const [filtersState, filtersDispatch] = useGroupFilters();
@@ -102,6 +100,8 @@ export default function CommunitySearch() {
     });
     filtersDispatch(resetValues(), reset());
   }
+
+  if (!flags.GROUP_FINDER) return null;
 
   return (
     <>


### PR DESCRIPTION
Closes #115 

Adds a `config/flags` file with `GROUP_FINDER: true` and then references that in the same places that #111 set up. The only thing we need to remember is that `next.config.js` can't (as far as I can tell) import `config/flags`, so I just commented it out for now and left a note.

### To test
- Load the app.
- You should see `Community` in the navigation.
- You should be able to click to `/community`.
- You should be able to visit a `/community/[title]` page.
- You should be able to visit `/community/search`.