### PR TITLE
Fix group card count pill and tweak groups responsiveness

### DIFF
--- a/components/GroupsList/GroupsList.js
+++ b/components/GroupsList/GroupsList.js
@@ -32,7 +32,6 @@ function GroupsList(props = {}) {
       display={currentBreakpoint.isSmall ? 'block' : 'flex'}
       flexWrap="wrap"
       pb="base"
-      flex="1"
     >
       {props.data.map(group => {
         const totalMembers =

--- a/components/GroupsList/GroupsList.js
+++ b/components/GroupsList/GroupsList.js
@@ -6,9 +6,12 @@ import { slugify } from 'utils';
 import { Box, CardGrid, GroupCard, Loader } from 'ui-kit';
 import { rem } from 'ui-kit/_utils';
 import { CustomLink } from 'components';
+import { useCurrentBreakpoint } from 'hooks';
 
 function GroupsList(props = {}) {
   const router = useRouter();
+  const currentBreakpoint = useCurrentBreakpoint();
+
   if (props.loading) return <Loader text="Loading your Groups" />;
 
   const noGroups = props.data.length === 0;
@@ -25,7 +28,12 @@ function GroupsList(props = {}) {
   };
 
   return (
-    <Box display="flex" flexWrap="wrap" m="s">
+    <Box
+      display={currentBreakpoint.isSmall ? 'block' : 'flex'}
+      flexWrap="wrap"
+      pb="base"
+      flex="1"
+    >
       {props.data.map(group => {
         const totalMembers =
           (group?.leaders?.totalCount || 0) + (group?.members?.totalCount || 0);
@@ -48,8 +56,9 @@ function GroupsList(props = {}) {
               md: `0 0 calc(50% - ${rem('20px')})`,
               lg: `0 0 calc(33.333% - ${rem('20px')})`,
             }}
-            m="s"
             maxWidth={{ lg: '340px' }}
+            m="s"
+            display="block"
           />
         );
       })}

--- a/components/GroupsList/GroupsList.js
+++ b/components/GroupsList/GroupsList.js
@@ -4,6 +4,7 @@ import { useRouter } from 'next/router';
 
 import { slugify } from 'utils';
 import { Box, CardGrid, GroupCard, Loader } from 'ui-kit';
+import { rem } from 'ui-kit/_utils';
 import { CustomLink } from 'components';
 
 function GroupsList(props = {}) {
@@ -24,7 +25,7 @@ function GroupsList(props = {}) {
   };
 
   return (
-    <CardGrid>
+    <Box display="flex" flexWrap="wrap" m="s">
       {props.data.map(group => {
         const totalMembers =
           (group?.leaders?.totalCount || 0) + (group?.members?.totalCount || 0);
@@ -42,10 +43,17 @@ function GroupsList(props = {}) {
             avatars={group?.members?.edges}
             totalHeroAvatars={group?.leaders?.totalCount}
             totalAvatars={totalMembers}
+            flex={{
+              _: `0 0 calc(100% - ${rem('20px')})`,
+              md: `0 0 calc(50% - ${rem('20px')})`,
+              lg: `0 0 calc(33.333% - ${rem('20px')})`,
+            }}
+            m="s"
+            maxWidth={{ lg: '340px' }}
           />
         );
       })}
-    </CardGrid>
+    </Box>
   );
 }
 

--- a/pages/groups/index.js
+++ b/pages/groups/index.js
@@ -8,7 +8,7 @@ export default function Groups() {
       <Cell
         as="main"
         maxWidth={utils.rem('1100px')}
-        px="base"
+        px={{ _: 'base', lg: '0' }}
         py={{ _: 'l', lg: 'xl' }}
       >
         <Box as="h1" mb="l">

--- a/ui-kit/GroupCard/GroupCard.js
+++ b/ui-kit/GroupCard/GroupCard.js
@@ -118,7 +118,7 @@ const GroupCard = (props = {}) => {
           {props.totalAvatars === 1 ? `Group Member` : 'Group Members'}
         </Box>
         {props.avatars?.length > 0 && (
-          <Box display="flex" mb="l" position="relative">
+          <Box display="inline-flex" mb="l" position="relative">
             {props.avatars.slice(0, maxAvatars).map((n, i = 2) => (
               <SquareAvatar
                 height="90px"

--- a/ui-kit/GroupCard/GroupCard.js
+++ b/ui-kit/GroupCard/GroupCard.js
@@ -118,7 +118,7 @@ const GroupCard = (props = {}) => {
           {props.totalAvatars === 1 ? `Group Member` : 'Group Members'}
         </Box>
         {props.avatars?.length > 0 && (
-          <Box display="flex" mb="l">
+          <Box display="flex" mb="l" position="relative">
             {props.avatars.slice(0, maxAvatars).map((n, i = 2) => (
               <SquareAvatar
                 height="90px"

--- a/ui-kit/GroupCard/GroupCard.js
+++ b/ui-kit/GroupCard/GroupCard.js
@@ -118,20 +118,28 @@ const GroupCard = (props = {}) => {
           {props.totalAvatars === 1 ? `Group Member` : 'Group Members'}
         </Box>
         {props.avatars?.length > 0 && (
-          <Box display="inline-flex" mb="l" position="relative">
+          <Box display="flex" gridColumnGap="s">
             {props.avatars.slice(0, maxAvatars).map((n, i = 2) => (
-              <SquareAvatar
-                height="90px"
+              <Box
                 key={i}
-                mr="xs"
-                name="Group Member"
-                src={n.node?.photo?.uri}
+                display="flex"
+                flexDirection="column"
+                justifyContent="center"
+                position="relative"
                 width="70px"
-              />
+                height="90px"
+              >
+                <SquareAvatar
+                  width="100%"
+                  height="100%"
+                  name="Group Member"
+                  src={n.node?.photo?.uri}
+                />
+                {avatarsDiff > 0 && props.avatars.length === i + 1 && (
+                  <Styled.AvatarCount>{`+${avatarsDiff}`}</Styled.AvatarCount>
+                )}
+              </Box>
             ))}
-            {avatarsDiff > 0 && (
-              <Styled.AvatarCount>{`+${avatarsDiff}`}</Styled.AvatarCount>
-            )}
           </Box>
         )}
         {props.callToAction && (

--- a/ui-kit/GroupCard/GroupCard.styles.js
+++ b/ui-kit/GroupCard/GroupCard.styles.js
@@ -12,7 +12,7 @@ const AvatarCount = styled.p`
   align-items: center;
   background-color: ${themeGet('colors.tertiary')};
   border-radius: ${themeGet('radii.xl')};
-  bottom: ${themeGet('space.base')};
+  top: ${rem('-14px')};
   color: ${themeGet('colors.white')};
   display: flex;
   font-size: ${themeGet('fontSizes.xs')};
@@ -20,8 +20,8 @@ const AvatarCount = styled.p`
   height: ${rem('28px')};
   justify-content: center;
   margin-bottom: auto;
-  position: relative;
-  right: ${themeGet('space.base')};
+  position: absolute;
+  right: ${rem('-8px')};
   width: ${rem('28px')};
 `;
 


### PR DESCRIPTION
Primary goal of this PR is to fix #194. The member count pill was not maintaining a perfect circle. I noticed some other responsive issues with the page and attempted to fix them in this PR too.  

TO TEST:
Go to `/groups` and resize the window make sure key breakpoints look good.

![2021-05-18 10 25 02](https://user-images.githubusercontent.com/2528817/118680632-86532100-b7c4-11eb-95a5-50d347c8df63.gif)
