### PR TITLE
Updated alue for medium breakpoint

### DIFF
--- a/ui-kit/_config/theme.js
+++ b/ui-kit/_config/theme.js
@@ -4,7 +4,7 @@ import colors from './colors';
 const theme = {
   breakpoints: {
     sm: rem('480px'),
-    md: rem('768px'),
+    md: rem('850px'),
     lg: rem('1024px'),
     xl: rem('1350px'),
   },


### PR DESCRIPTION
## What's this for?
Original intent for this PR was to fix the breakpoint in where chat hides on the Group Single page so we can point users to the mobile app when viewing from a mobile device. 

We had it set to hide chat for small and medium devices with the `getCurrentBreakpoint` hook. I found that it made most sense to just change the value for our `md` breakpoint from `768px` to `850px`. I tested it across the site and it seemed good to me for the most part