### PR TITLE
Patch user profile UI bugs

### DIFF
--- a/components/UserProfile/EditUserProfile.js
+++ b/components/UserProfile/EditUserProfile.js
@@ -74,11 +74,6 @@ function EditUserProfile(props = {}) {
               value: startCase(values.gender) || startCase(gender) || 'Unknown',
             },
             { field: 'BirthDate', value: values.birthdate || birthdate || '' },
-            {
-              field: 'PhoneNumber',
-              value: values.phone || phone || '',
-            },
-            { field: 'Email', value: values.email || email || '' },
           ],
           address: {
             street1: values.street || street || '',
@@ -131,8 +126,8 @@ function EditUserProfile(props = {}) {
               <TextInput
                 id="email"
                 label="Email"
-                onChange={handleChange}
                 value={values.email || email || ''}
+                disabled
                 mb="s"
               />
               <Checkbox
@@ -146,8 +141,8 @@ function EditUserProfile(props = {}) {
               <TextInput
                 id="phone"
                 label="Phone Number"
-                onChange={handleChange}
                 value={values.phone || phone || ''}
+                disabled
                 mb="s"
               />
               <Checkbox

--- a/components/UserProfile/UserProfile.styles.js
+++ b/components/UserProfile/UserProfile.styles.js
@@ -1,7 +1,4 @@
-import styled, { css } from 'styled-components';
-import { themeGet } from '@styled-system/theme-get';
-
-import { system } from 'ui-kit';
+import styled from 'styled-components';
 
 const UserProfile = styled.div``;
 
@@ -9,6 +6,11 @@ const AttributeValue = styled.p`
   overflow-wrap: break-word;
 `;
 
+const ContentGridSpacing = styled.div`
+  grid-column-end: span 4;
+`;
+
 UserProfile.AttributeValue = AttributeValue;
+UserProfile.ContentGridSpacing = ContentGridSpacing;
 
 export default UserProfile;

--- a/components/UserProfile/UserProfile.styles.js
+++ b/components/UserProfile/UserProfile.styles.js
@@ -1,0 +1,14 @@
+import styled, { css } from 'styled-components';
+import { themeGet } from '@styled-system/theme-get';
+
+import { system } from 'ui-kit';
+
+const UserProfile = styled.div``;
+
+const AttributeValue = styled.p`
+  overflow-wrap: break-word;
+`;
+
+UserProfile.AttributeValue = AttributeValue;
+
+export default UserProfile;

--- a/components/UserProfile/UserProfileAttribute.js
+++ b/components/UserProfile/UserProfileAttribute.js
@@ -6,12 +6,12 @@ import Styled from './UserProfile.styles';
 
 function UserProfileAttribute(props = {}) {
   return (
-    <Card boxShadow="base" p="base">
+    <Card boxShadow="base" p={{ _: 's', m: 'base' }}>
       <Box as="h2" color="subdued" fontSize="s" fontWeight="bold">
         {props.title}
       </Box>
       <Styled.AttributeValue>
-        {`${props.data}${props.data}` || (
+        {props.data || (
           <Box as="span" color="subdued" fontSize="s" fontStyle="italic">
             No {props.label} specified
           </Box>

--- a/components/UserProfile/UserProfileAttribute.js
+++ b/components/UserProfile/UserProfileAttribute.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import { Box, Card } from 'ui-kit';
+import Styled from './UserProfile.styles';
 
 function UserProfileAttribute(props = {}) {
   return (
@@ -9,13 +10,13 @@ function UserProfileAttribute(props = {}) {
       <Box as="h2" color="subdued" fontSize="s" fontWeight="bold">
         {props.title}
       </Box>
-      <Box as="p">
-        {props.data || (
+      <Styled.AttributeValue>
+        {`${props.data}${props.data}` || (
           <Box as="span" color="subdued" fontSize="s" fontStyle="italic">
             No {props.label} specified
           </Box>
         )}
-      </Box>
+      </Styled.AttributeValue>
     </Card>
   );
 }

--- a/components/UserProfile/UserProfileContent.js
+++ b/components/UserProfile/UserProfileContent.js
@@ -1,9 +1,10 @@
 import React from 'react';
 
 import { useUserProfileState } from 'providers/UserProfileProvider';
-import { Box } from 'ui-kit';
+import { CardGrid } from 'ui-kit';
 import EditUserProfile from './EditUserProfile';
 import UserProfileAttribute from './UserProfileAttribute';
+import Styled from './UserProfile.styles';
 
 function UserProfileContent(props = {}) {
   const { status, user } = useUserProfileState();
@@ -14,28 +15,39 @@ function UserProfileContent(props = {}) {
   }
 
   return (
-    <Box
-      display="grid"
-      gridTemplateColumns="repeat(3, 33%)"
-      gridColumnGap="s"
-      gridRowGap="s"
-      textAlign="center"
-    >
-      <UserProfileAttribute title="My Campus" data={campus} label="campus" />
-      <UserProfileAttribute title="Email" data={email} label="email" />
-      <UserProfileAttribute title="Phone" data={phone} label="phone" />
-      <UserProfileAttribute
-        title="Home Address"
-        data={address}
-        label="address"
-      />
-      <UserProfileAttribute
-        title="Date of Birth"
-        data={birthdate}
-        label="date of birth"
-      />
-      <UserProfileAttribute title="Gender" data={gender} label="gender" />
-    </Box>
+    <CardGrid columns="12" gridColumnGap="s" gridRowGap="s" textAlign="center">
+      <Styled.ContentGridSpacing>
+        <UserProfileAttribute title="My Campus" data={campus} label="campus" />
+      </Styled.ContentGridSpacing>
+
+      <Styled.ContentGridSpacing>
+        <UserProfileAttribute title="Email" data={email} label="email" />
+      </Styled.ContentGridSpacing>
+
+      <Styled.ContentGridSpacing>
+        <UserProfileAttribute title="Phone" data={phone} label="phone" />
+      </Styled.ContentGridSpacing>
+
+      <Styled.ContentGridSpacing>
+        <UserProfileAttribute
+          title="Home Address"
+          data={address}
+          label="address"
+        />
+      </Styled.ContentGridSpacing>
+
+      <Styled.ContentGridSpacing>
+        <UserProfileAttribute
+          title="Date of Birth"
+          data={birthdate}
+          label="date of birth"
+        />
+      </Styled.ContentGridSpacing>
+
+      <Styled.ContentGridSpacing>
+        <UserProfileAttribute title="Gender" data={gender} label="gender" />
+      </Styled.ContentGridSpacing>
+    </CardGrid>
   );
 }
 


### PR DESCRIPTION
## What is this PR?
There are a couple of misc changes/updates needed to the Profile page.

1. For long profile values, the text wasn't wrapping correctly
![image](https://user-images.githubusercontent.com/45076058/118519015-b805b280-b706-11eb-94d6-2ed171f22d0c.png)

2. Mobile has been updated from showing a 3 column layout
![Screen Shot 2021-05-17 at 11 58 16 AM](https://user-images.githubusercontent.com/45076058/118519510-31050a00-b707-11eb-9fde-a482c6aa21fb.png)

3. Email and Phone Numbers should not be editable by users
![Screen Shot 2021-05-17 at 11 59 14 AM](https://user-images.githubusercontent.com/45076058/118519685-572aaa00-b707-11eb-9c60-5eecce4a45b2.png)

## Related Issues
[CFDP-1372]


[CFDP-1372]: https://christfellowshipchurch.atlassian.net/browse/CFDP-1372