### PR TITLE
Generic error handler

### DIFF
--- a/components/GenericError/GenericError.js
+++ b/components/GenericError/GenericError.js
@@ -1,0 +1,30 @@
+import React from 'react';
+
+import { Box } from 'ui-kit';
+import { Layout } from 'components';
+
+const GenericError = () => {
+  return (
+    <Layout title="Error">
+      <Box mt="xl" textAlign="center">
+        <Box
+          as="img"
+          alt="Error Image"
+          width="90%%"
+          maxWidth={750}
+          src="/error.png"
+          margin="auto"
+        />
+        <Box as="h1" mt="l">
+          Oops! Something went wrong.
+        </Box>
+        <Box as="p" fontSize="l" mb="xxl">
+          We were unable to load the content you were looking for. Please hit
+          back and try again.
+        </Box>
+      </Box>
+    </Layout>
+  );
+};
+
+export default GenericError;

--- a/components/GenericError/GenericError.js
+++ b/components/GenericError/GenericError.js
@@ -19,7 +19,7 @@ const GenericError = () => {
           Oops! Something went wrong.
         </Box>
         <Box as="p" fontSize="l" mb="xxl">
-          We were unable to load the content you were looking for. Please hit
+          We were unable to load the content you were looking for. Please go
           back and try again.
         </Box>
       </Box>

--- a/components/GenericError/GenericError.js
+++ b/components/GenericError/GenericError.js
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { Box } from 'ui-kit';
-import { Layout } from 'components';
+import { CustomLink, Layout } from 'components';
 
 const GenericError = () => {
   return (
@@ -18,9 +18,16 @@ const GenericError = () => {
         <Box as="h1" mt="l">
           Oops! Something went wrong.
         </Box>
-        <Box as="p" fontSize="l" mb="xxl">
+        <Box as="p" fontSize="l">
           We were unable to load the content you were looking for. Please go
           back and try again.
+        </Box>
+        <Box as="p" fontSize="l" mb="xxl">
+          If you're still having trouble, you can{' '}
+          <CustomLink href="https://rock.gocf.org/contactus" title="Contact Us">
+            contact us
+          </CustomLink>{' '}
+          for assistance.
         </Box>
       </Box>
     </Layout>

--- a/components/GenericError/index.js
+++ b/components/GenericError/index.js
@@ -1,0 +1,3 @@
+import GenericError from './GenericError';
+
+export default GenericError;

--- a/components/index.js
+++ b/components/index.js
@@ -23,6 +23,7 @@ import FeatureFeed from './FeatureFeed';
 import FilterField from './FilterField';
 import Footer from './Footer';
 import GenderField from './GenderField';
+import GenericError from './GenericError';
 import GroupManage from './GroupManage';
 import GroupSearchFilters from './GroupSearchFilters';
 import GroupSingle from './GroupSingle';
@@ -75,6 +76,7 @@ export {
   FilterField,
   Footer,
   GenderField,
+  GenericError,
   GroupManage,
   GroupSearchFilters,
   GroupSingle,

--- a/pages/error/index.js
+++ b/pages/error/index.js
@@ -1,0 +1,3 @@
+import { GenericError } from 'components';
+
+export default GenericError;

--- a/pages/index.js
+++ b/pages/index.js
@@ -31,28 +31,37 @@ export default function Home(props = {}) {
 export async function getServerSideProps() {
   const apolloClient = initializeApollo();
 
-  const featureFeed = await apolloClient.query({
-    query: GET_FEATURE_FEED,
-    variables: { pathname: 'home' },
-  });
-  const features = featureFeed?.data?.featuresFeed?.features || [];
+  try {
+    const featureFeed = await apolloClient.query({
+      query: GET_FEATURE_FEED,
+      variables: { pathname: 'home' },
+    });
+    const features = featureFeed?.data?.featuresFeed?.features || [];
 
-  let promises = [];
-  features.map(item =>
-    promises.push(
-      apolloClient.query({
-        query: GET_FEATURE,
-        variables: {
-          featureId: item?.id,
-        },
-      })
-    )
-  );
-  await Promise.all(promises);
+    let promises = [];
+    features.map(item =>
+      promises.push(
+        apolloClient.query({
+          query: GET_FEATURE,
+          variables: {
+            featureId: item?.id,
+          },
+        })
+      )
+    );
+    await Promise.all(promises);
 
-  return {
-    props: {
-      initialApolloState: apolloClient.cache.extract(),
-    },
-  };
+    return {
+      props: {
+        initialApolloState: apolloClient.cache.extract(),
+      },
+    };
+  } catch (err) {
+    return {
+      redirect: {
+        permanent: false,
+        destination: '/error',
+      },
+    };
+  }
 }


### PR DESCRIPTION
# About

Fixes #269 by wrapping the Home page server side requests in a `try/catch`, so if something goes wrong, we can redirect to a new `/error` page gracefully instead of showing the raw error on screen.

This is a **bandaid** fix, as I cannot reproduce the real issue and suspect it's something performance related on the API.
The original errors look like server timeout/lower level errors where graphql couldn't respond with JSON at all.

# Testing
Start your local web server but **not** the API. The home page should redirect to `/error`.
Alternatively, start your API, but open `pages/index.js` and mess up the `pathname` variable on line 37 to force an error.

![CleanShot_2021-06-14_11 37 44](https://user-images.githubusercontent.com/1812955/121919438-048fde00-cd05-11eb-8abb-c62b5bcc6caf.jpg)