### PR TITLE
Added Label to HighlightCard

### DIFF
--- a/components/VerticalCardListFeature/VerticalCardListFeature.js
+++ b/components/VerticalCardListFeature/VerticalCardListFeature.js
@@ -36,6 +36,7 @@ function VerticalCardListFeature(props = {}) {
                 title={card?.title}
                 description={card?.summary}
                 type="HIGHLIGHT_SMALL"
+                label={card?.labelText}
               />
             </Styled.CardSpacing>
           ))}

--- a/ui-kit/Card/Card.styles.js
+++ b/ui-kit/Card/Card.styles.js
@@ -197,21 +197,19 @@ const CoverContent = styled.div`
   ${position};
 `;
 
-const coverLabelBackground = ({
-  coverImageLabelBgColor = 'fg',
-}) => props => css`
-  background-color: ${themeGet(`colors.${coverImageLabelBgColor}`)};
-`;
-
 const CoverLabel = styled.b`
-  ${coverLabelBackground}
+  background-color: rgb(6, 174, 238, 0.75);
+  backdrop-filter: blur(25px);
+  box-shadow: ${themeGet('shadows.l')};
+  border-radius: ${themeGet('radii.xxl')};
   color: ${themeGet('colors.white')};
-  bottom: 0;
+  top: 0;
   font-size: ${themeGet('fontSizes.xs')};
   font-weight: ${themeGet('fontWeights.bold')};
-  left: 0;
+  right: 0;
   letter-spacing: 0.125rem;
-  padding: ${themeGet('space.s')} ${themeGet('space.base')};
+  margin: 0.5rem ${themeGet('space.xs')};
+  padding: ${themeGet('space.xs')} ${themeGet('space.s')};
   position: absolute;
   text-transform: uppercase;
   z-index: 2;

--- a/ui-kit/HorizontalHighlightCard/HorizontalHighlightCard.js
+++ b/ui-kit/HorizontalHighlightCard/HorizontalHighlightCard.js
@@ -45,6 +45,7 @@ const HorizontalHighlightCard = (props = {}) => {
       title={null}
       display="block"
       cardSize={'s'}
+      coverImageLabel={props?.label}
     />
   );
 };

--- a/ui-kit/_config/theme.js
+++ b/ui-kit/_config/theme.js
@@ -40,6 +40,7 @@ const theme = {
     base: rem('6px'),
     l: rem('10px'),
     xl: rem('16px'),
+    xxl: rem('25px'),
   },
   // https://tailwindcss.com/docs/box-shadow
   shadows: {


### PR DESCRIPTION
## What's this for?
We need to add labels again to some of our cards on the home feed and events. This PR restyles and enables the ability to add labels to cards on the `VerticalCardListFeature`.

## Screenshots/Demo
* _Note:_ The labels still need to be setup on the backend so you will not see any labels when you load up the branch. They'll use the `labelText` attribute from the cards inside of the `VerticalCardListFeature`. The labels will look like this:

![image](https://user-images.githubusercontent.com/46049974/119890974-7515bd00-bf06-11eb-9ff7-d2d1c1dce5f1.png)
