### PR TITLE
Use `cache-and-network` fetch policy a lot more

### DIFF
--- a/hooks/useCampuses.js
+++ b/hooks/useCampuses.js
@@ -10,7 +10,10 @@ export const GET_CAMPUSES = gql`
 `;
 
 function useCampuses(options) {
-  const query = useQuery(GET_CAMPUSES, options);
+  const query = useQuery(GET_CAMPUSES, {
+    fetchPolicy: 'cache-and-network',
+    ...options,
+  });
 
   return {
     campuses: query?.data?.campuses || [],

--- a/hooks/useContentFeed.js
+++ b/hooks/useContentFeed.js
@@ -79,7 +79,10 @@ export const GET_CONTENT_FEED = gql`
 `;
 
 function useContentFeed(options = {}) {
-  const query = useQuery(GET_CONTENT_FEED, options);
+  const query = useQuery(GET_CONTENT_FEED, {
+    fetchPolicy: 'cache-and-network',
+    ...options,
+  });
 
   return {
     content: query?.data?.node?.childContentItemsConnection || [],

--- a/hooks/useCurrentPerson.js
+++ b/hooks/useCurrentPerson.js
@@ -42,7 +42,10 @@ export const GET_CURRENT_PERSON = gql`
 `;
 
 function useCurrentPerson(options = {}) {
-  const query = useAuthQuery(GET_CURRENT_PERSON, options);
+  const query = useAuthQuery(GET_CURRENT_PERSON, {
+    fetchPolicy: 'cache-and-network',
+    ...options,
+  });
 
   return {
     currentPerson: query?.data?.currentUser || [],

--- a/hooks/useCurrentUser.js
+++ b/hooks/useCurrentUser.js
@@ -24,7 +24,10 @@ export const GET_CURRENT_USER = gql`
 `;
 
 function useCurrentUser(options = {}) {
-  const query = useAuthQuery(GET_CURRENT_USER, options);
+  const query = useAuthQuery(GET_CURRENT_USER, {
+    fetchPolicy: 'cache-and-network',
+    ...options,
+  });
 
   return {
     currentUser: query?.data?.currentUser || null,

--- a/hooks/useDiscoverFilterCategories.js
+++ b/hooks/useDiscoverFilterCategories.js
@@ -26,7 +26,10 @@ export const GET_CATEGORIES_FROM_FILTER = gql`
 `;
 
 function useDiscoverFilterCategories(options = {}) {
-  const query = useQuery(GET_CATEGORIES_FROM_FILTER, options);
+  const query = useQuery(GET_CATEGORIES_FROM_FILTER, {
+    fetchPolicy: 'cache-and-network',
+    ...options,
+  });
 
   return {
     categories: query?.data?.node?.childContentItemsConnection?.edges || [],

--- a/hooks/useDiscoverFilterCategoriesPreview.js
+++ b/hooks/useDiscoverFilterCategoriesPreview.js
@@ -32,7 +32,10 @@ export const GET_CATEGORIES_FILTER_PREVIEW = gql`
 `;
 
 function useDiscoverFilterCategoriesPreview(options = {}) {
-  const query = useQuery(GET_CATEGORIES_FILTER_PREVIEW, options);
+  const query = useQuery(GET_CATEGORIES_FILTER_PREVIEW, {
+    fetchPolicy: 'cache-and-network',
+    ...options,
+  });
 
   return {
     categories: query?.data?.node?.childContentItemsConnection?.edges || [],

--- a/hooks/useDiscoverFilters.js
+++ b/hooks/useDiscoverFilters.js
@@ -9,8 +9,11 @@ export const GET_FILTERS = gql`
   }
 `;
 
-function useDiscoverFilters() {
-  const query = useQuery(GET_FILTERS);
+function useDiscoverFilters(options) {
+  const query = useQuery(GET_FILTERS, {
+    fetchPolicy: 'cache-and-network',
+    ...options,
+  });
 
   return {
     filters: query?.data?.browseFilters || [],

--- a/hooks/useEvent.js
+++ b/hooks/useEvent.js
@@ -64,7 +64,10 @@ export const GET_EVENT = gql`
 `;
 
 function useEvent(options = {}) {
-  const query = useQuery(GET_EVENT, options);
+  const query = useQuery(GET_EVENT, {
+    fetchPolicy: 'cache-and-network',
+    ...options,
+  });
 
   return {
     event: query?.data?.getEventContentByTitle || [],

--- a/hooks/useEvents.js
+++ b/hooks/useEvents.js
@@ -30,7 +30,10 @@ export const GET_EVENTS = gql`
 `;
 
 function useEvents(options = {}) {
-  const query = useQuery(GET_EVENTS, options);
+  const query = useQuery(GET_EVENTS, {
+    fetchPolicy: 'cache-and-network',
+    ...options,
+  });
 
   return {
     events: query?.data?.allEvents || [],

--- a/hooks/useEventsFeedFeatures.js
+++ b/hooks/useEventsFeedFeatures.js
@@ -33,7 +33,10 @@ export const GET_EVENTS_FEED_FEATURES = gql`
 `;
 
 function useEventsFeedFeatures(options = {}) {
-  const query = useQuery(GET_EVENTS_FEED_FEATURES, options);
+  const query = useQuery(GET_EVENTS_FEED_FEATURES, {
+    fetchPolicy: 'cache-and-network',
+    ...options,
+  });
 
   return {
     eventsFeatures: query?.data?.eventsFeedFeatures || [],

--- a/hooks/useFeedFeatures.js
+++ b/hooks/useFeedFeatures.js
@@ -27,7 +27,10 @@ export const GET_FEED_FEATURES = gql`
 `;
 
 function useFeedFeatures(options = {}) {
-  const query = useQuery(GET_FEED_FEATURES, options);
+  const query = useQuery(GET_FEED_FEATURES, {
+    fetchPolicy: 'cache-and-network',
+    ...options,
+  });
 
   return {
     features: query?.data?.userFeedFeatures || [],

--- a/hooks/useGroup.js
+++ b/hooks/useGroup.js
@@ -154,7 +154,10 @@ export const GET_GROUP = gql`
 `;
 
 function useGroup(options = {}) {
-  const query = useQuery(GET_GROUP, options);
+  const query = useQuery(GET_GROUP, {
+    fetchPolicy: 'cache-and-network',
+    ...options,
+  });
 
   return {
     group: query?.data?.node || [],

--- a/hooks/useGroupCoverImages.js
+++ b/hooks/useGroupCoverImages.js
@@ -15,7 +15,10 @@ export const GET_GROUP_COVER_IMAGES = gql`
 `;
 
 function useGroupCoverImages(options = {}) {
-  const query = useQuery(GET_GROUP_COVER_IMAGES, options);
+  const query = useQuery(GET_GROUP_COVER_IMAGES, {
+    fetchPolicy: 'cache-and-network',
+    ...options,
+  });
 
   return {
     coverImages: query?.data?.groupCoverImages || [],

--- a/hooks/useGroupResourceOptions.js
+++ b/hooks/useGroupResourceOptions.js
@@ -23,7 +23,10 @@ export const GROUP_RESOURCE_OPTIONS = gql`
 `;
 
 function useGroupResourceOptions(options = {}) {
-  const query = useQuery(GROUP_RESOURCE_OPTIONS, options);
+  const query = useQuery(GROUP_RESOURCE_OPTIONS, {
+    fetchPolicy: 'cache-and-network',
+    ...options,
+  });
 
   return {
     groupResourceOptions: query?.data?.groupResourceOptions || [],

--- a/hooks/useGroups.js
+++ b/hooks/useGroups.js
@@ -34,7 +34,10 @@ export const GET_GROUPS = gql`
 `;
 
 function useGroups(options = {}) {
-  const query = useQuery(GET_GROUPS, options);
+  const query = useQuery(GET_GROUPS, {
+    fetchPolicy: 'cache-and-network',
+    ...options,
+  });
 
   return {
     groups: query?.data?.currentUser?.profile?.groups || [],

--- a/hooks/useNotifyMeBanner.js
+++ b/hooks/useNotifyMeBanner.js
@@ -10,7 +10,10 @@ export const GET_NOTIFY_ME_BANNER = gql`
 `;
 
 function useNotifyMeBanner(options = {}) {
-  const query = useQuery(GET_NOTIFY_ME_BANNER, options);
+  const query = useQuery(GET_NOTIFY_ME_BANNER, {
+    fetchPolicy: 'cache-and-network',
+    ...options,
+  });
 
   return {
     notifyMeBanner: query?.data?.notifyMeBanner,

--- a/hooks/useSearchContentItems.js
+++ b/hooks/useSearchContentItems.js
@@ -34,7 +34,10 @@ export const SEARCH_CONTENT_ITEMS = gql`
 `;
 
 function useSearchContentItems(options = {}) {
-  const [search, query] = useLazyQuery(SEARCH_CONTENT_ITEMS, options);
+  const [search, query] = useLazyQuery(SEARCH_CONTENT_ITEMS, {
+    fetchPolicy: 'cache-and-network',
+    ...options,
+  });
 
   return [
     search,


### PR DESCRIPTION
# About
Closes #213 

To avoid inconsistent or stale data, updates the default fetch policy to `cache-and-network` for relevant queries.
Hooks/queries around authentication and mutations were not changes, as it adds risk with no reward in those cases.

# Testing
Thoroughly smoke test the deploy preview site, as a lot of hooks/queries were changes.

# Screenshots
<img src="https://user-images.githubusercontent.com/1812955/121914207-0efba900-cd00-11eb-8805-18aa502b8b93.jpg" width="500" />

