### PR TITLE
Adds a key to the leadership map to fix warning

### DIFF
--- a/pages/about/index.js
+++ b/pages/about/index.js
@@ -85,9 +85,10 @@ export default function About() {
           </Box>
         </List>
         {active === 'leadership' &&
-          data.leadership.map(item => (
+          data.leadership.map((item, i) => (
             <ContentBlock
               {...item}
+              key={i}
               justifySelf="center"
               maxWidth=" 1100px"
               mb="xl"


### PR DESCRIPTION
Fixes key warning in console.

TO TEST:

Go to `/about` and you should not see a warning about key in the console.

![image](https://user-images.githubusercontent.com/2528817/118885600-9bf84180-b8bd-11eb-905e-7da0621cd4fc.png)
