### PR TITLE
Defaults all cache policies

### DIFF
--- a/hooks/useGroupFacetFilters.js
+++ b/hooks/useGroupFacetFilters.js
@@ -7,7 +7,10 @@ export const GET_GROUP_FACET_FILTERS = gql`
 `;
 
 function useGroupFacetFilters(options = {}) {
-  const query = useQuery(GET_GROUP_FACET_FILTERS, options);
+  const query = useQuery(GET_GROUP_FACET_FILTERS, {
+    fetchPolicy: 'cache-and-network',
+    ...options,
+  });
 
   return {
     facets: query?.data?.groupFacetFilters || [],

--- a/hooks/useGroupFilterOptions.js
+++ b/hooks/useGroupFilterOptions.js
@@ -14,7 +14,10 @@ export const GET_GROUP_OPTIONS = gql`
 
 // NOTE: To be replaced by an API query that combines this data for us
 function useGroupFilterOptions(options = {}) {
-  const query = useQuery(GET_GROUP_OPTIONS, options);
+  const query = useQuery(GET_GROUP_OPTIONS, {
+    fetchPolicy: 'cache-and-network',
+    ...options,
+  });
 
   return query?.data?.groupSearchOptions;
 }

--- a/hooks/useGroupPreference.js
+++ b/hooks/useGroupPreference.js
@@ -37,8 +37,14 @@ export const GET_SUB_PREFERENCES = gql`
 `;
 
 function useGroupPreference(options = {}) {
-  const queryPreference = useQuery(GET_PREFERENCES, options);
-  const querySubPreferences = useQuery(GET_SUB_PREFERENCES, options);
+  const queryPreference = useQuery(GET_PREFERENCES, {
+    fetchPolicy: 'cache-and-network',
+    ...options,
+  });
+  const querySubPreferences = useQuery(GET_SUB_PREFERENCES, {
+    fetchPolicy: 'cache-and-network',
+    ...options,
+  });
 
   return {
     preference: queryPreference?.data?.node || {},

--- a/hooks/useGroupPreferences.js
+++ b/hooks/useGroupPreferences.js
@@ -43,8 +43,14 @@ function useGroupPreferences(props = {}) {
   const { preferencePath = null, ...options } = props;
   const [preference, setPreference] = useState(null);
 
-  const queryPreferences = useQuery(GET_PREFERENCES, options);
-  const querySubPreferences = useQuery(GET_SUB_PREFERENCES, options);
+  const queryPreferences = useQuery(GET_PREFERENCES, {
+    fetchPolicy: 'cache-and-network',
+    ...options,
+  });
+  const querySubPreferences = useQuery(GET_SUB_PREFERENCES, {
+    fetchPolicy: 'cache-and-network',
+    ...options,
+  });
 
   const preferences = queryPreferences?.data?.allPreferences || [];
   const subPreferences = querySubPreferences?.data?.allSubPreferences || [];

--- a/hooks/useSearchGroups.js
+++ b/hooks/useSearchGroups.js
@@ -60,7 +60,10 @@ export const SEARCH_GROUPS = gql`
 `;
 
 function useSearchGroups(options = {}) {
-  const [searchGroups, query] = useLazyQuery(SEARCH_GROUPS, options);
+  const [searchGroups, query] = useLazyQuery(SEARCH_GROUPS, {
+    fetchPolicy: 'cache-and-network',
+    ...options,
+  });
 
   return [
     searchGroups,


### PR DESCRIPTION
## What is this PR and why is it needed? 
Quick scan of the `hooks` directory found no default cache policy being set on the Group Search hooks. I _think_ that this might be causing an issue where newly indexed results are not displaying immediately on device.

This gut check is coming from similar issues previously found on the Mobile App

This PR updates all of these Group Search queries to use a `cache-and-network` fetch policy.