### PR TITLE
Fix prop name for Avatar photo source

### DIFF
--- a/components/ContentSingle/ContentSingle.js
+++ b/components/ContentSingle/ContentSingle.js
@@ -74,7 +74,7 @@ function ContentSingle(props = {}) {
             <Box mr="base">
               <Avatar
                 name={author.firstName}
-                source={author.photo?.uri}
+                src={author.photo?.uri}
                 height="60px"
                 width="60px"
               />


### PR DESCRIPTION
## What does it do?
Resolves an issue where the incorrect prop name was being passed into the Avatar component

## How do I test it?
Open up `/messages/full-of-it-part-3` and you should see the author's photo instead of the placeholder avatar image

## Screenshots
<img width="1520" alt="Screen Shot 2021-05-04 at 4 40 02 PM" src="https://user-images.githubusercontent.com/45076058/117067245-c2cc4a80-acf7-11eb-9e8e-df01c532828c.png">

## Jira Issues
[CFDP-1357]

[CFDP-1357]: https://christfellowshipchurch.atlassian.net/browse/CFDP-1357