### PR TITLE
Updated breakpoint for GroupChatMobile

### DIFF
--- a/components/GroupSingle/GroupChat.js
+++ b/components/GroupSingle/GroupChat.js
@@ -14,7 +14,7 @@ export default function GroupChat(props = {}) {
     return null;
   }
 
-  if (currentBreakpoint.isSmall || currentBreakpoint.isMedium) {
+  if (currentBreakpoint.isSmall) {
     return <GroupChatMobile />;
   }
 


### PR DESCRIPTION
## What's This For?
* The breakpoint for hiding chat on GroupSingle was too large, so I changed it to only show for `isSmall` devices (<768px) with the `useCurrentBreakpoint()` hook.

## Demo/Screenshots
* Sign in and go to a GroupSingle page and inspect the page in different sizes.

![Image 3](https://user-images.githubusercontent.com/46049974/117983961-68d61100-b305-11eb-934d-234134234d76.gif)
## Jira Tickets
[CFDP-1360]

[CFDP-1360]: https://christfellowshipchurch.atlassian.net/browse/CFDP-1360