### PR TITLE
Refine group search query

### DIFF
--- a/lib/apolloClient/initCache.js
+++ b/lib/apolloClient/initCache.js
@@ -1,5 +1,6 @@
 import { InMemoryCache } from '@apollo/client/core';
 import { persistCache } from 'apollo3-cache-persist';
+import uniqBy from 'lodash/uniqBy';
 
 import fragmentTypes from './fragmentTypes.json';
 import introspectionToPossibleTypes from './introspectionToPossibleTypes';
@@ -23,7 +24,10 @@ const initCache = initialState => {
                 ...existing,
                 totalResults: incoming.totalResults,
                 pageInfo: incoming.pageInfo,
-                edges: existing.edges.concat(incoming.edges),
+                edges: uniqBy(
+                  existing.edges.concat(incoming.edges),
+                  'node.__ref'
+                ),
               };
             },
           },

--- a/pages/community/search/index.js
+++ b/pages/community/search/index.js
@@ -41,6 +41,7 @@ export default function CommunitySearch() {
   const [filtersState, filtersDispatch] = useGroupFilters();
   const [searchGroups, { loading, groups, data, fetchMore }] = useSearchGroups({
     notifyOnNetworkStatusChange: true,
+    fetchPolicy: 'cache-and-network',
   });
 
   // Logical shorthands

--- a/providers/GroupFiltersProvider.js
+++ b/providers/GroupFiltersProvider.js
@@ -266,7 +266,7 @@ function GroupFiltersProvider(props = {}) {
 
   // :: Update filter options.
   useEffect(() => {
-    const updateMeetingType = optionsData?.meetingType.map(type =>
+    const updateMeetingType = optionsData?.meetingType?.map(type =>
       type === 'Online' ? 'Virtual' : type
     );
 


### PR DESCRIPTION
# About
Closes #208 
Fixes #209 

Updates fetch policy for `searchGroups` query on Group Finder, and de-dupes the pagination handler to prevent edge cases where duplicate group results were possible. This also prevents a bunch of React warnings about duplicate keys.

# Testing
Play with the Group Finder search functionality, and verify that pagination works as expected, etc.