### PR TITLE
Moved the </a> one line up to remove the extra space 

### DIFF
--- a/lib/aboutData.js
+++ b/lib/aboutData.js
@@ -31,8 +31,7 @@ const leadership = [
         <b>Instagram</b></a>
       and
       <a href="https://twitter.com/jtoddmullins/" target="_blank">
-        <b>Twitter</b></a>
-      : @jtoddmullins
+        <b>Twitter</b></a>: @jtoddmullins
     </p>
     <p>
       You can follow Pastor Julie on Instagram:

--- a/lib/aboutData.js
+++ b/lib/aboutData.js
@@ -28,12 +28,10 @@ const leadership = [
     <p>
       You can follow Pastor Todd on
       <a href="https://www.instagram.com/jtoddmullins/" target="_blank">
-        <b>Instagram</b>
-      </a>
+        <b>Instagram</b></a>
       and
       <a href="https://twitter.com/jtoddmullins/" target="_blank">
-        <b>Twitter</b>
-      </a>
+        <b>Twitter</b></a>
       : @jtoddmullins
     </p>
     <p>


### PR DESCRIPTION
## Jira Ticket 
[CFDP-1379]

## Description 
Moved the `</a>` one line up to remove the extra space that was showing after "Twitter" and "Instagram"

## Demo
On the About page there was a space showing after "Twitter" and "Instagram", under "Senior Pastors: Todd & Julie Mullins", there should not be a space there anymore 

## Images 
### Before
<img width="438" alt="Screen Shot 2021-05-11 at 11 41 38 AM" src="https://user-images.githubusercontent.com/46769629/117844659-dd4d7900-b24d-11eb-8adb-17f3a2b6685b.png">

### After
<img width="435" alt="Screen Shot 2021-05-11 at 11 40 12 AM" src="https://user-images.githubusercontent.com/46769629/117844431-ad9e7100-b24d-11eb-971a-b2d1c7eb76b0.png">


[CFDP-1379]: https://christfellowshipchurch.atlassian.net/browse/CFDP-1379