### PR TITLE
Update Max Text Lines Displayed for GroupCard

### DIFF
--- a/ui-kit/GroupCard/GroupCard.js
+++ b/ui-kit/GroupCard/GroupCard.js
@@ -13,15 +13,12 @@ import {
   SquareAvatar,
   systemPropTypes,
 } from 'ui-kit';
-import { textTrimmer } from 'utils';
 
 import Styled from './GroupCard.styles';
 
 const GroupCard = (props = {}) => {
   const modalDispatch = useModalDispatch();
 
-  const summaryLength = props?.summary?.length || 0;
-  const maxChar = 240;
   const maxAvatars = 4;
 
   // Option if we want to add a Avatar Count label for leaders
@@ -94,24 +91,9 @@ const GroupCard = (props = {}) => {
           </Styled.DateTimeLabel>
         )}
         {props.summary && (
-          <Box as="p" fontSize="s" mt="s">
-            {summaryLength > maxChar ? (
-              <>
-                {textTrimmer(props.summary, maxChar)}
-                <Box
-                  as="a"
-                  pl="xs"
-                  textDecoration="none"
-                  href="#"
-                  onClick={handleSeeMore}
-                >
-                  See More...
-                </Box>
-              </>
-            ) : (
-              props.summary
-            )}
-          </Box>
+          <Styled.GroupDescription as="p" fontSize="s" mt="s">
+            {props?.summary}
+          </Styled.GroupDescription>
         )}
         <Box as="h5" mt="base">
           <Box as="span">{props.totalAvatars}</Box>{' '}

--- a/ui-kit/GroupCard/GroupCard.styles.js
+++ b/ui-kit/GroupCard/GroupCard.styles.js
@@ -3,6 +3,8 @@ import { themeGet } from '@styled-system/theme-get';
 import Card from 'ui-kit/Card/Card.styles';
 import { rem } from 'ui-kit/_utils';
 
+import { system } from 'ui-kit';
+
 const GroupCard = styled(Card)`
   display: flex;
   flex-direction: column;
@@ -76,11 +78,21 @@ const GroupCardSubTitle = styled.div`
   color: ${themeGet('colors.subdued')};
 `;
 
+const GroupDescription = styled.p`
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+
+  ${system}
+`;
+
 GroupCard.AvatarCount = AvatarCount;
 GroupCard.DateTimeLabel = DateTimeLabel;
 GroupCard.GradientBackground = GradientBackground;
 GroupCard.GroupCardContent = GroupCardContent;
 GroupCard.GroupCardTitle = GroupCardTitle;
 GroupCard.GroupCardSubTitle = GroupCardSubTitle;
+GroupCard.GroupDescription = GroupDescription;
 
 export default GroupCard;


### PR DESCRIPTION
## What's this for?
In order to reduce empty space inside of the GroupCards on search, we are limiting amount lines displayed for a text description to 3 for all cards. This PR adds a custom style to use CSS to accomplish this.

## Updates/Changes
* Removed `textTrimmer` from Group Card and added a `line-clamp` CSS style to card summary.

## Demo/Screenshots
![image](https://user-images.githubusercontent.com/46049974/119560509-07d12300-bd72-11eb-8e34-cab094c5272f.png)

## Jira Tickets
[CFDP-1405]

[CFDP-1405]: https://christfellowshipchurch.atlassian.net/browse/CFDP-1405