### PR TITLE
Gracefully handle disabled Group Chat

### DIFF
--- a/components/GroupSingle/GroupChat.js
+++ b/components/GroupSingle/GroupChat.js
@@ -10,6 +10,10 @@ import Styled from './GroupSingle.styles';
 export default function GroupChat(props = {}) {
   const currentBreakpoint = useCurrentBreakpoint();
 
+  if (!props.streamChatChannel) {
+    return null;
+  }
+
   if (currentBreakpoint.isSmall || currentBreakpoint.isMedium) {
     return <GroupChatMobile />;
   }

--- a/components/GroupSingle/GroupSingle.js
+++ b/components/GroupSingle/GroupSingle.js
@@ -24,7 +24,6 @@ function GroupSingle(props = {}) {
     nodeId: props.data.id,
   });
 
-  const enableChat = Boolean(props.data?.streamChatChannel);
   const totalMembers =
     (props.data?.leaders?.totalCount || 0) +
     (props.data?.members?.totalCount || 0);
@@ -40,35 +39,79 @@ function GroupSingle(props = {}) {
     }
   };
 
-  function renderChat() {
-    return (
-      <Box mb="l">
-        <Card>
-          <GroupChat
-            streamChatChannel={props.data?.streamChatChannel}
-            relatedNode={props.data}
-            pt="s"
-          />
-        </Card>
+  // Sub-render functions for clarity
+  // -----------------------------------
+  const renderMembers = () => (
+    <Box display="flex" flexDirection="column" mt="l" pb="base">
+      <Box as="h2" fontSize="h3" mb="base">
+        {totalMembers} Members
       </Box>
-    );
-  }
+      <GroupMembers
+        showCount={currentBreakpoint.isSmall ? 5 : 7}
+        leaders={props.data?.leaders}
+        members={props.data?.members}
+      />
+    </Box>
+  );
 
-  function renderAboutAndResources() {
-    return (
-      <Card p="base" mb="l">
-        <Box as="h2" fontSize="h3">
-          About
-        </Box>
-        <Box as="p">{props.data?.summary}</Box>
+  const renderMeetingDetails = () => (
+    <Box
+      display="flex"
+      flexDirection="column"
+      justifyContent="center"
+      alignItems="center"
+      pb="l"
+      mt={{ _: 'l', md: '0' }}
+    >
+      <Box>
+        <GroupDateTime
+          title={props.data?.title}
+          summary={props.data?.summary}
+          address={document.URL}
+          dateTime={props.data?.dateTime}
+          parentVideoCall={props.data?.parentVideoCall}
+          videoCall={props.data?.videoCall}
+        />
+        <GroupActions
+          userName={
+            currentUser?.profile?.nickName || currentUser?.profile?.firstName
+          }
+          parentVideoCall={props.data?.parentVideoCall}
+          videoCall={props.data?.videoCall}
+          onClickVideoCall={handleOnClickVideoCall}
+          onClickParentVideoCall={handleOnClickVideoCall}
+          checkInCompleted={checkInCompleted}
+        />
+      </Box>
+    </Box>
+  );
 
-        <Box as="h2" fontSize="h3" mt="l" mb="base">
-          Resources
-        </Box>
-        <GroupResources resources={props.data?.resources} />
+  const renderChat = () => (
+    <Box mb="l">
+      <Card>
+        <GroupChat
+          streamChatChannel={props.data?.streamChatChannel}
+          relatedNode={props.data}
+          pt="s"
+        />
       </Card>
-    );
-  }
+    </Box>
+  );
+
+  const renderAboutAndResources = () => (
+    <Card p="base" mb="l">
+      <Box as="h2" fontSize="h3">
+        About
+      </Box>
+      <Box as="p">{props.data?.summary}</Box>
+
+      <Box as="h2" fontSize="h3" mt="l" mb="base">
+        Resources
+      </Box>
+      <GroupResources resources={props.data?.resources} />
+    </Card>
+  );
+  // -----------------------------------
 
   return (
     <ChatConnectionProvider>
@@ -85,52 +128,10 @@ function GroupSingle(props = {}) {
             </CustomLink>
           ) : null
         }
-        renderContentB={() => (
-          <Box display="flex" flexDirection="column" mt="l" pb="base">
-            <Box as="h2" fontSize="h3" mb="base">
-              {totalMembers} Members
-            </Box>
-            <GroupMembers
-              showCount={currentBreakpoint.isSmall ? 5 : 7}
-              leaders={props.data?.leaders}
-              members={props.data?.members}
-            />
-          </Box>
-        )}
-        renderC={() => (
-          <Box
-            display="flex"
-            flexDirection="column"
-            justifyContent="center"
-            alignItems="center"
-            pb="l"
-            mt={{ _: 'l', md: '0' }}
-          >
-            <Box>
-              <GroupDateTime
-                title={props.data?.title}
-                summary={props.data?.summary}
-                address={document.URL}
-                dateTime={props.data?.dateTime}
-                parentVideoCall={props.data?.parentVideoCall}
-                videoCall={props.data?.videoCall}
-              />
-              <GroupActions
-                userName={
-                  currentUser?.profile?.nickName ||
-                  currentUser?.profile?.firstName
-                }
-                parentVideoCall={props.data?.parentVideoCall}
-                videoCall={props.data?.videoCall}
-                onClickVideoCall={handleOnClickVideoCall}
-                onClickParentVideoCall={handleOnClickVideoCall}
-                checkInCompleted={checkInCompleted}
-              />
-            </Box>
-          </Box>
-        )}
-        renderD={enableChat ? renderChat : renderAboutAndResources}
-        renderE={enableChat ? renderAboutAndResources : null}
+        renderContentB={renderMembers}
+        renderC={renderMeetingDetails}
+        renderD={renderChat}
+        renderE={renderAboutAndResources}
       />
     </ChatConnectionProvider>
   );

