### PR TITLE
Updated Discover to use Node Route urls

### DIFF
--- a/components/DiscoverFilterSection/DiscoverFilterSection.js
+++ b/components/DiscoverFilterSection/DiscoverFilterSection.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { useRouter } from 'next/router';
 
-import { getURLFromType, slugify } from 'utils';
+import { getUrlFromRelatedNode, getURLFromType, slugify } from 'utils';
 import { useDiscoverFilterCategoriesPreview } from 'hooks';
 
 import { Button, Box, DefaultCard, CardGrid } from 'ui-kit';
@@ -43,7 +43,7 @@ const DiscoverFilterSection = ({ contentId, title }) => {
             boxShadow="none"
             coverImage={n?.coverImage?.sources[0]?.uri}
             description={n?.summary}
-            href={getURLFromType(n, n?.title)}
+            href={getUrlFromRelatedNode(n)}
             key={n?.id}
             scaleCard={false}
             scaleCoverImage={true}

--- a/components/DiscoverItemsList/DiscoverItemsList.js
+++ b/components/DiscoverItemsList/DiscoverItemsList.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import { getURLFromType } from 'utils';
+import { getUrlFromRelatedNode } from 'utils';
 
 import { Box, CardGrid, DefaultCard, Loader } from 'ui-kit';
 import { CustomLink } from 'components';
@@ -22,7 +22,7 @@ function DiscoverItemsList(props = {}) {
           boxShadow="none"
           coverImage={contentItem?.coverImage?.sources[0]?.uri}
           description={contentItem?.summary}
-          href={getURLFromType(contentItem?.node, contentItem?.title)}
+          href={getUrlFromRelatedNode(contentItem?.node)}
           key={contentItem?.id}
           scaleCard={false}
           scaleCoverImage={true}

--- a/components/HeroListFeature/HeroListFeature.js
+++ b/components/HeroListFeature/HeroListFeature.js
@@ -5,7 +5,7 @@ import isEmpty from 'lodash/isEmpty';
 
 import { CustomLink } from '..';
 import { Box, CardGrid, DefaultCard, RowCard } from 'ui-kit';
-import { getURLFromType, getUrlFromRelatedNode } from 'utils';
+import { getUrlFromRelatedNode } from 'utils';
 
 function HeroListFeature(props = {}) {
   const onPressActionItem = props?.onPressActionItem;
@@ -63,7 +63,7 @@ function HeroListFeature(props = {}) {
       {bottomCard && (
         <CustomLink
           as="a"
-          href={getURLFromType(bottomCard?.relatedNode, bottomCard?.title)}
+          href={getUrlFromRelatedNode(bottomCard?.relatedNode)}
           Component={RowCard}
           coverImage={bottomCard?.coverImage?.sources[0]?.uri}
           coverImageOverlay={true}

--- a/hooks/useDiscoverFilterCategories.js
+++ b/hooks/useDiscoverFilterCategories.js
@@ -16,6 +16,11 @@ export const GET_CATEGORIES_FROM_FILTER = gql`
           }
         }
       }
+      ... on NodeRoute {
+        routing {
+          pathname
+        }
+      }
     }
   }
 `;

--- a/hooks/useDiscoverFilterCategoriesPreview.js
+++ b/hooks/useDiscoverFilterCategoriesPreview.js
@@ -6,7 +6,6 @@ export const GET_CATEGORIES_FILTER_PREVIEW = gql`
       id
       ... on ContentItem {
         title
-
         childContentItemsConnection(first: $first) {
           edges {
             node {
@@ -17,6 +16,11 @@ export const GET_CATEGORIES_FILTER_PREVIEW = gql`
                 name
                 sources {
                   uri
+                }
+              }
+              ... on NodeRoute {
+                routing {
+                  pathname
                 }
               }
             }

--- a/hooks/useSearchContentItems.js
+++ b/hooks/useSearchContentItems.js
@@ -22,6 +22,11 @@ export const SEARCH_CONTENT_ITEMS = gql`
             id
             __typename
           }
+          ... on NodeRoute {
+            routing {
+              pathname
+            }
+          }
         }
       }
     }

--- a/pages/discover/[title].js
+++ b/pages/discover/[title].js
@@ -1,7 +1,7 @@
 import { useRouter } from 'next/router';
 import startCase from 'lodash/startCase';
 
-import { getURLFromType } from 'utils';
+import { getUrlFromRelatedNode } from 'utils';
 import { useDiscoverFilterCategoriesPreview } from 'hooks';
 
 import { Box, DefaultCard, CardGrid, Cell, Icon, Button, utils } from 'ui-kit';
@@ -48,7 +48,7 @@ export default function Content(props) {
               boxShadow="none"
               coverImage={n?.coverImage?.sources[0]?.uri}
               description={n?.summary}
-              href={getURLFromType(n, n?.title)}
+              href={getUrlFromRelatedNode(n)}
               key={n?.id}
               scaleCard={false}
               scaleCoverImage={true}

--- a/utils/getURLFromType.js
+++ b/utils/getURLFromType.js
@@ -4,6 +4,9 @@ import slugify from './slugify';
  * note : Added additional check for title. If no title exist in the related node, pass in a separate title
  */
 
+/**
+ * ! Deprecated: these URLs are not valid anymore, and won't be used when we launch the Web 2.0
+ */
 function getURLFromType(node, title) {
   const [type, randomId] = node?.id?.split(':');
 


### PR DESCRIPTION
## What is this for?
This PR updates Discover to use the `getUrlFromRelatedNode()` method to generate the new URLs for all the cards inside of Discover. In order to grab the new pathname we need to add `NodeRoute` to the `hooks` being used for Discover.

## Demo
Go to Discover and click on any of the cards inside of Search or Categories, they should now be using the new URL format.

## Jira Tickets
[CFDP-1373]

