### PR TITLE
Update See More Page URL

### DIFF
--- a/components/DiscoverFilterSection/DiscoverFilterSection.js
+++ b/components/DiscoverFilterSection/DiscoverFilterSection.js
@@ -21,10 +21,7 @@ const DiscoverFilterSection = ({ contentId, title }) => {
     const [type, id] = contentId.split(':');
 
     event.preventDefault();
-    router.push(
-      `/discover/${slugify(title)}?id=${slugify(id)}`,
-      `/discover/${slugify(title)}`
-    );
+    router.push(`/discover/${slugify(title)}?id=${slugify(id)}`);
   };
 
   return (


### PR DESCRIPTION
## What's this for?
The urls being displayed for the **See More** page in Discover were hiding the category id, and therefore when you would open the URL from anywhere but the **See More** button the page would break. This PR has the **See More** page show the _entire_ URL with the `id` so that the URL can be opened from other places.

## Screenshots/Demo
* Go to any **See More** page on Discover and check out the URL
#### Before: 
![image](https://user-images.githubusercontent.com/46049974/122825791-64abf480-d2b0-11eb-9fee-6c288b3878ce.png)
#### After:
![image](https://user-images.githubusercontent.com/46049974/122825674-40501800-d2b0-11eb-8464-a517a44b12e4.png)

## Jira Ticket
[CFDP-1504]

[CFDP-1504]: https://christfellowshipchurch.atlassian.net/browse/CFDP-1504