### PR TITLE
Fix logout redirect to home

### DIFF
--- a/components/Nav/Nav.js
+++ b/components/Nav/Nav.js
@@ -22,7 +22,7 @@ function Nav(props = {}) {
   function handleLogoutClick(event) {
     event.preventDefault();
     authDispatch(logout());
-    router.reload();
+    router.push('/');
   }
 
   return (

--- a/components/Nav/Nav.js
+++ b/components/Nav/Nav.js
@@ -22,7 +22,7 @@ function Nav(props = {}) {
   function handleLogoutClick(event) {
     event.preventDefault();
     authDispatch(logout());
-    router.push('/');
+    router.reload();
   }
 
   return (

--- a/pages/connect/index.js
+++ b/pages/connect/index.js
@@ -1,15 +1,28 @@
-import React from 'react';
+import React, { useEffect } from 'react';
+import { useRouter } from 'next/router';
 
 import { FeatureFeedProvider } from 'providers';
+import { useAuth } from 'providers/AuthProvider';
+
 import { Layout, FeatureFeed } from 'components';
 import { Cell, utils } from 'ui-kit';
 
 export default function Connect(props = {}) {
+  const router = useRouter();
+  const [{ authenticated }] = useAuth();
   const options = {
     variables: {
       pathname: 'connect',
     },
   };
+
+  useEffect(() => {
+    if (!authenticated) {
+      router.push('/');
+    }
+  }, [router, authenticated]);
+
+  if (!authenticated) return null;
 
   return (
     <Layout title="Connect">

--- a/providers/AuthProvider.js
+++ b/providers/AuthProvider.js
@@ -1,6 +1,5 @@
 import React, { createContext, useContext, useEffect, useReducer } from 'react';
 import PropTypes from 'prop-types';
-import { useRouter } from 'next/router';
 
 import { AUTH_TOKEN_KEY } from 'config/keys';
 
@@ -59,7 +58,6 @@ function getInitialState(state) {
 }
 
 function AuthProvider(props = {}) {
-  const router = useRouter();
   const [state, dispatch] = useReducer(reducer, initialState, getInitialState);
   const { authenticated, token } = state;
 
@@ -71,7 +69,6 @@ function AuthProvider(props = {}) {
       } else {
         if (!authenticated) {
           window.localStorage.removeItem(AUTH_TOKEN_KEY);
-          router.push('/');
         }
       }
     }

--- a/ui-kit/CardGrid/CardGrid.js
+++ b/ui-kit/CardGrid/CardGrid.js
@@ -10,7 +10,7 @@ function CardGrid(props = {}) {
 
 CardGrid.propTypes = {
   ...systemPropTypes,
-  columns: PropTypes.string,
+  columns: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 CardGrid.defaultProps = {


### PR DESCRIPTION
# About 
Closes #122

Moves the redirect to `/` to happen on logout click, instead of trying to do it all fancy-like up in the state provider.
I think this is a simpler, safer solution.

Also fixes a PropType warning on `CardGrid`.

# Testing
Log in and go to a page like **Discover**. Log out. Verify you're sent to home.
Navigate the site while unauthenticated, and sit on pages for ~5-10s to make sure you're not redirected randomly.