### PR TITLE
Fix undefined cards in CardCarousel

### DIFF
--- a/components/HorizontalCardListFeature/HorizontalCardListFeature.js
+++ b/components/HorizontalCardListFeature/HorizontalCardListFeature.js
@@ -86,23 +86,24 @@ function HorizontalCardListFeature(props = {}) {
         hideArrows={!cards || cards.length < 2}
         mx={'-0.625rem'}
       >
-        {cards.map((card, i) => {
-          return (
-            <CustomLink
-              as="a"
-              key={i}
-              m="s"
-              boxShadow="none"
-              href={getUrlFromRelatedNode(card?.relatedNode)}
-              Component={HorizontalHighlightCard}
-              coverImage={card?.coverImage?.sources[0]?.uri || '/cf-logo.png'}
-              coverImageOverlay={true}
-              title={card?.title}
-              description={card?.summary}
-              type={cardType}
-            />
-          );
-        })}
+        {!isEmpty(cards) &&
+          cards?.map((card, i) => {
+            return (
+              <CustomLink
+                as="a"
+                key={i}
+                m="s"
+                boxShadow="none"
+                href={getUrlFromRelatedNode(card?.relatedNode)}
+                Component={HorizontalHighlightCard}
+                coverImage={card?.coverImage?.sources[0]?.uri || '/cf-logo.png'}
+                coverImageOverlay={true}
+                title={card?.title}
+                description={card?.summary}
+                type={cardType}
+              />
+            );
+          })}
       </CardCarousel>
     </Box>
   );

--- a/components/HorizontalCardListFeature/HorizontalCardListFeature.js
+++ b/components/HorizontalCardListFeature/HorizontalCardListFeature.js
@@ -14,15 +14,11 @@ import {
 import { getUrlFromRelatedNode } from 'utils';
 
 function HorizontalCardListFeature(props = {}) {
-  let data = props?.data;
+  const { title, subtitle, cards } = props?.data;
 
-  if (!data) {
+  if (!props.data) {
     return null;
   }
-
-  let title = data?.title;
-  let subtitle = data?.subtitle;
-  let cards = data?.cards;
 
   const cardType = props?.data?.cardType || 'default';
   let cardsDisplayed;
@@ -113,7 +109,12 @@ function HorizontalCardListFeature(props = {}) {
 }
 
 HorizontalCardListFeature.propTypes = {
-  data: PropTypes.object,
+  data: PropTypes.shape({
+    cardType: PropTypes.string,
+    cards: PropTypes.arrayOf(PropTypes.shape({})),
+    subtitle: PropTypes.string,
+    title: PropTypes.string,
+  }),
 };
 
 export default HorizontalCardListFeature;

--- a/ui-kit/CardCarousel/CardCarousel.js
+++ b/ui-kit/CardCarousel/CardCarousel.js
@@ -31,7 +31,7 @@ const CardCarousel = (props = {}) => {
     },
   };
 
-  const lastIndex = props.children.length - 1;
+  const lastIndex = props.children?.length - 1;
 
   const CustomArrows = ({ next, previous, goToSlide, ...rest }) => {
     const {
@@ -72,12 +72,12 @@ const CardCarousel = (props = {}) => {
       }
     }, props.slideInterval); // Your custom auto loop delay in ms
     return () => clearInterval(autoloop);
-  }, []);
+  }, [lastIndex, props.cardsDisplayed, props.slideInterval]);
 
   /**
    * note : when child items exceed the amount of items being displayed, the carousel will be disabled and arrows hidden
    */
-  let isCarousel = props.children.length > props.cardsDisplayed;
+  const isCarousel = props.children?.length > props.cardsDisplayed;
 
   return (
     <Box {...props}>
@@ -97,6 +97,7 @@ const CardCarousel = (props = {}) => {
 };
 
 CardCarousel.propTypes = {
+  children: PropTypes.oneOfType([PropTypes.element, PropTypes.node]).isRequired,
   animationSpeed: PropTypes.number,
   cardsDisplayed: PropTypes.number,
   hideArrows: PropTypes.bool,


### PR DESCRIPTION
This PR should fix undefined cards error on the `HorizontalCardListFeature` seen on the Home page.

TO TEST: See if you can still reproduce the error you see in the gif below.


If this is still a problem we might need to just add a <Loader/> to the CardCarousel.

Mentioned by @rkdavidson  in https://github.com/christfellowshipchurch/apollos-api/pull/258

![](https://user-images.githubusercontent.com/1812955/119520074-f4a95d80-bd47-11eb-95d4-77771180f0e8.gif)
