### PR TITLE
Changed "Serve" to "Volunteer" on hamburger menu

### DIFF
--- a/config/metadata.js
+++ b/config/metadata.js
@@ -4,7 +4,7 @@ const metadata = {
     pastMessages:
       'https://www.youtube.com/playlist?list=PLUQ7jSnRB_efXMDq9Lka6stS02awWoaz4',
     giveOnline: 'https://pushpay.com/g/christfellowship',
-    serve: 'https://rock.christfellowship.church/dreamteam',
+    volunteer: 'https://rock.christfellowship.church/dreamteam',
     shopOnline: 'https://resource.gochristfellowship.com/',
     connectCard: 'https://rock.gocf.org/connect',
     submitPrayerRequest: 'https://rock.gocf.org/RequestPrayer',

--- a/config/navigation.js
+++ b/config/navigation.js
@@ -9,8 +9,8 @@ const navigation = {
       call: 'Events',
     },
     {
-      action: links.serve,
-      call: 'Serve',
+      action: links.volunteer,
+      call: 'Volunteer',
     },
     {
       action: '/groups',


### PR DESCRIPTION
## Jira Ticket 
[CFDP-1375]

## Description 
The term "Serve" was changed to "Volunteer" from the hamburger menu on the website

## Demo
Open the hamburger menu, you should see "Volunteer" instead of "Serve"
<img width="42" alt="Screen Shot 2021-05-10 at 4 16 56 PM" src="https://user-images.githubusercontent.com/46769629/117719236-25678f80-b1ab-11eb-9963-749edf460744.png">

## Images 
### Before 
![Screen Shot 2021-05-10 at 2 29 24 PM](https://user-images.githubusercontent.com/46769629/117719320-3ca67d00-b1ab-11eb-9b76-a098843f4c63.png)

### After
<img width="338" alt="Screen Shot 2021-05-10 at 4 15 07 PM" src="https://user-images.githubusercontent.com/46769629/117719346-49c36c00-b1ab-11eb-9494-f60bfc90171c.png">



[CFDP-1375]: https://christfellowshipchurch.atlassian.net/browse/CFDP-1375