### PR TITLE
Fix preferences with two word titles

### DIFF
--- a/components/CommunitySingle/CommunitySingle.js
+++ b/components/CommunitySingle/CommunitySingle.js
@@ -11,7 +11,8 @@ import {
   Header,
   SEO,
 } from 'components';
-import { useCurrentUser, useNotifyMeBanner } from 'hooks';
+import { useCurrentUser, useNotifyMeBanner, useGroupFacetFilters } from 'hooks';
+
 import { htmlToReactParser } from 'utils';
 import { update as updateAuth, useAuth } from 'providers/AuthProvider';
 import {
@@ -37,6 +38,15 @@ function CommunitySingle(props = {}) {
   const { currentUser } = useCurrentUser();
   const router = useRouter();
 
+  const options = {
+    variables: {
+      facet: 'subPreference',
+      facetFilters: [`preference:${props.data?.title}`],
+    },
+  };
+
+  const { facets } = useGroupFacetFilters(options);
+
   // Grabs NotifyMeBanner if exists for hub.
   const { notifyMeBanner } = useNotifyMeBanner({
     variables: {
@@ -48,7 +58,7 @@ function CommunitySingle(props = {}) {
   // Filter subPreference lineups for current preference
   // Compares all subPreferences in Rock againist subPreferences in algolia
   const lineups = props.data?.subPreferences.filter(item =>
-    includes(props.data?.facets, item.title)
+    includes(facets, item.title)
   );
 
   // Pre-populate the Preference filter from the URL

--- a/pages/community/[title].js
+++ b/pages/community/[title].js
@@ -6,7 +6,7 @@ import isEmpty from 'lodash/isEmpty';
 
 import flags from 'config/flags';
 import { CommunitiesProvider } from 'providers';
-import { useGroupPreferences, useGroupFacetFilters } from 'hooks';
+import { useGroupPreferences } from 'hooks';
 import { CommunitySingle, Layout } from 'components';
 import { Box, Cell, Loader, utils } from 'ui-kit';
 
@@ -18,22 +18,9 @@ export default function Community(props) {
   const preferenceOptions = {
     preferencePath: ['community', title].join('/'),
   };
-  const {
-    preference,
-    subPreferences,
-    loading: preferenceLoading,
-  } = useGroupPreferences(preferenceOptions);
-
-  const options = {
-    variables: {
-      facet: 'subPreference',
-      facetFilters: [`preference:${title}`],
-    },
-  };
-
-  const { loading: facetLoading, facets } = useGroupFacetFilters(options);
-
-  const loading = facetLoading || preferenceLoading;
+  const { preference, subPreferences, loading } = useGroupPreferences(
+    preferenceOptions
+  );
 
   if (!flags.GROUP_FINDER) return null;
 
@@ -57,7 +44,7 @@ export default function Community(props) {
   return (
     <CommunitiesProvider
       Component={CommunitySingle}
-      data={{ ...preference, subPreferences, facets, loading }}
+      data={{ ...preference, subPreferences, loading }}
     />
   );
 }


### PR DESCRIPTION
Now subPreferences will show up for Preferences that have two word names, Young Adults, Married People, etc.

![image](https://user-images.githubusercontent.com/2528817/120541674-c7942500-c3af-11eb-85a3-7eaffe5e20ce.png)
![image](https://user-images.githubusercontent.com/2528817/120541696-cebb3300-c3af-11eb-8410-b666871eaf02.png)
![image](https://user-images.githubusercontent.com/2528817/120541714-d7136e00-c3af-11eb-92a3-a92b54f28831.png)
