### PR TITLE
Update Navigation

### DIFF
--- a/components/Header/Header.js
+++ b/components/Header/Header.js
@@ -11,11 +11,7 @@ function Header(props = {}) {
     <Styled>
       <Link href="/">
         <a>
-          <Box
-            as={Logo}
-            mx={{ _: 'auto', md: '0' }}
-            mb={{ _: 'base', md: '0' }}
-          />
+          <Box as={Logo} mx={{ _: 'auto', md: '0' }} />
         </a>
       </Link>
       <NavigationProvider Component={Nav} />

--- a/components/Header/Header.styles.js
+++ b/components/Header/Header.styles.js
@@ -18,10 +18,9 @@ const Header = styled.header`
     justify-self: flex-end;
   }
 
-  @media screen and (min-width: ${themeGet('breakpoints.md')}) {
-    display: grid;
-    justify-content: flex-start;
-  }
+  /* @media screen and (min-width: ${themeGet('breakpoints.md')}) { */
+  display: grid;
+  justify-content: flex-start;
 
   @media screen and (min-width: ${themeGet('breakpoints.lg')}) {
     padding: ${themeGet('space.base')} ${themeGet('space.xl')};

--- a/components/Nav/Nav.js
+++ b/components/Nav/Nav.js
@@ -27,7 +27,37 @@ function Nav(props = {}) {
 
   return (
     <Styled>
-      <QuickAction data={props.data.quickAction} />
+      <QuickAction
+        type="primary"
+        display={{ _: 'none', md: 'inline' }}
+        data={props.data.quickAction}
+      />
+      <ClientSideComponent>
+        {authenticated ? (
+          <CurrentUserProvider
+            Component={UserAvatar}
+            handleAuthClick={handleAuthClick}
+          />
+        ) : (
+          <Box
+            as="a"
+            href="#0"
+            display="block"
+            border="2px solid"
+            borderColor="fg"
+            borderRadius="50%"
+            lineHeight="38px"
+            size="45px"
+            textAlign="center"
+            onClick={handleAuthClick}
+          >
+            <Icon name="user" color="fg" size="28px" />
+            <Box as="span" className="srt">
+              User
+            </Box>
+          </Box>
+        )}
+      </ClientSideComponent>
       <Menu
         cardContentProps={{
           p: '0',
@@ -42,12 +72,28 @@ function Nav(props = {}) {
           </Box>
         )}
         side="right"
-        menuWidth="175px"
+        menuWidth="230px"
       >
         <List py="xs" space="0">
+          {/* Mobile Watch Online */}
+          <Box as="li" display={{ _: 'inline', md: 'none' }}>
+            <Menu.Link>
+              <QuickAction
+                py="xs"
+                type="link"
+                icon
+                data={props.data.quickAction}
+              />
+            </Menu.Link>
+          </Box>
           <Box as="li">
             {authenticated ? (
-              <Menu.Link href="/connect" px="base" py="xs">
+              <Menu.Link
+                display={{ _: 'inline', md: 'none' }}
+                href="/connect"
+                px="base"
+                py="xs"
+              >
                 <Icon name="user" mr="s" size="18" />
                 Connect
               </Menu.Link>
@@ -103,7 +149,14 @@ function Primary(props = {}) {
 
 function QuickAction(props = {}) {
   return (
-    <Button as="a" href={props.data.action} target="_blank">
+    <Button
+      variant={props?.type}
+      {...props}
+      as="a"
+      href={props.data.action}
+      target="_blank"
+    >
+      {props?.icon && <Icon color="primary" name="play" mr={'s'} size="18" />}
       {props.data.call}
     </Button>
   );

--- a/components/Nav/Nav.js
+++ b/components/Nav/Nav.js
@@ -72,7 +72,7 @@ function Nav(props = {}) {
           </Box>
         )}
         side="right"
-        menuWidth="230px"
+        menuWidth="260px"
       >
         <List py="xs" space="0">
           {/* Mobile Watch Online */}

--- a/components/Nav/Nav.js
+++ b/components/Nav/Nav.js
@@ -72,7 +72,7 @@ function Nav(props = {}) {
           </Box>
         )}
         side="right"
-        menuWidth="260px"
+        menuWidth="245px"
       >
         <List py="xs" space="0">
           {/* Mobile Watch Online */}


### PR DESCRIPTION
## What's this for?
For our navigation bar, we wanted to add back the user icon with profile photo when logged in. We also wanted to clean up how the navigation displays on mobile.

## Changes/Updates
* Added back Profile Icon link to `Nav`
* Condensed mobile navigation and moved 'Watch Online' to menu on mobile only.

## Demo/Screenshots
![image](https://user-images.githubusercontent.com/46049974/121930531-7ae60d80-cd10-11eb-8f07-15679b6fa857.png)

![image](https://user-images.githubusercontent.com/46049974/121930514-74f02c80-cd10-11eb-9188-5754e75c8da6.png)

## Jira Ticket
[CFDP-1522]


[CFDP-1522]: https://christfellowshipchurch.atlassian.net/browse/CFDP-1522