--- a/components/GroupSingle/GroupSingle.js
+++ b/components/GroupSingle/GroupSingle.js
@@ -24,6 +24,7 @@ function GroupSingle(props = {}) {
     nodeId: props.data.id,
   });
 
+  const enableChat = Boolean(props.data?.streamChatChannel);
   const totalMembers =
     (props.data?.leaders?.totalCount || 0) +
     (props.data?.members?.totalCount || 0);
@@ -38,6 +39,36 @@ function GroupSingle(props = {}) {
       checkInCurrentUser({ optionIds: options.map(({ id }) => id) });
     }
   };
+
+  function renderChat() {
+    return (
+      <Box mb="l">
+        <Card>
+          <GroupChat
+            streamChatChannel={props.data?.streamChatChannel}
+            relatedNode={props.data}
+            pt="s"
+          />
+        </Card>
+      </Box>
+    );
+  }
+
+  function renderAboutAndResources() {
+    return (
+      <Card p="base" mb="l">
+        <Box as="h2" fontSize="h3">
+          About
+        </Box>
+        <Box as="p">{props.data?.summary}</Box>
+
+        <Box as="h2" fontSize="h3" mt="l" mb="base">
+          Resources
+        </Box>
+        <GroupResources resources={props.data?.resources} />
+      </Card>
+    );
+  }
 
   return (
     <ChatConnectionProvider>
@@ -98,30 +129,8 @@ function GroupSingle(props = {}) {
             </Box>
           </Box>
         )}
-        renderD={() => (
-          <Box>
-            <Card>
-              <GroupChat
-                streamChatChannel={props.data?.streamChatChannel}
-                relatedNode={props.data}
-                pt="s"
-              />
-            </Card>
-          </Box>
-        )}
-        renderE={() => (
-          <Card p="base">
-            <Box as="h2" fontSize="h3">
-              About
-            </Box>
-            <Box as="p">{props.data?.summary}</Box>
-
-            <Box as="h2" fontSize="h3" mt="l" mb="base">
-              Resources
-            </Box>
-            <GroupResources resources={props.data?.resources} />
-          </Card>
-        )}
+        renderD={enableChat ? renderChat : renderAboutAndResources}
+        renderE={enableChat ? renderAboutAndResources : null}
       />
     </ChatConnectionProvider>
   );

--- a/components/HorizontalCardListFeature/HorizontalCardListFeature.js
+++ b/components/HorizontalCardListFeature/HorizontalCardListFeature.js
@@ -54,7 +54,7 @@ function HorizontalCardListFeature(props = {}) {
         {!isEmpty(subtitle) && <Box as="p">{subtitle}</Box>}
         <CardCarousel
           cardsDisplayed={4}
-          hideArrows={cards.length < 2}
+          hideArrows={!cards || cards.length < 2}
           mx={'-0.625rem'}
         >
           {cards.map((card, i) => (
@@ -79,7 +79,7 @@ function HorizontalCardListFeature(props = {}) {
       {!isEmpty(subtitle) && <Box as="p">{subtitle}</Box>}
       <CardCarousel
         cardsDisplayed={cardsDisplayed}
-        hideArrows={cards.length < 2}
+        hideArrows={!cards || cards.length < 2}
         mx={'-0.625rem'}
       >
         {cards.map((card, i) => {


### PR DESCRIPTION
# About

Closes #129
Closes #136

This PR fixes two bugs that prevent the `/groups` and `/groups/[title]` pages from loading in production sometimes.
It gracefully handles missing `streamChatChannel` data for a single group, and fixes a bug in the `HorizontalCardListFeature` component around the `hideArrows` prop. When `cards` was `null` or `undefined`, the page would hard crash.

Also includes a subjective code styling tweak, to break down the render props in `GroupSingle` into sub-functions since I personally found it a bit unwieldy with the nesting. I'm open to feedback on that change and happy to revert it if the team doesn't agree it clarifies the view structure.

# Testing
To force-hide the `streamChatChannel` data for your group, open the API file `src/data/group-item/data-source.js` and put a `return null;` before line 950 (just inside the `getStreamChatChannel` method).

Then, go to a group single page, and verify the page still loads — albeit with a big empty area for chat.
_This should not happen in production, so didn't spend much time fleshing this edge case out_.

The `/groups` page crash is harder to reproduce, so manually edit `components/HorizontalCardListFeature/HorizontalCardListFeature.js` and change **line 19** to be `let cards;` instead.
Then verify the `/groups` page still loads properly.