### PR TITLE
Fix Category Title on See More Section

### DIFF
--- a/hooks/useDiscoverFilterCategoriesPreview.js
+++ b/hooks/useDiscoverFilterCategoriesPreview.js
@@ -4,6 +4,7 @@ export const GET_CATEGORIES_FILTER_PREVIEW = gql`
   query getFilterCategories($id: ID!, $first: Int) {
     node(id: $id) {
       id
+      title
       ... on ContentItem {
         title
         childContentItemsConnection(first: $first) {
@@ -38,7 +39,10 @@ function useDiscoverFilterCategoriesPreview(options = {}) {
   });
 
   return {
-    categories: query?.data?.node?.childContentItemsConnection?.edges || [],
+    categoryTitle: query?.data?.node?.title,
+    contentItems:
+      query?.data?.node?.childContentItemsConnection?.edges.map(n => n.node) ||
+      [],
     ...query,
   };
 }

--- a/pages/discover/[title].js
+++ b/pages/discover/[title].js
@@ -7,17 +7,15 @@ import { useDiscoverFilterCategoriesPreview } from 'hooks';
 import { Box, DefaultCard, CardGrid, Cell, Icon, Button, utils } from 'ui-kit';
 import { Layout, CustomLink } from 'components';
 
-export default function Content(props) {
+export default function DiscoverFilterCategoriesPreview(props) {
   const { query, back } = useRouter();
   const type = 'UniversalContentItem';
   const contentId = type.concat(':', query?.id);
 
-  const { categories } = useDiscoverFilterCategoriesPreview({
+  const { categoryTitle, contentItems } = useDiscoverFilterCategoriesPreview({
     variables: { id: contentId, first: 21 },
     fetchPolicy: 'cache-and-network',
   });
-
-  const content = categories?.map(edge => edge.node);
 
   return (
     <Layout title={startCase(query?.title)}>
@@ -34,14 +32,14 @@ export default function Content(props) {
           mb="l"
         >
           <Box as="h1" mb="0">
-            {startCase(query?.title)}
+            {categoryTitle}
           </Box>
           <Button variant="link" onClick={() => back()} pr="0">
             <Icon name="angleLeft" /> Back
           </Button>
         </Box>
         <CardGrid columns="3" mb="xl">
-          {content.map((n, i) => (
+          {contentItems.map(n => (
             <CustomLink
               Component={DefaultCard}
               as="a"


### PR DESCRIPTION
## What's this for?
The category title on the DiscoverFilterCategoriesPreview pages we're not displaying correctly, removing some of the original characters and styling. This is cause the title was being generated from the URL. To fix this, I updated the page to use the title from the query instead so that it would have the exact title.

## Updates/Changes
* Added `categoryTitle` to DiscoverFilterCategoriesPreview

## Screenshots/Demo
* Go to 'Kids' filter in **Discover** and look at any of the **See More** pages.
### Before
![image](https://user-images.githubusercontent.com/46049974/123281546-c601dc80-d4d7-11eb-81e9-1f53da941c79.png)
### After
![image](https://user-images.githubusercontent.com/46049974/123281578-cdc18100-d4d7-11eb-8e9b-d10d5e40b505.png)

## Jira Tickets
[CFDP-1504]

[CFDP-1504]: https://christfellowshipchurch.atlassian.net/browse/CFDP-1504