### PR TITLE
Switch to default arrows on small devices for CardCarousel

### DIFF
--- a/ui-kit/CardCarousel/CardCarousel.js
+++ b/ui-kit/CardCarousel/CardCarousel.js
@@ -6,6 +6,7 @@ import 'react-multi-carousel/lib/styles.css';
 import { Box, Icon } from 'ui-kit';
 
 import Styled from './CardCarousel.styles';
+import { useCurrentBreakpoint } from 'hooks';
 
 const CardCarousel = (props = {}) => {
   const responsive = {
@@ -79,16 +80,22 @@ const CardCarousel = (props = {}) => {
    */
   const isCarousel = props.children?.length > props.cardsDisplayed;
 
+  const currentBreakpoint = useCurrentBreakpoint();
+
   return (
     <Box {...props}>
       <Carousel
         ssr
         responsive={responsive}
-        arrows={false}
+        arrows={currentBreakpoint.isMedium || currentBreakpoint.isSmall}
         customTransition={`transform ${props.animationSpeed}ms ease-in-out`}
         ref={el => (carousel = el)}
         renderButtonGroupOutside={isCarousel && !props.hideArrows}
-        customButtonGroup={!props.hideArrows ? <CustomArrows /> : null}
+        customButtonGroup={
+          !props.hideArrows && currentBreakpoint.isLarge ? (
+            <CustomArrows />
+          ) : null
+        }
       >
         {props.children}
       </Carousel>


### PR DESCRIPTION
## What's this for?
**Problem:**
On our `CardCarousel` component inside of the `HorizontalCardListFeature` we need the Custom Arrows on the carousel to display on mobile devices when there is only one card being displayed at a time. Unfortunately the `CustomArrows` option in the `react-multi-carousel` component does _NOT_ support this. However the default carousel buttons seem to show correctly on smaller devices. 

**Solution:**
This PR updates the `CardCarousel` to use the _default_ arrows on small devices and the _custom_ ones for larger devices.

## Demo/Screenshots
desktop:
![image](https://user-images.githubusercontent.com/46049974/120859735-9dc73380-c552-11eb-9024-49cec9aa9c6c.png)
mobile:
![image](https://user-images.githubusercontent.com/46049974/120859774-ae77a980-c552-11eb-9121-2c57ffa90ab7.png)

