### PR TITLE
Filters out null resources

### DIFF
--- a/components/GroupSingle/GroupResources.js
+++ b/components/GroupSingle/GroupResources.js
@@ -17,34 +17,38 @@ export default function GroupResources(props = {}) {
 
   return (
     <List>
-      {props.resources.map(resource => (
-        <Box key={resource.relatedNode?.id} as="li">
-          <CustomLink
-            key={resource.relatedNode?.id}
-            href={getURLFromType(resource.relatedNode)}
-            textDecoration="none"
-            onClick={() => {
-              amplitude.trackEvent({
-                category: 'Group Item',
-                action: `${resource.title} - Group Resource Action`,
-                label: `${resource.title} Button`,
-              });
-            }}
-          >
-            <Box display="flex" alignItems="center">
-              <Image
-                maxWidth="50px"
-                source={
-                  resource.relatedNode?.coverImage?.sources[0]?.uri ||
-                  '/link.png'
-                }
-                mr="base"
-              />
-              <Box as="h4">{resource.title || resource.relatedNode?.title}</Box>
-            </Box>
-          </CustomLink>
-        </Box>
-      ))}
+      {props.resources
+        .filter(resource => resource.title || resource.relatedNode?.title)
+        .map(resource => (
+          <Box key={resource.relatedNode?.id} as="li">
+            <CustomLink
+              key={resource.relatedNode?.id}
+              href={getURLFromType(resource.relatedNode)}
+              textDecoration="none"
+              onClick={() => {
+                amplitude.trackEvent({
+                  category: 'Group Item',
+                  action: `${resource.title} - Group Resource Action`,
+                  label: `${resource.title} Button`,
+                });
+              }}
+            >
+              <Box display="flex" alignItems="center">
+                <Image
+                  maxWidth="50px"
+                  source={
+                    resource.relatedNode?.coverImage?.sources[0]?.uri ||
+                    '/link.png'
+                  }
+                  mr="base"
+                />
+                <Box as="h4">
+                  {resource.title || resource.relatedNode?.title}
+                </Box>
+              </Box>
+            </CustomLink>
+          </Box>
+        ))}
     </List>
   );
 }

--- a/components/GroupSingle/GroupResources.js
+++ b/components/GroupSingle/GroupResources.js
@@ -14,7 +14,7 @@ export default function GroupResources(props = {}) {
   // Currently ignoring the `action` of resources, since we can
   // typically derive a URL from the `relatedNode` regardless of
   // whether it's an `OPEN_URL` or `READ_CONTENT` etc action.
-
+  console.log({ props });
   return (
     <List>
       {props.resources

--- a/components/GroupSingle/GroupResources.js
+++ b/components/GroupSingle/GroupResources.js
@@ -14,7 +14,7 @@ export default function GroupResources(props = {}) {
   // Currently ignoring the `action` of resources, since we can
   // typically derive a URL from the `relatedNode` regardless of
   // whether it's an `OPEN_URL` or `READ_CONTENT` etc action.
-  console.log({ props });
+
   return (
     <List>
       {props.resources


### PR DESCRIPTION
This can happen if someone deletes a url from Rock. I added a filter to look for a title at the root resource or on the relatedNode object.

To Test:

Go to `http://localhost:3000/groups/cfdp-testing-group` and make sure there are no errors and resources show up as expected.

Discovered this issue on the mobile app while pairing with Caleb. Logged an issue for the mobile app. https://github.com/christfellowshipchurch/apollos-app/issues/212