### PR TITLE
Fixed Days of Week Filters

### DIFF
--- a/providers/GroupFiltersProvider.js
+++ b/providers/GroupFiltersProvider.js
@@ -10,7 +10,15 @@ const GroupFiltersProviderDispatchContext = createContext();
 // Frozen to convey that these are static.
 const options = Object.freeze({
   campuses: [],
-  days: ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'],
+  days: [
+    'Sunday',
+    'Monday',
+    'Tuesday',
+    'Wednesday',
+    'Thursday',
+    'Friday',
+    'Saturday',
+  ],
   preferences: [],
   subPreferences: [],
   meetingType: [],

--- a/ui-kit/_config/icons.js
+++ b/ui-kit/_config/icons.js
@@ -125,7 +125,7 @@ const icons = {
       stroke: '#221b38',
     },
     {
-      d: 'M9 6L3 12L9 18"',
+      d: 'M9 6L3 12L9 18',
       strokeWidth: '1',
       strokeLinejoin: 'round',
       strokeLinecap: 'round',


### PR DESCRIPTION
## What's it for?
This PR fixes the Days of Week filter for GroupFinder search that were not working previously.

## Demo
* Test the filters  on `/community/search`

## Jira Tickets
[CFDP-1439]

[CFDP-1439]: https://christfellowshipchurch.atlassian.net/browse/CFDP-1439