### PR TITLE
Fixed card clipping on HorizontalCardList

### DIFF
--- a/components/HorizontalCardListFeature/HorizontalCardListFeature.js
+++ b/components/HorizontalCardListFeature/HorizontalCardListFeature.js
@@ -96,7 +96,7 @@ function HorizontalCardListFeature(props = {}) {
               <CustomLink
                 as="a"
                 key={i}
-                mx="s"
+                m="s"
                 boxShadow="none"
                 href={getUrlFromRelatedNode(card?.relatedNode)}
                 Component={HorizontalHighlightCard}


### PR DESCRIPTION
## What's this for?
On the `HorizontalCardList` component, cards inside of the `CardCarousel` would clip as they expanded on hover. This PR fixes the margin of the cards inside of the `HoriztonalCardList` so they display correctly.

## Demo/Screenshots
* look at any of the `HorizontalCardList` features on the home feed. 

![Image 3](https://user-images.githubusercontent.com/46049974/118043237-1b789480-b343-11eb-85e3-1fd270686318.gif)

## Jira Tickets
[CFDP-1388]

[CFDP-1388]: https://christfellowshipchurch.atlassian.net/browse/CFDP-1388