### PR TITLE
Limit group Filter options hook to just community pages

### DIFF
--- a/hooks/useGroupFilterOptions.js
+++ b/hooks/useGroupFilterOptions.js
@@ -1,4 +1,5 @@
 import { gql, useQuery } from '@apollo/client';
+import { useRouter } from 'next/router';
 
 export const GET_GROUP_OPTIONS = gql`
   query getGroupOptions {
@@ -14,8 +15,11 @@ export const GET_GROUP_OPTIONS = gql`
 
 // NOTE: To be replaced by an API query that combines this data for us
 function useGroupFilterOptions(options = {}) {
+  const router = useRouter();
+
   const query = useQuery(GET_GROUP_OPTIONS, {
     fetchPolicy: 'cache-and-network',
+    skip: !router?.asPath.includes('/community'),
     ...options,
   });
 


### PR DESCRIPTION
This would be a temporary fix for the `useGroupFilterOptions` hook getting called on any page on load. Just incase the Algolia numbers start heading towards our 250k limit. Next week it would probably be better to use React Portals. 

@asleepingpanda I just wanted you to have something that could turn down the facet a little if those Algolia numbers spike. Again, I think this just a temporary fix.

TO TEST:
Console log `optionsData` in the GroupFiltersProvider.js and it should be undefined unless you are on a `/community` page.

![image](https://user-images.githubusercontent.com/2528817/120039447-845e3e80-bfca-11eb-937a-597198a25484.png)

![image](https://user-images.githubusercontent.com/2528817/120039670-edde4d00-bfca-11eb-9768-fbaf0fa3fd7f.png)

