### PR TITLE
Updated card grid for Vertical Card List Feature

### DIFF
--- a/components/VerticalCardListFeature/VerticalCardListFeature.styles.js
+++ b/components/VerticalCardListFeature/VerticalCardListFeature.styles.js
@@ -28,6 +28,10 @@ const cardSpan = ({ index, total }) => {
     span = 12 / remainder;
   }
 
+  if (remainder === 1 && index < 4) {
+    span = 6;
+  }
+
   return css`
     grid-column-end: span ${span};
   `;


### PR DESCRIPTION
## What's this for?
In order to help the cards in the `VerticalCardListFeature` have more of a `16:9` aspect ratio, we updated the `VerticalCardListFeature` to split up its' cards differently in the grid. You can see the changes in the screenshot below.

## Screenshots
![image](https://user-images.githubusercontent.com/46049974/122112515-eef6e300-cdee-11eb-8c59-da078a5abb74.png)

## Jira Tickets
[CFDP-1509]


[CFDP-1509]: https://christfellowshipchurch.atlassian.net/browse/CFDP-1509