### PR TITLE
Remove Custom Validity Check for Checkbox

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "color": "^3.1.3",
     "cross-fetch": "^3.0.6",
     "date-fns": "^2.16.1",
-    "device-agnostic-ui": "^7.0.1",
     "graphql": "^15.4.0",
     "html-to-react": "^1.4.5",
     "lodash": "^4.17.20",

--- a/ui-kit/Checkbox/Checkbox.js
+++ b/ui-kit/Checkbox/Checkbox.js
@@ -3,15 +3,18 @@ import PropTypes from 'prop-types';
 
 import { systemPropTypes } from 'ui-kit';
 import Styled from './Checkbox.styles';
-import { useCustomValidity } from 'device-agnostic-ui';
+// import { useCustomValidity } from 'device-agnostic-ui';
 
 function Checkbox(props = {}) {
-  const ref = useRef();
-  useCustomValidity(ref, props.validationMessage);
-  
+  /**
+   * todo : Need to find better solution updating Custom Validity text for checkboxes.
+   */
+  // const ref = useRef();
+  // useCustomValidity(ref, props.validationMessage);
+
   return (
     <Styled {...props.containerProps}>
-      <Styled.Input id={props.id} name={props.id} ref={ref} {...props} />
+      <Styled.Input id={props.id} name={props.id} {...props} />
       {props.label && (
         <Styled.Label htmlFor={props.id} {...props.labelProps}>
           {props.label}
@@ -35,7 +38,7 @@ Checkbox.propTypes = {
 
 Checkbox.defaultProps = {
   type: 'checkbox',
-  validationMessage: "Select this checkbox to continue"
+  validationMessage: 'Select this checkbox to continue',
 };
 
 export default Checkbox;

--- a/yarn.lock
+++ b/yarn.lock
@@ -4249,11 +4249,6 @@ cjs-module-lexer@^0.6.0:
   resolved "https://registry.yarnpkg.com/cjs-module-lexer/-/cjs-module-lexer-0.6.0.tgz#4186fcca0eae175970aee870b9fe2d6cf8d5655f"
   integrity sha512-uc2Vix1frTfnuzxxu1Hp4ktSvM3QaI4oXl4ZUqL1wjTu/BGki9TrCWoqLTg/drR1KwAEarXuRFCG2Svr1GxPFw==
 
-class-name-prop@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/class-name-prop/-/class-name-prop-2.0.0.tgz#367f4f0465db2c8dd2e77ef63a2faec2f87d3149"
-  integrity sha512-0WwBzHzFoyadf9BrXQul9FRXYB3Tbvvt1jb0wwRMuelZuy72XRu1b4ZwwQPb+6b5pHjQTHy/LzRcfvlVKkKcIQ==
-
 class-utils@^0.3.5:
   version "0.3.6"
   resolved "https://registry.yarnpkg.com/class-utils/-/class-utils-0.3.6.tgz#f93369ae8b9a7ce02fd41faad0ca83033190c463"
@@ -5064,16 +5059,6 @@ detect-port@^1.3.0:
   dependencies:
     address "^1.0.1"
     debug "^2.6.0"
-
-device-agnostic-ui@^7.0.1:
-  version "7.0.1"
-  resolved "https://registry.yarnpkg.com/device-agnostic-ui/-/device-agnostic-ui-7.0.1.tgz#0c3db159aa215b89c2f079e367292a6635465d5b"
-  integrity sha512-y6W5Z7q3JOi6BaNMMBn2T2l+mMtxzIuWY+2NyCvfjax4dMP2sROSQoDmH8tsHFz1/siEmwQmirCaYintoKeNVw==
-  dependencies:
-    "@babel/runtime" "^7.12.13"
-    class-name-prop "^2.0.0"
-    object-assign "^4.1.1"
-    prop-types "^15.7.2"
 
 diff-sequences@^26.6.2:
   version "26.6.2"


### PR DESCRIPTION
## What's this for
Update for 'Agree to Terms...' checkbox for login. The checkbox is not being recognized that it's checked due the update we made earlier to add `useCustomValidity` to change the validation text. So we would like to remove the custom text component all together for now to make sure the checkbox works correctly.