### PR TITLE
Legacy Routing is less strict

### DIFF
--- a/components/LegacyNodeRouter/LegacyNodeRouter.js
+++ b/components/LegacyNodeRouter/LegacyNodeRouter.js
@@ -35,6 +35,8 @@ export default function LegacyNodeRouter(props) {
   useEffect(() => {
     if (!isEmpty(node?.routing?.pathname)) {
       router.push(`/${node?.routing?.pathname}`);
+    } else {
+      router.push(`/items/${title}`);
     }
   }, [node]);
 


### PR DESCRIPTION
* If landing on /content, the Legacy router will look for a new Url structure inside of Rock
* If a new, updated Url is found, the web app will redirect to the "prettier" Url
* If no new url is found, the web app will redirect to /items which will render all Content Items just like they did on the 1.0 website