### PR TITLE
Added Page Route for Devotionals

### DIFF
--- a/pages/devotionals/[title].js
+++ b/pages/devotionals/[title].js
@@ -1,0 +1,44 @@
+import { useRouter } from 'next/router';
+import { ContentItemProvider } from 'providers';
+import { ContentSingle, Layout } from 'components';
+
+function getItemId(slug) {
+  const id = slug.split('-').pop();
+  return `MediaContentItem:${id}`;
+}
+
+export default function Devotionals(props) {
+  const router = useRouter();
+  const { title } = router.query;
+
+  const options = {
+    variables: {
+      pathname: `devotionals/${title}`,
+    },
+  };
+
+  return (
+    <Layout title={title}>
+      <ContentItemProvider Component={ContentSingle} options={options} />
+    </Layout>
+  );
+}
+
+/**
+ * todo : Need to fix ServerSideProps, currenlty breaking page.
+ */
+
+// export async function getServerSideProps(context) {
+//   const apolloClient = initializeApollo();
+
+//   await apolloClient.query({
+//     query: GET_CONTENT_ITEM,
+//     variables: { itemId: getItemId(context.params.title) },
+//   });
+
+//   return {
+//     props: {
+//       initialApolloState: apolloClient.cache.extract(),
+//     },
+//   };
+// }


### PR DESCRIPTION
## What's this for?
Devotionals were not being loaded on the web app because it did not have the correct `/pages` route added for them. This PR adds `/devotionals` to `/pages` so it can render the Devotional content items correctly. 

## Demo/Screenshots
* Go to a Devotional item such as: `/devotionals/day-23-which-way-now-a-daily-devotional`

![image](https://user-images.githubusercontent.com/46049974/118689132-b4406180-b7d4-11eb-8bd9-6423a32e3c5f.png)

## Jira Ticket
[CFDP-1414]



[CFDP-1414]: https://christfellowshipchurch.atlassian.net/browse/CFDP-1414