### PR TITLE
Fixed Filter for MeetingType in Group Finder

### DIFF
--- a/pages/community/search/Sidebar.js
+++ b/pages/community/search/Sidebar.js
@@ -84,7 +84,7 @@ function Sidebar(props = {}) {
           values={filtersState.values.meetingType}
           disabledValues={disableInPerson}
           placeholder="Select a meeting type..."
-          onChange={handleMultiSelectChange}
+          onChange={handleSelectChange}
           onClear={handleClear}
         />
         <FilterField

--- a/ui-kit/GroupCard/GroupCard.js
+++ b/ui-kit/GroupCard/GroupCard.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { format } from 'date-fns';
 import isEmpty from 'lodash/isEmpty';
+import get from 'lodash/get';
 
 import { useModalDispatch, showModal } from 'providers/ModalProvider';
 
@@ -52,27 +53,31 @@ const GroupCard = (props = {}) => {
     },
   };
 
-  const labelType = labelTypes[camelCase(props?.meetingType)];
+  const labelType = get(labelTypes, camelCase(props?.meetingType));
+  const heroAvatars = props.heroAvatars.slice(0, maxAvatars);
 
   return (
     <Styled {...props}>
       <Box>
         {props.coverImage ? (
           <Styled.GradientBackground src={props.coverImage}>
-            <Styled.Label backgroundColor={labelType.color}>
-              <Icon name={labelType.icon} />
-            </Styled.Label>
-            {props.heroAvatars ? (
-              props.heroAvatars
-                .slice(0, 3)
+            {!isEmpty(labelType) && (
+              <Styled.Label backgroundColor={labelType.color}>
+                {props?.meetingType}
+                <Icon size={18} name={labelType.icon} ml="xs" />
+              </Styled.Label>
+            )}
+            {heroAvatars ? (
+              heroAvatars
+                .slice(0, maxAvatars)
                 .map((n, i) => (
                   <Avatar
-                    height="80px"
+                    height={heroAvatars.length > 3 ? '60px' : '80px'}
+                    width={heroAvatars.length > 3 ? '60px' : '80px'}
                     key={i}
                     mr={props.heroAvatars.length > 1 ? 'xs' : null}
                     name={`${n.node?.firstName} ${n.node?.lastName}`}
                     src={n.node?.photo?.uri}
-                    width="80px"
                   />
                 ))
             ) : (

--- a/ui-kit/GroupCard/GroupCard.styles.js
+++ b/ui-kit/GroupCard/GroupCard.styles.js
@@ -49,24 +49,28 @@ const DateTimeLabel = styled.p`
 `;
 
 const GradientBackground = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  position: relative;
+  overflow: hidden;
+
+  padding-bottom: ${themeGet('space.xl')};
+  padding-top: ${themeGet('space.xl')};
+  min-height: 200px;
+
   background-image: linear-gradient(
       to top,
       rgb(255, 255, 255, 1),
-      rgba(255, 255, 255, 0.6)
+      rgba(255, 255, 255, 0.4)
     ),
     url(${props => props.src});
   background-position: center;
   background-repeat: no-repeat;
   background-size: cover;
+
   border-top-left-radius: ${themeGet('radii.base')};
   border-top-right-radius: ${themeGet('radii.base')};
-  display: flex;
-  justify-content: center;
-  min-height: 200px;
-  overflow: hidden;
-  padding-bottom: ${themeGet('space.xl')};
-  padding-top: ${themeGet('space.xl')};
-  position: relative;
 `;
 
 const GroupCardContent = styled.div`
@@ -115,20 +119,26 @@ const SeeMore = styled.a`
 `;
 
 const Label = styled.b`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  position: absolute;
+  top: 0;
+  right: 0;
+
+  margin: 1rem;
+  padding: ${themeGet('space.xs')} ${themeGet('space.s')};
+
   background-color: ${props => props?.backgroundColor};
   backdrop-filter: blur(25px);
   box-shadow: ${themeGet('shadows.l')};
   border-radius: ${themeGet('radii.xxl')};
   color: ${themeGet('colors.white')};
-  top: 0;
+
   font-size: ${themeGet('fontSizes.xs')};
   font-weight: ${themeGet('fontWeights.bold')};
-  right: 0;
-  letter-spacing: 0.125rem;
-  margin: 0.5rem ${themeGet('space.xs')};
-  padding: ${themeGet('space.xs')} ${themeGet('space.s')};
-  position: absolute;
-  text-transform: uppercase;
+
   z-index: 2;
 `;
 


### PR DESCRIPTION
## What's this for?
To fix Filter for `MeetingType` in Group Finder, it wasn't changing correctly when switching between filters. But now should work correctly.

### ALSO:
Moved GroupCard styling changes over from 'Enable Group Finder' PR, so the changes will reflect in `master`.

## Demo
* Go to `/community/search` and select Campus and Hub, and switch between the different **Meeting Types**.

## Jira Tickets
[CFDP-1493]
