### PR TITLE
Changed spacing between features in home page from xl to l

### DIFF
--- a/components/FeatureFeed/FeatureFeed.js
+++ b/components/FeatureFeed/FeatureFeed.js
@@ -60,7 +60,7 @@ const FeatureFeed = (props = {}) => {
   }
 
   return props.data?.map((edge, i) => (
-    <Box key={edge?.id} py="xl">
+    <Box key={edge?.id} py="l">
       <FeatureProvider
         onPressActionItem={props?.onPressActionItem}
         Component={getComponent(edge, {


### PR DESCRIPTION
## Description
Tightened the spacing between Features on the Home Screen (from extra large to large)

## How to Test
You can see that the spacing between collections of cards in the home screen has decreased

## Jira Ticket
[CFDP-1355]

[CFDP-1355]: https://christfellowshipchurch.atlassian.net/browse/CFDP-1355