### PR TITLE
Remove blank card when there are no Calls to Action in Articles

### DIFF
--- a/components/ContentSingle/ContentSingle.js
+++ b/components/ContentSingle/ContentSingle.js
@@ -108,28 +108,32 @@ function ContentSingle(props = {}) {
         </Box>
       )}
       contentTitleE={videos?.length >= 2 ? 'Videos' : null}
-      renderContentE={() => [
-        <Styled.ButtonContainer
-          key={`actions-${props?.data?.id}`}
-          p={{ _: 's', md: 'base' }}
-        >
-          {actions?.map((n, i) => (
-            <Styled.ButtonLink
-              key={i}
-              href={getUrlFromRelatedNode(n?.relatedNode) || '/'}
-              target={n?.relatedNode?.url?.includes('http') ? '_blank' : ''}
+      renderContentE={() => (
+        <>
+          {actions?.length > 0 && (
+            <Styled.ButtonContainer
+              key={`actions-${props?.data?.id}`}
+              p={{ _: 's', md: 'base' }}
             >
-              <Button width="100%">{n.title}</Button>
-            </Styled.ButtonLink>
-          ))}
-        </Styled.ButtonContainer>,
-        <ContentVideosList
-          key={`videos-${props?.data?.id}`}
-          thumbnail={coverImageUri}
-          videos={videos}
-          onSelectVideo={handleSelectVideo}
-        />,
-      ]}
+              {actions?.map((n, i) => (
+                <Styled.ButtonLink
+                  key={i}
+                  href={getUrlFromRelatedNode(n?.relatedNode) || '/'}
+                  target={n?.relatedNode?.url?.includes('http') ? '_blank' : ''}
+                >
+                  <Button width="100%">{n.title}</Button>
+                </Styled.ButtonLink>
+              ))}
+            </Styled.ButtonContainer>
+          )}
+          <ContentVideosList
+            key={`videos-${props?.data?.id}`}
+            thumbnail={coverImageUri}
+            videos={videos}
+            onSelectVideo={handleSelectVideo}
+          />
+        </>
+      )}
       htmlContent={htmlContent}
       features={featureFeed?.features}
     />


### PR DESCRIPTION
## What's this for?
To remove blank card when there are no Calls to Action in Articles.

## Screenshots
Previous issue was blank card to the left:
![image](https://user-images.githubusercontent.com/46049974/121916970-a104b100-cd02-11eb-86c7-cab0e7a4e4c3.png)

Solution:
![image](https://user-images.githubusercontent.com/46049974/121917101-c396ca00-cd02-11eb-88db-6fab3bfae960.png)

