### PR TITLE
Added correct ISO dates to 'Group Single'

### DIFF
--- a/components/GroupSingle/GroupSingle.js
+++ b/components/GroupSingle/GroupSingle.js
@@ -5,7 +5,7 @@ import { ContentLayout } from 'components';
 import { useCurrentBreakpoint, useCurrentUser, useCheckIn } from 'hooks';
 
 import { ChatConnectionProvider } from 'providers';
-import { currentUserIsLeader } from 'utils';
+import { currentUserIsLeader, transformISODates } from 'utils';
 import { Box, Card, Icon } from 'ui-kit';
 import { CustomLink } from 'components';
 
@@ -118,7 +118,9 @@ function GroupSingle(props = {}) {
       <ContentLayout
         mode={props.data.mode}
         title={props.data?.title}
-        summary={props.data.schedule?.friendlyScheduleText}
+        summary={transformISODates(props.data?.dateTime?.start, {
+          withTime: true,
+        })}
         coverImage={props.data?.coverImage?.sources[0]?.uri}
         titleIconLink={() =>
           isLeader ? (

--- a/utils/dateTextFormat.js
+++ b/utils/dateTextFormat.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import { format, isValid, isSameWeek, isSameYear } from 'date-fns';
+import { format, isValid, isSameWeek, isSameYear, isTomorrow } from 'date-fns';
 
 const dateTextFormat = date => {
   const fnsDate = new Date(date);
@@ -12,15 +12,18 @@ const dateTextFormat = date => {
   /** If the date is today, display the isTodayText */
   if (format(fnsDate, 'MMddyyyy') === format(now, 'MMddyyyy')) {
     label = format(fnsDate, "'Today at' h:mm aa");
+  } else if (isTomorrow(fnsDate)) {
+    /** if the date is tomorrow: Tomorrow at 6:00pm*/
+    label = format(fnsDate, "'Tomorrow at' h:mm a");
   } else if (isSameWeek(fnsDate, now)) {
     /** If the date is within this week: Monday */
-    label = format(fnsDate, "dddd 'at' h:mm aa");
+    label = format(fnsDate, "EEEE 'at' h:mm aa");
   } else if (isSameYear(fnsDate, now)) {
     /** If the date is outside of this year: Jan 1, 1996 */
     label = format(fnsDate, 'MMM dd, yyyy');
   } else {
     /** If the date is within this year: January 1 */
-    label = format(fnsDate, "MMMM dd 'at' h:mm A");
+    label = format(fnsDate, "MMMM dd 'at' h:mm a");
   }
 
   return label;

--- a/utils/transformISODates.js
+++ b/utils/transformISODates.js
@@ -27,7 +27,7 @@ const transformISODates = (
   { isTodayText = 'Today', withTime = false } = {}
 ) => {
   if (!!str && typeof str === 'string') {
-    const isoRegex = /\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d:[0-5]\d\.\d+([+-][0-2]\d:[0-5]\d|Z)/gim;
+    const isoRegex = /(\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d:[0-5]\d\.\d+([+-][0-2]\d:[0-5]\d|Z))|(\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d:[0-5]\d([+-][0-2]\d:[0-5]\d|Z))|(\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d([+-][0-2]\d:[0-5]\d|Z))/;
 
     return str.replace(isoRegex, match => {
       try {
@@ -35,7 +35,7 @@ const transformISODates = (
 
         /** If the date is today, display the isTodayText */
         if (isToday(iso)) {
-          return withTime ? format(iso, `'Today at' h:mm A`) : isTodayText;
+          return withTime ? format(iso, `'Today at' h:mm a`) : isTodayText;
         }
 
         /** If the date is within this week: Monday */
@@ -46,7 +46,7 @@ const transformISODates = (
           })
         ) {
           return withTime
-            ? format(iso, `EEEE 'at' h:mm A`)
+            ? format(iso, `EEEE 'at' h:mm aaa`)
             : format(iso, 'EEEE');
         }
 
@@ -62,7 +62,7 @@ const transformISODates = (
 
         /** If the date is within this year: January 1 */
         return withTime
-          ? format(iso, 'MMM d [at] h:mm A')
+          ? format(iso, `MMM d 'at' h:mm a`)
           : format(iso, 'MMMM d');
       } catch (e) {
         console.warn('Unable to parse ISO string', { e });

--- a/utils/transformISODates.js
+++ b/utils/transformISODates.js
@@ -35,7 +35,7 @@ const transformISODates = (
 
         /** If the date is today, display the isTodayText */
         if (isToday(iso)) {
-          return withTime ? format(iso, `'Today at' h:mm a`) : isTodayText;
+          return withTime ? format(iso, `'Today at' h:mmaaa`) : isTodayText;
         }
 
         /** If the date is within this week: Monday */
@@ -46,7 +46,7 @@ const transformISODates = (
           })
         ) {
           return withTime
-            ? format(iso, `EEEE 'at' h:mm aaa`)
+            ? format(iso, `EEEE 'at' h:mmaaa`)
             : format(iso, 'EEEE');
         }
 
@@ -62,7 +62,7 @@ const transformISODates = (
 
         /** If the date is within this year: January 1 */
         return withTime
-          ? format(iso, `MMM d 'at' h:mm a`)
+          ? format(iso, `MMM d 'at' h:mmaaa`)
           : format(iso, 'MMMM d');
       } catch (e) {
         console.warn('Unable to parse ISO string', { e });


### PR DESCRIPTION
## What's this for?
We needed to display the `dateTime` schedules for `GroupSingle` instead of the `friendlyScheduleText` attribute. This PR adds the `dateTime` to groups and updates the `transformISODates` and `dateTextFormat` utils.

## Screenshots/Demo
* View any Group Single page.
![image](https://user-images.githubusercontent.com/46049974/123117914-2a596900-d410-11eb-8ea4-e4c282da2c44.png)

## Jira Tickets
[CFDP-1354]
