### PR TITLE
Content layout updates

### DIFF
--- a/components/ContentLayout/ContentLayout.js
+++ b/components/ContentLayout/ContentLayout.js
@@ -66,7 +66,7 @@ function ContentLayout(props = {}) {
     const noContent = !props.htmlContent || props.htmlContent === '';
     if (noContent && !props.renderContentD) return null;
     return (
-      <Box mb={{ _: 'l', md: '' }}>
+      <Box mb={{ _: 'l', md: '' }} mt={{ _: 'l', md: '0' }}>
         {props.contentTitleD ? (
           <Box as="h2" fontSize="h3" mb="base">
             {props.contentTitleD}
@@ -126,9 +126,10 @@ function ContentLayout(props = {}) {
             {renderC()}
           </Box>
           <Box
-            display={{ lg: 'grid' }}
+            display={{ _: 'flex', lg: 'grid' }}
             gridTemplateColumns="65% 1fr"
             gridColumnGap="l"
+            flexDirection="column-reverse"
           >
             {renderD()}
             {renderE()}

--- a/components/ContentLayout/ContentLayout.js
+++ b/components/ContentLayout/ContentLayout.js
@@ -66,7 +66,7 @@ function ContentLayout(props = {}) {
     const noContent = !props.htmlContent || props.htmlContent === '';
     if (noContent && !props.renderContentD) return null;
     return (
-      <Box mb={{ _: 'l', md: '' }} mt={{ _: 'l', md: '0' }}>
+      <Box mb={{ _: 'l', md: '' }} mt={{ _: 'l', lg: '0' }}>
         {props.contentTitleD ? (
           <Box as="h2" fontSize="h3" mb="base">
             {props.contentTitleD}


### PR DESCRIPTION
## What is this PR and what does it do?
In order to best serve up content on all device types, I've made an update that offers CTA's above the Article Content on mobile

## Trade-off's?
Since the Content Layout was the component being used here, I've made this change globally to the Content Layout component. Section D and E flip orders on mobile devices so that section E goes _before_ D. This change is global and may not make sense for 100% of the use cases. Groups is the only one that I'm a little bit iffy on, but it doesn't look bad atm.

If anything, I would prefer a new "Group Layout" be made at some point. But for the time being, I felt like this update gets us over the hill with a change in a way that makes sense to the content currently on the site.

## Screenshots
![Screen Shot 2021-05-27 at 10 54 42 AM](https://user-images.githubusercontent.com/45076058/119849900-08d19400-bedb-11eb-9a17-0490d8d1d892.png)
![Screen Shot 2021-05-27 at 10 55 10 AM](https://user-images.githubusercontent.com/45076058/119849903-08d19400-bedb-11eb-9386-0f20bd3a0a89.png)
