### PR TITLE
Added Hub Titles to Search All Button

### DIFF
--- a/components/CommunityActionSection/CommunityActionSection.js
+++ b/components/CommunityActionSection/CommunityActionSection.js
@@ -19,7 +19,8 @@ export default function CommunityActionSection(props) {
         that’s right for you!
       </Box>
       <Button onClick={props.handleOnClick} rounded={true} mb="base">
-        Search ALL Groups &amp; Classes
+        {/* Allows for Group Hub titles to be passed in */}
+        {`Search All ${props?.title ? props?.title + ' ' : ''}Groups & Classes`}
       </Button>
 
       <CustomLink target="_blank" href="https://rock.gocf.org/page/2113">

--- a/components/CommunitySingle/CommunitySingle.js
+++ b/components/CommunitySingle/CommunitySingle.js
@@ -120,26 +120,25 @@ function CommunitySingle(props = {}) {
     <>
       <SEO title={props.data?.title} />
       <Header />
-      <Box
-        width="100%"
-        px="xxs"
-        py={{ _: 's', lg: 'base' }}
-      >
-        <Box 
-          as="a" 
-          textDecoration="none" 
+      <Box width="100%" px="xxs" py={{ _: 's', lg: 'base' }}>
+        <Box
+          as="a"
+          textDecoration="none"
           px="xxl"
-          href="#0" 
+          href="#0"
           onClick={() => router.back()}
         >
           <Icon name="arrowLeft" color="fg" />
-          <Box as="span" p="xs" color="fg" >
+          <Box as="span" p="xs" color="fg">
             back
           </Box>
         </Box>
-        
+
         <Box my={'-2.5rem'}>
-          <Styled.Hero my={'-1.5rem'}src={props.data?.coverImage?.sources[0]?.uri}>
+          <Styled.Hero
+            my={'-1.5rem'}
+            src={props.data?.coverImage?.sources[0]?.uri}
+          >
             <Box
               display="flex"
               flexDirection="column"
@@ -219,7 +218,10 @@ function CommunitySingle(props = {}) {
             </Box>
           </Box>
         )}
-        <CommunityActionSection handleOnClick={handleOnClick} />
+        <CommunityActionSection
+          title={props?.data?.title}
+          handleOnClick={handleOnClick}
+        />
         <CommunityLeaderActions />
       </Box>
       <Footer />


### PR DESCRIPTION
## What's this for?
Updated `CommunityActionSection` to accept an additional title for 'Search All' button if passed through.

## Screenshots/Demo
* Look at any of the Hub pages

![image](https://user-images.githubusercontent.com/46049974/120543520-61f96600-c3ba-11eb-8d78-edd239b6f3ec.png)

## Jira Tickets
[CFDP-1482]


[CFDP-1482]: https://christfellowshipchurch.atlassian.net/browse/CFDP-1482