### PR TITLE
Updated Hero banner styling for PageSingle and LocationSingle pages

### DIFF
--- a/components/LocationSingle/LocationSingle.styles.js
+++ b/components/LocationSingle/LocationSingle.styles.js
@@ -31,7 +31,7 @@ const Hero = styled.div`
   background-size: cover;
 
   padding: ${themeGet('space.m')};
-  min-height: ${props => (isEmpty(props.coverImage) ? '0' : '55vh')};
+  min-height: ${props => (isEmpty(props.coverImage) ? '0' : '80vh')};
 `;
 
 const Glass = styled.div`

--- a/components/PageSingle/PageSingle.styles.js
+++ b/components/PageSingle/PageSingle.styles.js
@@ -13,7 +13,7 @@ const Hero = styled.div`
   background-image: url(${props => props.coverImage});
   background-position: center;
   background-size: cover;
-  min-height: 40vh;
+  min-height: 80vh;
   overflow: hidden;
   padding-top: ${themeGet('space.xxl')};
 `;


### PR DESCRIPTION
## What's this for?
Update Hero banner styling for `PageSingle` and `LocationSingle` pages to `80vh`

## Demo/Screenshots
* Go to `/get-connected` and `/locations/palm-beach-gardens`

![image](https://user-images.githubusercontent.com/46049974/118505375-5b03ff80-b6fa-11eb-8fca-7e7c50df6237.png)
![image](https://user-images.githubusercontent.com/46049974/118505435-63f4d100-b6fa-11eb-9712-1e1e6b4d6ab8.png)

## Jira Ticket
[CFDP-1397]

[CFDP-1397]: https://christfellowshipchurch.atlassian.net/browse/CFDP-1397