### PR TITLE
Studies page route

### DIFF
--- a/components/SearchField/SearchField.js
+++ b/components/SearchField/SearchField.js
@@ -43,6 +43,7 @@ function SearchField(props = {}) {
         borderTopLeftRadius="0"
         borderBottomLeftRadius="0"
         outline="none"
+        lineHeight="1"
       >
         {props.children}
       </Button>

--- a/pages/studies/[title].js
+++ b/pages/studies/[title].js
@@ -1,0 +1,44 @@
+import { useRouter } from 'next/router';
+import { ContentItemProvider } from 'providers';
+import { ContentSingle, Layout } from 'components';
+
+function getItemId(slug) {
+  const id = slug.split('-').pop();
+  return `MediaContentItem:${id}`;
+}
+
+export default function Study(props) {
+  const router = useRouter();
+  const { title } = router.query;
+
+  const options = {
+    variables: {
+      pathname: `studies/${title}`,
+    },
+  };
+
+  return (
+    <Layout title={title}>
+      <ContentItemProvider Component={ContentSingle} options={options} />
+    </Layout>
+  );
+}
+
+/**
+ * todo : Need to fix ServerSideProps, currenlty breaking page.
+ */
+
+// export async function getServerSideProps(context) {
+//   const apolloClient = initializeApollo();
+
+//   await apolloClient.query({
+//     query: GET_CONTENT_ITEM,
+//     variables: { itemId: getItemId(context.params.title) },
+//   });
+
+//   return {
+//     props: {
+//       initialApolloState: apolloClient.cache.extract(),
+//     },
+//   };
+// }

--- a/ui-kit/Button/Button.styles.js
+++ b/ui-kit/Button/Button.styles.js
@@ -64,7 +64,7 @@ const size = ({ size }) => props => {
   if (size === 's') {
     return css`
       font-size: ${themeGet('fontSizes.s')};
-      line-height: 2.2;
+      line-height: 1;
       padding-left: ${themeGet('space.s')};
       padding-right: ${themeGet('space.s')};
     `;
@@ -72,7 +72,7 @@ const size = ({ size }) => props => {
 
   if (size === 'l') {
     return css`
-      line-height: 2.8;
+      line-height: 2.2;
       padding-left: ${themeGet('space.l')};
       padding-right: ${themeGet('space.l')};
     `;


### PR DESCRIPTION
## What is this PR and why is it needed?
Introduces a new `/studies` route for a Content Channel specifically holding Studies & Series. This is primarily used for Groups, but needs to be available site-wide

## How to test?
![image](https://user-images.githubusercontent.com/45076058/118841876-b1a64080-b896-11eb-84b2-7b1b3b7d6a97.png)

## Related Issues
[CFDP-1396]
[API Dependecy](https://github.com/christfellowshipchurch/apollos-api/pull/252)

[CFDP-1396]: https://christfellowshipchurch.atlassian.net/browse/CFDP-1396