### PR TITLE
Fix feature feed warning

### DIFF
--- a/components/FeatureFeed/FeatureFeed.js
+++ b/components/FeatureFeed/FeatureFeed.js
@@ -8,8 +8,8 @@ import HeroListFeature from '../HeroListFeature';
 import HorizontalCardListFeature from '../HorizontalCardListFeature';
 import VerticalCardListFeature from '../VerticalCardListFeature';
 import { FeatureProvider } from 'providers';
-import { Box, Divider } from 'ui-kit';
-import { getComponent, htmlToReactParser } from 'utils';
+import { Box } from 'ui-kit';
+import { getComponent } from 'utils';
 
 const FEATURE_COMPONENTS = {
   ActionBarFeature,
@@ -51,8 +51,6 @@ const onPressActionItem = (event, { action, relatedNode }) => {
 
 // This component is created to map the features by type and send them.
 const FeatureFeed = (props = {}) => {
-  const isLastItem = i => i < props.data.length - 1;
-
   const error = props?.error?.toString();
 
   if (error && error === 'Error: Must be logged in') {

--- a/components/HorizontalCardListFeature/HorizontalCardListFeature.js
+++ b/components/HorizontalCardListFeature/HorizontalCardListFeature.js
@@ -82,35 +82,33 @@ function HorizontalCardListFeature(props = {}) {
   }
 
   return (
-    !props.loading && (
-      <Box>
-        {!isEmpty(title) && <Box as="h2">{title}</Box>}
-        {!isEmpty(subtitle) && <Box as="p">{subtitle}</Box>}
-        <CardCarousel
-          cardsDisplayed={cardsDisplayed}
-          hideArrows={!cards || cards.length < 2}
-          mx={'-0.625rem'}
-        >
-          {cards.map((card, i) => {
-            return (
-              <CustomLink
-                as="a"
-                key={i}
-                m="s"
-                boxShadow="none"
-                href={getUrlFromRelatedNode(card?.relatedNode)}
-                Component={HorizontalHighlightCard}
-                coverImage={card?.coverImage?.sources[0]?.uri || '/cf-logo.png'}
-                coverImageOverlay={true}
-                title={card?.title}
-                description={card?.summary}
-                type={cardType}
-              />
-            );
-          })}
-        </CardCarousel>
-      </Box>
-    )
+    <Box>
+      {!isEmpty(title) && <Box as="h2">{title}</Box>}
+      {!isEmpty(subtitle) && <Box as="p">{subtitle}</Box>}
+      <CardCarousel
+        cardsDisplayed={cardsDisplayed}
+        hideArrows={!cards || cards.length < 2}
+        mx={'-0.625rem'}
+      >
+        {cards.map((card, i) => {
+          return (
+            <CustomLink
+              as="a"
+              key={i}
+              m="s"
+              boxShadow="none"
+              href={getUrlFromRelatedNode(card?.relatedNode)}
+              Component={HorizontalHighlightCard}
+              coverImage={card?.coverImage?.sources[0]?.uri || '/cf-logo.png'}
+              coverImageOverlay={true}
+              title={card?.title}
+              description={card?.summary}
+              type={cardType}
+            />
+          );
+        })}
+      </CardCarousel>
+    </Box>
   );
 }
 


### PR DESCRIPTION
There was an error about `Did not expect server HTML to contain a <div> in <div>.` in the console on the home page. By removing the check for `!props.loading` in the `HorizontalCardListFeature` it fixes this warning. I don't believe we need that check since react just inherently won't render anything for that component if it is loading.

Also, I fixed some linting warnings by removing some items not being used in `FeatureFeed.js`

TO TEST:

- Make sure the `HorizontalCardListFeature` items on the home page still work as expected.
- Make sure you don't see the `Did not expect server HTML to contain a <div> in <div>.` in the console.

![image](https://user-images.githubusercontent.com/2528817/118884172-bcbf9780-b8bb-11eb-884f-f04914bd92cc.png)

![image](https://user-images.githubusercontent.com/2528817/118884552-3c4d6680-b8bc-11eb-9698-ba8209075794.png)
