### PR TITLE
Adds new Url Routing to Group resources

### DIFF
--- a/components/GroupSingle/GroupResources.js
+++ b/components/GroupSingle/GroupResources.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { List, Box, Image } from 'ui-kit';
 import { CustomLink } from 'components';
 
-import { getURLFromType } from 'utils';
+import { getUrlFromRelatedNode } from 'utils';
 import amplitude from 'lib/amplitude';
 export default function GroupResources(props = {}) {
   if (!props.resources?.length) {
@@ -23,7 +23,7 @@ export default function GroupResources(props = {}) {
           <Box key={resource.relatedNode?.id} as="li">
             <CustomLink
               key={resource.relatedNode?.id}
-              href={getURLFromType(resource.relatedNode)}
+              href={getUrlFromRelatedNode(resource.relatedNode)}
               textDecoration="none"
               target="_blank"
               onClick={() => {

--- a/hooks/useGroup.js
+++ b/hooks/useGroup.js
@@ -16,6 +16,12 @@ export const GROUP_RESOURCE_FRAGMENT = gql`
       ... on Url {
         url
       }
+
+      ... on NodeRoute {
+        routing {
+          pathname
+        }
+      }
     }
   }
 `;


### PR DESCRIPTION
## What is this PR and what does it do?
This PR updates the creation of the Group Resource Url's to use a correct link.

## How do I test?
Load up a Group and click on one of the resources. It should link to the correct item.