### PR TITLE
Hide Update Resource

### DIFF
--- a/components/GroupManage/GroupManage.js
+++ b/components/GroupManage/GroupManage.js
@@ -79,23 +79,28 @@ function GroupManage(props = {}) {
                   }
 
                   return (
-                    <Box
-                      key={idx}
-                      width="100%"
-                      p="s"
-                      px="base"
-                      onClick={handleSectionClick(_section)}
-                      // backgroundColor={
-                      //   section === _section ? 'primarySubduedHover' : ''
-                      // }
-                      borderLeft={section === _section ? '5px solid' : ''}
-                      {...borderRadius}
-                      color={section === _section ? 'primary' : 'neutrals.700'}
-                      // cursor="pointer"
-                      fontWeight="bold"
-                    >
-                      Update {capitalize(_section)}
-                    </Box>
+                    /**
+                     * todo : Hiding 'Update' section for now TEMPORARILY per request.
+                     */
+                    // <Box
+                    //   display="none"
+                    //   key={idx}
+                    //   width="100%"
+                    //   p="s"
+                    //   px="base"
+                    //   onClick={handleSectionClick(_section)}
+                    //   backgroundColor={
+                    //     section === _section ? 'primarySubduedHover' : ''
+                    //   }
+                    //   borderLeft={section === _section ? '5px solid' : ''}
+                    //   {...borderRadius}
+                    //   color={section === _section ? 'primary' : 'neutrals.700'}
+                    //   cursor="pointer"
+                    //   fontWeight="bold"
+                    // >
+                    //   Update {capitalize(_section)}
+                    // </Box>
+                    <></>
                   );
                 }
               )}


### PR DESCRIPTION
## What's this for?
We want to hide the **Update Resource** button for now, until further updates are made to Group Manage.

## Screenshot
![image](https://user-images.githubusercontent.com/46049974/122809051-96ff2700-d29b-11eb-82cf-814b34a30921.png)

## Jira Ticket
[CFDP-1526]

[CFDP-1526]: https://christfellowshipchurch.atlassian.net/browse/CFDP-1526