### PR TITLE
Remove about on content single

### DIFF
--- a/components/ContentSingle/ContentSingle.js
+++ b/components/ContentSingle/ContentSingle.js
@@ -101,7 +101,6 @@ function ContentSingle(props = {}) {
           <Share title={title} />
         </Box>
       )}
-      contentTitleD="About"
       contentTitleE={videos?.length >= 2 ? 'Videos' : null}
       renderContentE={() => (
         <ContentVideosList

--- a/config/navigation.js
+++ b/config/navigation.js
@@ -31,7 +31,7 @@ const navigation = {
       call: 'Discover',
     },
     {
-      action: links.giveOnline,
+      action: '/give',
       call: 'Give',
     },
   ],


### PR DESCRIPTION
## Jira Ticket 
[CFDP-1391]

## Description 
The "About" label above the body on Content Single has been removed.

## Demo
1. Open any of the cards under Latest Messages & Guides
2. There should not be an "About" label/title above the content 

## Images 
### Before
<img width="1426" alt="Screen Shot 2021-05-12 at 4 14 19 PM" src="https://user-images.githubusercontent.com/46769629/118038453-1ca6c300-b33d-11eb-942d-c1af9cf361f5.png">

### After
<img width="1276" alt="Screen Shot 2021-05-12 at 4 14 40 PM" src="https://user-images.githubusercontent.com/46769629/118038486-29c3b200-b33d-11eb-839c-374470323969.png">


