### PR TITLE
Remove the “Day of Week” filter from the “Group Filter Modal” CFDP-1329

### DIFF
--- a/components/Modals/GroupFilterModal/GroupFilterWhereWhen.js
+++ b/components/Modals/GroupFilterModal/GroupFilterWhereWhen.js
@@ -98,37 +98,6 @@ function GroupFilterWhereWhen(props = {}) {
           })}
         </Select>
       </Box>
-      <Box mb="l">
-        <FormLabel color="subdued">What days can you meet?</FormLabel>
-        <Box
-          display="grid"
-          width="100%"
-          gridTemplateColumns="repeat(7, 1fr)"
-          gridColumnGap="xs"
-        >
-          {filtersState.options.days.map(value => (
-            <Button
-              key={value}
-              variant="secondary"
-              status={
-                filtersState.values.days.includes(value) ? 'SELECTED' : 'IDLE'
-              }
-              onClick={event => {
-                event.preventDefault();
-                handleDayChange(value);
-              }}
-              mb="xs"
-              px="0"
-            >
-              {value[0]}
-              {/* Gross, but quick way to abbreviate for mobile... */}
-              <Box as="span" display={{ _: 'none', md: 'inline' }}>
-                {value.slice(1)}
-              </Box>
-            </Button>
-          ))}
-        </Box>
-      </Box>
       <Box display="flex" alignItems="center" justifyContent="space-between">
         <Button variant="secondary" onClick={handleGoBack}>
           <Icon name="angleLeft" />


### PR DESCRIPTION
## Description
Removed the Day of Week filter from the Group Filter Modal that shows on the Hub page

## How to Test
1. Go to the Community page /community
2. Click on any of the cards, eg: /community/married-people
3. Click on any the cards or buttons on that page, when the _Find your Community_  modal comes up you should no longer see an option to select a day of the week. Instead you should only see 2 questions: _What campus do you prefer?_ and _How do you prefer to meet?_

## Jira Ticket
[CFDP-1329]

[CFDP-1329]: https://christfellowshipchurch.atlassian.net/browse/CFDP-1329