### PR TITLE
Legacy Routing

### DIFF
--- a/components/FeatureFeed/FeatureFeed.js
+++ b/components/FeatureFeed/FeatureFeed.js
@@ -59,8 +59,6 @@ const FeatureFeed = (props = {}) => {
     return <Box as="h1">Please Log In to View Page</Box>;
   }
 
-  console.log({ props });
-
   return props.data?.map((edge, i) => (
     <Box key={edge?.id} py="xl">
       <FeatureProvider

--- a/components/LegacyNodeRouter/LegacyNodeRouter.js
+++ b/components/LegacyNodeRouter/LegacyNodeRouter.js
@@ -1,0 +1,50 @@
+import { useEffect } from 'react';
+import { useRouter } from 'next/router';
+import isEmpty from 'lodash/isEmpty';
+
+import { Layout } from 'components';
+import { Box, Cell, Loader } from 'ui-kit';
+import { useNodeRoute } from 'hooks';
+
+/**
+ * note : This file exists for backwards compatibility
+ *
+ * /content/item-name-9f59c65055fec6cd0292deb993711bf5
+ * redirects to new, prettier content url
+ */
+
+function getItemId(slug) {
+  if (!isEmpty(slug)) {
+    const id = slug.split('-').pop();
+    return `MediaContentItem:${id}`;
+  }
+
+  return null;
+}
+
+export default function LegacyNodeRouter(props) {
+  const router = useRouter();
+  const { title } = router.query;
+  const itemId = getItemId(title);
+
+  const { node } = useNodeRoute({
+    variables: { id: itemId },
+    skip: isEmpty(itemId),
+  });
+
+  useEffect(() => {
+    if (!isEmpty(node?.routing?.pathname)) {
+      router.push(`/${node?.routing?.pathname}`);
+    }
+  }, [node]);
+
+  return (
+    <Layout title={title}>
+      <Cell>
+        <Box p="xl" justifyContent="center" alignItems="center" display="flex">
+          <Loader alignSelf="center" alignContent="center" />
+        </Box>
+      </Cell>
+    </Layout>
+  );
+}

--- a/components/LegacyNodeRouter/index.js
+++ b/components/LegacyNodeRouter/index.js
@@ -1,0 +1,3 @@
+import LegacyNodeRouter from './LegacyNodeRouter';
+
+export default LegacyNodeRouter;

--- a/components/index.js
+++ b/components/index.js
@@ -33,6 +33,7 @@ import HeroListFeature from './HeroListFeature';
 import HomeFeed from './HomeFeed';
 import HorizontalCardListFeature from './HorizontalCardListFeature';
 import Layout from './Layout';
+import LegacyNodeRouter from './LegacyNodeRouter';
 import LocationSingle from './LocationSingle';
 import LiveStreamSingle from './LiveStreamSingle';
 import Logo from './Logo';
@@ -84,6 +85,7 @@ export {
   HomeFeed,
   HorizontalCardListFeature,
   Layout,
+  LegacyNodeRouter,
   LocationSingle,
   LiveStreamSingle,
   Logo,

--- a/hooks/index.js
+++ b/hooks/index.js
@@ -4,7 +4,7 @@ import useAuthenticateCredentials from './useAuthenticateCredentials';
 import useCampuses from './useCampuses';
 import useCheckIn from './useCheckIn';
 import useContactGroupLeader from './useContactGroupLeader';
-import useContentFeed from './useNode';
+import useContentFeed from './useNodeRoute';
 import useContentItem from './useContentItem';
 import useCurrentBreakpoint from './useCurrentBreakpoint';
 import useCurrentChatUser from './useCurrentChatUser';
@@ -31,6 +31,7 @@ import useLiveStream from './useLiveStream';
 import useLiveStreams from './useLiveStreams';
 import useLiveStreamsQuery from './useLiveStreamsQuery';
 import useNode from './useNode';
+import useNodeRoute from './useNodeRoute';
 import useRegisterWithEmail from './useRegisterWithEmail';
 import useRegisterWithSms from './useRegisterWithSms';
 import useRemoveGroupResource from './useRemoveGroupResource';
@@ -80,6 +81,7 @@ export {
   useLiveStreams,
   useLiveStreamsQuery,
   useNode,
+  useNodeRoute,
   useRegisterWithEmail,
   useRegisterWithSms,
   useRemoveGroupResource,

--- a/hooks/useNodeRoute.js
+++ b/hooks/useNodeRoute.js
@@ -1,0 +1,29 @@
+import { gql, useQuery } from '@apollo/client';
+
+export const GET_NODE_ROUTE = gql`
+  query getNodeRoute($id: ID!) {
+    node(id: $id) {
+      id
+      __typename
+      ... on NodeRoute {
+        routing {
+          pathname
+        }
+      }
+    }
+  }
+`;
+
+function useNodeRoute(options = {}) {
+  const query = useQuery(GET_NODE_ROUTE, {
+    fetchPolicy: 'cache-and-network',
+    ...options,
+  });
+
+  return {
+    node: query?.data?.node || {},
+    ...query,
+  };
+}
+
+export default useNodeRoute;

--- a/pages/content/[title].js
+++ b/pages/content/[title].js
@@ -1,49 +1,12 @@
-import { useRouter } from 'next/router';
-
-import { initializeApollo } from 'lib/apolloClient';
-import { ContentItemProvider } from 'providers';
-import { GET_CONTENT_ITEM } from 'hooks/useContentItem';
-import { ContentSingle, Layout } from 'components';
-import { Box } from 'ui-kit';
-
-function getItemId(slug) {
-  const id = slug.split('-').pop();
-  return `MediaContentItem:${id}`;
-}
-
-export default function Content(props) {
-  const router = useRouter();
-  const { title } = router.query;
-
-  return (
-    <Layout title={title}>
-      {title && (
-        <ContentItemProvider
-          Component={ContentSingle}
-          options={{
-            variables: { itemId: getItemId(title) },
-          }}
-        />
-      )}
-    </Layout>
-  );
-}
+import { LegacyNodeRouter } from 'components';
 
 /**
- * todo : Need to fix ServerSideProps, currenlty breaking page.
+ * note : This file exists for backwards compatibility
+ *
+ * /content/item-name-9f59c65055fec6cd0292deb993711bf5
+ * redirects to new, prettier content url
  */
 
-// export async function getServerSideProps(context) {
-//   const apolloClient = initializeApollo();
-
-//   await apolloClient.query({
-//     query: GET_CONTENT_ITEM,
-//     variables: { itemId: getItemId(context.params.title) },
-//   });
-
-//   return {
-//     props: {
-//       initialApolloState: apolloClient.cache.extract(),
-//     },
-//   };
-// }
+export default function Content() {
+  return <LegacyNodeRouter />;
+}

--- a/pages/items/[title].js
+++ b/pages/items/[title].js
@@ -1,49 +1,12 @@
-import { useRouter } from 'next/router';
-
-import { initializeApollo } from 'lib/apolloClient';
-import { ContentItemProvider } from 'providers';
-import { GET_CONTENT_ITEM } from 'hooks/useContentItem';
-import { ContentSingle, Layout } from 'components';
-import { Box } from 'ui-kit';
-
-function getItemId(slug) {
-  const id = slug.split('-').pop();
-  return `InformationalContentItem:${id}`;
-}
-
-export default function Item(props) {
-  const router = useRouter();
-  const { title } = router.query;
-
-  return (
-    <Layout title={title}>
-      {title && (
-        <ContentItemProvider
-          Component={ContentSingle}
-          options={{
-            variables: { itemId: getItemId(title) },
-          }}
-        />
-      )}
-    </Layout>
-  );
-}
+import { LegacyNodeRouter } from 'components';
 
 /**
- * todo : Need to fix ServerSideProps, currenlty breaking page.
+ * note : This file exists for backwards compatibility
+ *
+ * /items/item-name-9f59c65055fec6cd0292deb993711bf5
+ * redirects to new, prettier content url
  */
 
-// export async function getServerSideProps(context) {
-//   const apolloClient = initializeApollo();
-
-//   await apolloClient.query({
-//     query: GET_CONTENT_ITEM,
-//     variables: { itemId: getItemId(context.params.title) },
-//   });
-
-//   return {
-//     props: {
-//       initialApolloState: apolloClient.cache.extract(),
-//     },
-//   };
-// }
+export default function Item() {
+  return <LegacyNodeRouter />;
+}


### PR DESCRIPTION
## What is it?
In the new website, we are moving away from attaching the Id in the url and instead are using a prettier url manually set by the CM's in Rock.
In order to not cause mass chaos, we need to be able to re-route old urls to the new ones

## How does it work/how do I test?
* When landing on /items/[title] or /content/[title] show a loading indicator
* Get Node Id from the title
* Fetch the NodeRouter for the given node
* If the server returns a pathname, push the user to that new route

https://christfellowship.church/content/full-of-it-part-3-9f59c65055fec6cd0292deb993711bf5 is set up with the new Routing Urls

## Tradeoffs
* Only Content Items that have a Url set on them will show up on the platform. This is intentional and understood by content teams

## Jira Issues
[CFDP-1338] /content and /items should reroute to the correct Url for their content

[CFDP-1338]: https://christfellowshipchurch.atlassian.net/browse/CFDP-1338