### PR TITLE
Changed manage to edit

### DIFF
--- a/components/GroupManage/GroupManage.js
+++ b/components/GroupManage/GroupManage.js
@@ -54,7 +54,7 @@ function GroupManage(props = {}) {
               letterSpacing="1px"
               textTransform="uppercase"
             >
-              Manage
+              Edit
             </Box>
             <Box as="h1" fontSize="h3">
               {props?.data?.title}

--- a/next.config.js
+++ b/next.config.js
@@ -15,6 +15,11 @@ module.exports = {
         destination: '/discover',
         permanent: true,
       },
+      {
+        source: '/groups/:title/manage',
+        destination: '/groups/:title/edit',
+        permanent: true,
+      },
       // TODO: Uncomment these lines to hide Group Finder.
       // NOTE: We can't get `config/flags` in this file.
       // {

--- a/pages/groups/[title]/edit.js
+++ b/pages/groups/[title]/edit.js
@@ -5,7 +5,7 @@ import { GroupProvider } from 'providers';
 import { Cell, Loader } from 'ui-kit';
 import { GroupManage, Layout } from 'components';
 
-export default function Manage(props) {
+export default function Edit(props) {
   const router = useRouter();
   const { title, id } = router.query;
   const state = useGroupContentId({ title, id });
@@ -16,7 +16,7 @@ export default function Manage(props) {
   return (
     // TODO: It should say the group's name here.
     // Use `title` and then deal with the hyphened title.
-    <Layout title="Manage Group">
+    <Layout title="Edit Group">
       <Cell px="base" py={{ _: 'l', lg: 'xl' }}>
         {isLoading ? (
           <Loader text="Loading your Group" />


### PR DESCRIPTION
## What does this PR do?
* Updated MANAGE title to Edit
* Update /manage route to /edit
* Added redirect for old /manage route

## Screenshots
<img width="1663" alt="Screen Shot 2021-05-06 at 2 55 01 PM" src="https://user-images.githubusercontent.com/45076058/117351109-54b09080-ae7b-11eb-9074-5987565c9192.png">

## Jira Issues
[CFDP-1364]

[CFDP-1364]: https://christfellowshipchurch.atlassian.net/browse/CFDP-1364