### PR TITLE
The Add To Calendar options are left aligned CFDP-1361

### DIFF
--- a/components/AddToCalendar/AddToCalendar.js
+++ b/components/AddToCalendar/AddToCalendar.js
@@ -35,7 +35,7 @@ const AddToCalendar = (
     )}
     {...props}
   >
-    <List py="xs" space="0">
+    <List textAlign="left" py="xs" space="0">
       <Box as="li">
         <CustomLink
           href={icsLink({ ...event, description: alternateDescription })}


### PR DESCRIPTION
## Description 
The Add To Calendar options are now left aligned

## How to Test 
1. Open the groups page /groups/cfdp-testing-group
2. Click on Add to Calendar
3. Apple, Google, and Outlook options should be left aligned

## Jira Ticket 
[CFDP-1361]

## Images 
### Before 
<img width="312" alt="Screen Shot 2021-05-06 at 12 32 28 PM" src="https://user-images.githubusercontent.com/46769629/117334473-09d94d80-ae68-11eb-9d08-c6b9c184a728.png">

### After
<img width="302" alt="Screen Shot 2021-05-06 at 12 38 59 PM" src="https://user-images.githubusercontent.com/46769629/117334476-0c3ba780-ae68-11eb-8e2a-f28ad360e1a8.png">



[CFDP-1361]: https://christfellowshipchurch.atlassian.net/browse/CFDP-1361