### PR TITLE
New Page/Location Single hero image ratios

### DIFF
--- a/components/LocationSingle/LocationSingle.styles.js
+++ b/components/LocationSingle/LocationSingle.styles.js
@@ -17,6 +17,22 @@ const glassBackground = ({ coverImage }) => props => {
   }
 };
 
+const heroImageRatios = ({ coverImage }) => props => {
+  if (!isEmpty(coverImage)) {
+    return css`
+      padding-top: 100%;
+
+      @media screen and (min-width: ${themeGet('breakpoints.md')}) {
+        padding-top: 56.25%;
+      }
+
+      @media screen and (min-width: ${themeGet('breakpoints.xl')}) {
+        padding-top: 42.86%;
+      }
+    `;
+  }
+};
+
 const LocationSingle = styled.div`
   ${system}
 `;
@@ -26,12 +42,16 @@ const Hero = styled.div`
   align-items: flex-end;
   justify-content: flex-end;
 
+  position: relative;
+  overflow: hidden;
+  padding-top: 100%;
+  height: 0;
+
   background-image: url(${props => props.coverImage});
   background-position: bottom;
   background-size: cover;
 
-  padding: ${themeGet('space.m')};
-  min-height: ${props => (isEmpty(props.coverImage) ? '0' : '80vh')};
+  ${heroImageRatios}
 `;
 
 const Glass = styled.div`

--- a/components/PageSingle/PageSingle.styles.js
+++ b/components/PageSingle/PageSingle.styles.js
@@ -13,9 +13,16 @@ const Hero = styled.div`
   background-image: url(${props => props.coverImage});
   background-position: center;
   background-size: cover;
-  min-height: 80vh;
   overflow: hidden;
-  padding-top: ${themeGet('space.xxl')};
+  padding-top: 100%;
+
+  @media screen and (min-width: ${themeGet('breakpoints.md')}) {
+    padding-top: 56.25%;
+  }
+
+  @media screen and (min-width: ${themeGet('breakpoints.xl')}) {
+    padding-top: 42.86%;
+  }
 `;
 
 const Section = styled.div`


### PR DESCRIPTION
## What is this PR and what does it do?
We got some feedback that the images on Page Builder and Location Pages did not respond well to the images on different aspect ratios for different device sizes. The following ratios are copied over from the old site and seemed to have worked well.

Extra Small: 1:1
Medium: 16:9
Extra Large: 21:9

## Screenshots
![Screen Shot 2021-05-18 at 3 39 27 PM](https://user-images.githubusercontent.com/45076058/118715259-6ede5d00-b7f1-11eb-8259-61475b5f74a8.png)
![Screen Shot 2021-05-18 at 3 39 37 PM](https://user-images.githubusercontent.com/45076058/118715262-700f8a00-b7f1-11eb-802e-e8e80abb4f35.png)
![Screen Shot 2021-05-18 at 3 39 53 PM](https://user-images.githubusercontent.com/45076058/118715266-700f8a00-b7f1-11eb-9e27-3f1fa36b0108.png)

## Related Issues
[CFDP-1410]

[CFDP-1410]: https://christfellowshipchurch.atlassian.net/browse/CFDP-1410