### PR TITLE
Fix undefined variable `card` in HeroListFeature

### DIFF
--- a/components/HeroListFeature/HeroListFeature.js
+++ b/components/HeroListFeature/HeroListFeature.js
@@ -71,7 +71,7 @@ function HeroListFeature(props = {}) {
           coverImageOverlay={true}
           title={bottomCard?.title}
           description={bottomCard?.subtitle}
-          label={card?.labelText}
+          label={bottomCard?.labelText}
         />
       )}
     </Box>


### PR DESCRIPTION
# About
Fixes #292, a bug introduced by PR #284.

This bug causes an error on the home page.