### PR TITLE
Added Line Limit to Card Descriptions

### DIFF
--- a/ui-kit/Card/Card.styles.js
+++ b/ui-kit/Card/Card.styles.js
@@ -217,9 +217,19 @@ const CoverLabel = styled.b`
   z-index: 2;
 `;
 
+const Description = styled.p`
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+
+  ${system}
+`;
+
 Card.Content = Content;
 Card.Cover = Cover;
 Card.CoverContent = CoverContent;
 Card.CoverLabel = CoverLabel;
+Card.Description = Description;
 
 export default Card;

--- a/ui-kit/DefaultCard/DefaultCard.js
+++ b/ui-kit/DefaultCard/DefaultCard.js
@@ -33,7 +33,9 @@ const DefaultCard = (props = {}) => {
                     </Box>
                   ) : null}
                   {props.coverImageDescription ? (
-                    <Box as="p">{props.coverImageDescription}</Box>
+                    <Styled.Description>
+                      {props.coverImageDescription}
+                    </Styled.Description>
                   ) : null}
                 </Box>
               ) : null}
@@ -56,9 +58,9 @@ const DefaultCard = (props = {}) => {
           </Box>
         ) : null}
         {props.description ? (
-          <Box as="p" color="neutrals.600" fontSize="s">
+          <Styled.Description color="neutrals.600" fontSize="s">
             {props.description}
-          </Box>
+          </Styled.Description>
         ) : null}
         {props.children ? props.children : null}
       </Styled.Content>

--- a/ui-kit/HorizontalHighlightCard/HorizontalHighlightCard.js
+++ b/ui-kit/HorizontalHighlightCard/HorizontalHighlightCard.js
@@ -14,15 +14,9 @@ const HorizontalHighlightCard = (props = {}) => {
     switch (props.type) {
       case 'HIGHLIGHT_X_SMALL':
         height = 141; // 16:9 of Small size
-        if (props.description?.length > 40) {
-          trimmedDescription = `${textTrimmer(props.description, 40)}...`;
-        }
         break;
       case 'HIGHLIGHT_SMALL':
         height = 250;
-        if (props.description?.length > 40) {
-          trimmedDescription = `${textTrimmer(props.description, 40)}...`;
-        }
         break;
       case 'HIGHLIGHT_MEDIUM':
         height = 450;
@@ -33,17 +27,15 @@ const HorizontalHighlightCard = (props = {}) => {
     }
   }
 
-  const description = trimmedDescription
-    ? trimmedDescription
-    : props.description;
-
   return (
     <Styled
       {...props}
       // Overriding the default props from DefaultCard
       // so that the component only uses the coverImage props
       coverImageDescription={
-        props.coverImageDescription ? props.coverImageDescription : description
+        props.coverImageDescription
+          ? props.coverImageDescription
+          : props.description
       }
       coverImageTitle={
         props.coverImageTitle ? props.coverImageTitle : props.title

--- a/ui-kit/RowCard/RowCard.js
+++ b/ui-kit/RowCard/RowCard.js
@@ -23,9 +23,9 @@ const RowCard = (props = {}) => {
           </Box>
         ) : null}
         {props.description ? (
-          <Box as="p" color="neutrals.600" fontSize="s">
+          <Styled.Description color="neutrals.600" fontSize="s">
             {props.description}
-          </Box>
+          </Styled.Description>
         ) : null}
         {props.children ? props.children : null}
         <Divider />


### PR DESCRIPTION
## What's this for?
The `textTrimmer` function that was being used to trim text for card descriptions was working the way we wanted it to. We found that CSS would be able to accomplish limiting the lines of text in a card in a much better way.

## Changes/Updates
* Added `line-clamp` styling to Card descriptions and removed `textTrimmer` from the HorizontalHighlight cards. 
* **All** Card descriptions are now limited to **2** lines.

## Demo/Screenshots
* Look at cards on home feed.

![image](https://user-images.githubusercontent.com/46049974/118183485-29dcb400-b408-11eb-9854-d7c19d0c3fb2.png)

## Jira Ticket
[CFDP-1386]

[CFDP-1386]: https://christfellowshipchurch.atlassian.net/browse/CFDP-1386