### PR TITLE
Add Calls to Action to Content Block

### DIFF
--- a/components/ContentBlockFeature/ContentBlockFeature.js
+++ b/components/ContentBlockFeature/ContentBlockFeature.js
@@ -14,9 +14,6 @@ import { Box, ContentBlock } from 'ui-kit';
 
 const ContentBlockFeature = props => {
   const content = props?.data;
-  if (content?.actions.length > 0) {
-    console.log({ content });
-  }
 
   return (
     <Box maxWidth={1100} mx="auto">

--- a/components/ContentBlockFeature/ContentBlockFeature.js
+++ b/components/ContentBlockFeature/ContentBlockFeature.js
@@ -14,17 +14,20 @@ import { Box, ContentBlock } from 'ui-kit';
 
 const ContentBlockFeature = props => {
   const content = props?.data;
+  if (content?.actions.length > 0) {
+    console.log({ content });
+  }
 
   return (
     <Box maxWidth={1100} mx="auto">
       <ContentBlock
         title={content?.title}
-        summary={content?.summary}
+        subtitle={content?.subtitle}
         htmlContent={content?.htmlContent}
         image={content?.coverImage?.sources[0]?.uri}
         contentLayout={content?.orientation}
         imageRatio={content?.imageRatio}
-        callToAction={content?.callToAction}
+        actions={content?.actions}
       />
     </Box>
   );

--- a/fragments/features.js
+++ b/fragments/features.js
@@ -106,20 +106,19 @@ const AVATAR_LIST_FEATURE_FRAGMENT = gql`
 const CONTENT_BLOCK_FEATURE_FRAGMENT = gql`
   fragment ContentBlockFeatureFragment on ContentBlockFeature {
     title
-    summary
+    subtitle
     htmlContent
     coverImage {
       sources {
         uri
       }
     }
-    callToAction {
-      call
+    actions {
+      title
       action
-    }
-    secondaryCallToAction {
-      call
-      action
+      relatedNode {
+        ...RelatedFeatureNodeFragment
+      }
     }
     orientation
     imageRatio

--- a/ui-kit/Button/Button.styles.js
+++ b/ui-kit/Button/Button.styles.js
@@ -15,8 +15,8 @@ const variant = ({ variant, active }) => props => {
   if (variant === 'secondary') {
     return css`
       background-color: transparent;
-      border-color: ${themeGet('colors.fg')};
-      color: ${themeGet('colors.fg')};
+      border-color: ${themeGet('colors.primary')};
+      color: ${themeGet('colors.primary')};
     `;
   }
 

--- a/ui-kit/ContentBlock/ContentBlock.js
+++ b/ui-kit/ContentBlock/ContentBlock.js
@@ -47,6 +47,9 @@ function ContentBlock(props = {}) {
                 Component={Button}
                 variant={i === 0 ? 'primary' : 'secondary'}
                 my="xs"
+                /**
+                 * todo : We want to eventually add functionality with the 'onPressActionItem' to be able to perform more actions in the future.
+                 */
                 // onClick={e => onPressActionItem(e, heroCard)}
               >
                 {action?.title}

--- a/ui-kit/ContentBlock/ContentBlock.js
+++ b/ui-kit/ContentBlock/ContentBlock.js
@@ -3,7 +3,8 @@ import PropTypes from 'prop-types';
 
 // import { Video } from 'components';
 import { Box, Button, Image, systemPropTypes } from 'ui-kit';
-import { htmlToReactParser } from 'utils';
+import { htmlToReactParser, getUrlFromRelatedNode } from 'utils';
+import { CustomLink } from 'components';
 
 import Styled from './ContentBlock.styles';
 import toLower from 'lodash/toLower';
@@ -29,17 +30,29 @@ function ContentBlock(props = {}) {
         </Styled.Media>
       )}
       <Styled.Content textAlign={horizontalLayout ? 'flex-start' : 'center'}>
-        {(props.title || props.summary) && (
+        {(props.title || props.subtitle) && (
           <>
-            <Styled.Subtitle>{props.summary}</Styled.Subtitle>
+            <Styled.Subtitle>{props.subtitle}</Styled.Subtitle>
             <Styled.Title>{props.title}</Styled.Title>
           </>
         )}
         <Box>{htmlToReactParser.parse(props.htmlContent)}</Box>
-        {props?.callToAction && (
-          <Button mt="l" href={props.callToAction.action}>
-            {props.callToAction.call}
-          </Button>
+
+        {props?.actions && props?.actions?.length > 0 && (
+          <Box my="base" flexDirection="column" display="flex">
+            {props?.actions.map((action, i) => (
+              <CustomLink
+                as="a"
+                href={getUrlFromRelatedNode(action?.relatedNode)}
+                Component={Button}
+                variant={i === 0 ? 'primary' : 'secondary'}
+                my="xs"
+                // onClick={e => onPressActionItem(e, heroCard)}
+              >
+                {action?.title}
+              </CustomLink>
+            ))}
+          </Box>
         )}
       </Styled.Content>
     </Styled.Container>
@@ -59,7 +72,7 @@ ContentBlock.propTypes = {
   images: PropTypes.array,
   openLinksInNewTab: PropTypes.bool,
   secondaryCallToAction: PropTypes.object,
-  summary: PropTypes.string,
+  subtitle: PropTypes.string,
   textAlignment: PropTypes.string,
   title: PropTypes.string,
   variant: PropTypes.oneOf(['light', 'dark']),

--- a/ui-kit/ContentBlock/ContentBlock.js
+++ b/ui-kit/ContentBlock/ContentBlock.js
@@ -47,6 +47,7 @@ function ContentBlock(props = {}) {
                 Component={Button}
                 variant={i === 0 ? 'primary' : 'secondary'}
                 my="xs"
+                textTransform="capitalize!important"
                 /**
                  * todo : We want to eventually add functionality with the 'onPressActionItem' to be able to perform more actions in the future.
                  */

--- a/ui-kit/ContentBlock/ContentBlock.styles.js
+++ b/ui-kit/ContentBlock/ContentBlock.styles.js
@@ -44,6 +44,15 @@ const gridLayout = ({ gridLayout }) => props => {
   }
 };
 
+const buttonType = ({ variant }) => props => {
+  if (variant === 'secondary') {
+    return css`
+      border-color: ${themeGet('colors.primary')};
+      color: ${themeGet('colors.primary')};
+    `;
+  }
+};
+
 const Container = styled.div`
   display: grid;
   grid-row-gap: ${themeGet('space.l')};

--- a/ui-kit/ContentBlock/ContentBlock.styles.js
+++ b/ui-kit/ContentBlock/ContentBlock.styles.js
@@ -44,15 +44,6 @@ const gridLayout = ({ gridLayout }) => props => {
   }
 };
 
-const buttonType = ({ variant }) => props => {
-  if (variant === 'secondary') {
-    return css`
-      border-color: ${themeGet('colors.primary')};
-      color: ${themeGet('colors.primary')};
-    `;
-  }
-};
-
 const Container = styled.div`
   display: grid;
   grid-row-gap: ${themeGet('space.l')};


### PR DESCRIPTION
## What do this do?
This PR is made to update our `ContentBlockFeature` to use `actions` that will be used as an array of calls to action for a `ContentBlock` component. This will allow for content managers to add buttons to a piece of content. 

## Demo/Screenshots
* To test go to a page that uses pagebuilder. For example: `/get-connected`

## Jira Issues
[CFDP-1339]


[CFDP-1339]: https://christfellowshipchurch.atlassian.net/browse/CFDP-1339