### PR TITLE
Fix ContentSingle play button and loading state

### DIFF
--- a/components/ContentSingle/ContentSingle.js
+++ b/components/ContentSingle/ContentSingle.js
@@ -10,9 +10,9 @@ import ContentVideosList from './ContentVideosList';
 
 function ContentSingle(props = {}) {
   const {
-    __typename,
     author,
     coverImage,
+    featureFeed,
     htmlContent,
     mode,
     publishDate,
@@ -54,20 +54,6 @@ function ContentSingle(props = {}) {
       renderA={() => (
         <ContentVideo video={currentVideo} poster={coverImageUri} />
       )}
-      renderC={() => (
-        <Box justifySelf="flex-end" alignSelf="start">
-          <Share title={title} />
-        </Box>
-      )}
-      contentTitleD={__typename === 'EventContentItem' ? 'About' : null}
-      contentTitleE={hasMultipleVideos ? 'Videos' : null}
-      renderContentE={() => (
-        <ContentVideosList
-          thumbnail={coverImageUri}
-          videos={videos}
-          onSelectVideo={handleSelectVideo}
-        />
-      )}
       renderContentB={() =>
         author && (
           <Box display="flex" mt="base">
@@ -90,26 +76,26 @@ function ContentSingle(props = {}) {
       }
       renderC={() => (
         <Box justifySelf="flex-end" alignSelf="start">
-          <Share title={props.data?.title} />
+          <Share title={title} />
         </Box>
       )}
       contentTitleD="About"
       contentTitleE={hasMultipleVideos ? 'Videos' : null}
       renderContentE={() => (
         <ContentVideosList
-          thumbnail={coverImage}
-          videos={props.data?.videos}
+          thumbnail={coverImageUri}
+          videos={videos}
           onSelectVideo={handleSelectVideo}
         />
       )}
-      htmlContent={props.data.htmlContent}
-      features={props?.data?.featureFeed?.features}
+      htmlContent={htmlContent}
+      features={featureFeed?.features}
     />
   );
 }
 
 ContentSingle.propTypes = {
-  data: PropTypes.array,
+  data: PropTypes.object,
 };
 
 export default ContentSingle;

--- a/components/ContentSingle/ContentSingle.js
+++ b/components/ContentSingle/ContentSingle.js
@@ -1,14 +1,41 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import { format } from 'date-fns';
 
-import { Box, Avatar } from 'ui-kit';
+import { Box, Avatar, Loader } from 'ui-kit';
 import { ContentLayout, Share } from 'components';
 
 import ContentVideo from './ContentVideo';
 import ContentVideosList from './ContentVideosList';
 
 function ContentSingle(props = {}) {
+  const [currentVideo, setCurrentVideo] = useState(
+    Array.isArray(props.data?.videos) ? props.data.videos[0] : null
+  );
+
+  useEffect(() => {
+    // Do we have videos now, when we didn't before?
+    // ( Loading just finished, so we can properly select the first video if present )
+    if (props.data?.videos?.length >= 1 && currentVideo === null) {
+      setCurrentVideo(props.data.videos[0]);
+    }
+  }, [props.data?.videos, currentVideo]);
+
+  if (props.loading) {
+    return (
+      <Box
+        display="flex"
+        justifyContent="center"
+        alignContent="center"
+        alignItems="center"
+        width="100%"
+        minHeight="50vh"
+      >
+        <Loader />
+      </Box>
+    );
+  }
+
   const {
     author,
     coverImage,
@@ -21,16 +48,11 @@ function ContentSingle(props = {}) {
     title,
     videos = [],
   } = props.data;
-  const [currentVideo, setCurrentVideo] = useState(
-    Array.isArray(videos) ? videos[0] : null
-  );
 
   const coverImageUri = coverImage?.sources[0]?.uri;
   const authorName = author
     ? `${author.firstName} ${author.lastName}`
     : undefined;
-
-  const hasMultipleVideos = videos?.length >= 2;
 
   const handleSelectVideo = video => {
     if (video !== currentVideo) {
@@ -47,7 +69,7 @@ function ContentSingle(props = {}) {
         image: coverImageUri,
         author: authorName,
         url: typeof window !== 'undefined' ? window.location.href : undefined,
-        video: videos[0]?.sources[0]?.uri,
+        video: currentVideo?.sources[0]?.uri,
       }}
       summary={schedule?.friendlyScheduleText || summary}
       coverImage={currentVideo ? null : coverImageUri}
@@ -80,7 +102,7 @@ function ContentSingle(props = {}) {
         </Box>
       )}
       contentTitleD="About"
-      contentTitleE={hasMultipleVideos ? 'Videos' : null}
+      contentTitleE={videos?.length >= 2 ? 'Videos' : null}
       renderContentE={() => (
         <ContentVideosList
           thumbnail={coverImageUri}
@@ -96,6 +118,8 @@ function ContentSingle(props = {}) {
 
 ContentSingle.propTypes = {
   data: PropTypes.object,
+  error: PropTypes.any,
+  loading: PropTypes.bool,
 };
 
 export default ContentSingle;

--- a/components/ContentSingle/ContentVideo.js
+++ b/components/ContentSingle/ContentVideo.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 
 import { useCurrentBreakpoint } from 'hooks';
 import { Video } from 'components';
-import { Button, DefaultCard, Icon } from 'ui-kit';
+import { DefaultCard, Icon } from 'ui-kit';
 
 import Styled from './ContentSingle.styles';
 

--- a/components/ContentSingle/ContentVideo.js
+++ b/components/ContentSingle/ContentVideo.js
@@ -47,7 +47,7 @@ export default function ContentVideo(props = {}) {
         )
       }
       mb="l"
-    ></DefaultCard>
+    />
   );
 }
 

--- a/hooks/useContentItem.js
+++ b/hooks/useContentItem.js
@@ -152,7 +152,7 @@ function useContentItem(options = {}) {
   });
 
   return {
-    item: query?.data?.getNodeByPathname || [],
+    item: query?.data?.getNodeByPathname || null,
     ...query,
   };
 }

--- a/providers/ContentItemProvider.js
+++ b/providers/ContentItemProvider.js
@@ -2,27 +2,11 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import { useContentItem } from 'hooks';
-import { Box, Loader } from 'ui-kit';
 
 function ContentItemProvider({ Component, options, ...props }) {
   const { loading, error, item } = useContentItem(options);
 
-  if (loading) {
-    return (
-      <Box
-        display="flex"
-        justifyContent="center"
-        alignContent="center"
-        alignItems="center"
-        width="100%"
-        minHeight="50vh"
-      >
-        <Loader />
-      </Box>
-    );
-  }
-
-  return <Component data={item} error={error} {...props} />;
+  return <Component data={item} error={error} loading={loading} {...props} />;
 }
 
 ContentItemProvider.propTypes = {

--- a/providers/ContentItemProvider.js
+++ b/providers/ContentItemProvider.js
@@ -2,11 +2,27 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import { useContentItem } from 'hooks';
+import { Box, Loader } from 'ui-kit';
 
 function ContentItemProvider({ Component, options, ...props }) {
   const { loading, error, item } = useContentItem(options);
 
-  return <Component data={item} loading={loading} error={error} {...props} />;
+  if (loading) {
+    return (
+      <Box
+        display="flex"
+        justifyContent="center"
+        alignContent="center"
+        alignItems="center"
+        width="100%"
+        minHeight="50vh"
+      >
+        <Loader />
+      </Box>
+    );
+  }
+
+  return <Component data={item} error={error} {...props} />;
 }
 
 ContentItemProvider.propTypes = {


### PR DESCRIPTION
# About

Fixes #150 

Adds a loading state to `ContentSingle`, and cleans up the `videos` handling accordingly.
This fixes the problem of #150 and a previously unnoticed merge quirk that caused duplicate props.

Another sneaky subtle problem fixed while in here was that the `seo` data for `video` was always referencing the first video. I made it reference `currentVideo` instead, though I don't have a firm grasp on what the value/effect of dynamically changing `<meta>` tags on the page like that is 🤔.
It shouldn't _hurt_, but it probably doesn't help 🤷‍♂️.


# Testing
Load a piece a **Message** content item (go to Discover and click one from the **Messages** section).
Verify there's a brief loading state, then that the page loads properly with a video play icon on the hero image.
Tap play, wait a few seconds, reload the page, and verify the same thing happens. Page should load and show the play button again.