### PR TITLE
Google option in Add To Calendar opens in a new tab now

### DIFF
--- a/components/AddToCalendar/AddToCalendar.js
+++ b/components/AddToCalendar/AddToCalendar.js
@@ -53,6 +53,7 @@ const AddToCalendar = (
           Component={Menu.Link}
           px="base"
           py="xs"
+          target="_blank"
         >
           <Icon name="google" mr="s" />
           Google


### PR DESCRIPTION
## Description 
The Google option in Add to Calendar opens in a new tab now 
This task is part of a jira ticket that is currently closed [CFDP-1361]

## How to Test 

1. Open the groups page /groups/cfdp-testing-group
2. Click on Add to Calendar
3. Click on Google
4. A new tab should open

## Jira Ticket 
[CFDP-1361]

[CFDP-1361]: https://christfellowshipchurch.atlassian.net/browse/CFDP-1361
[CFDP-1361]: https://christfellowshipchurch.atlassian.net/browse/CFDP-1361