### PR TITLE
Remove 'media' grid-template-area if no media

### DIFF
--- a/ui-kit/ContentBlock/ContentBlock.js
+++ b/ui-kit/ContentBlock/ContentBlock.js
@@ -25,8 +25,14 @@ function ContentBlock(props = {}) {
     !isEmpty(htmlContent) ||
     actions?.length > 0;
 
+  const noMedia =
+    !(props.image || props.image !== '') && !(props.videos?.length >= 1);
+
   return (
-    <Styled.Container gridLayout={props.contentLayout} {...props}>
+    <Styled.Container
+      gridLayout={noMedia ? 'NO_MEDIA' : props.contentLayout}
+      {...props}
+    >
       {(props.image || props.image !== '') && (
         <Styled.Media maxWidth={horizontalLayout ? '500px' : '800px'}>
           <Image source={props.image} aspectRatio={props.imageRatio} />

--- a/ui-kit/ContentBlock/ContentBlock.styles.js
+++ b/ui-kit/ContentBlock/ContentBlock.styles.js
@@ -33,6 +33,10 @@ const gridLayout = ({ gridLayout }) => props => {
           'content'
           'media';
       `;
+    case 'NO_MEDIA':
+      return css`
+        grid-template-areas: 'content';
+      `;
     case 'default':
     default:
       return css`


### PR DESCRIPTION
## What's this for?
When a ContentBlock has no media(image/video) it is still rendering an extra `grid-template-area` with nothing in it. This PR removes the extra space if there is no media.

## Screenshot/Demo
![image](https://user-images.githubusercontent.com/46049974/119018621-47f76680-b96a-11eb-84dd-3a3df951cad4.png)
