### PR TITLE
Fixed DiscoverFilterSection

### DIFF
--- a/components/DiscoverFilterSection/DiscoverFilterSection.js
+++ b/components/DiscoverFilterSection/DiscoverFilterSection.js
@@ -5,12 +5,12 @@ import { useRouter } from 'next/router';
 import { getUrlFromRelatedNode, slugify } from 'utils';
 import { useDiscoverFilterCategoriesPreview } from 'hooks';
 
-import { Button, Box, DefaultCard, CardGrid } from 'ui-kit';
+import { Button, Box, DefaultCard, CardGrid, Loader } from 'ui-kit';
 import { CustomLink } from 'components';
 
 const DiscoverFilterSection = ({ contentId, title }) => {
   const router = useRouter();
-  const { contentItems } = useDiscoverFilterCategoriesPreview({
+  const { contentItems, loading } = useDiscoverFilterCategoriesPreview({
     variables: { id: contentId, first: 3 },
   });
 
@@ -33,20 +33,24 @@ const DiscoverFilterSection = ({ contentId, title }) => {
       </Box>
 
       <CardGrid columns="3" mb="xl">
-        {contentItems.map((n, i) => (
-          <CustomLink
-            key={i}
-            Component={DefaultCard}
-            as="a"
-            boxShadow="none"
-            coverImage={n?.coverImage?.sources[0]?.uri}
-            description={n?.summary}
-            href={getUrlFromRelatedNode(n)}
-            scaleCard={false}
-            scaleCoverImage={true}
-            title={n?.title}
-          />
-        ))}
+        {loading ? (
+          <Loader />
+        ) : (
+          contentItems.map((n, i) => (
+            <CustomLink
+              key={i}
+              Component={DefaultCard}
+              as="a"
+              boxShadow="none"
+              coverImage={n?.coverImage?.sources[0]?.uri}
+              description={n?.summary}
+              href={getUrlFromRelatedNode(n)}
+              scaleCard={false}
+              scaleCoverImage={true}
+              title={n?.title}
+            />
+          ))
+        )}
       </CardGrid>
     </Box>
   );

--- a/components/DiscoverFilterSection/DiscoverFilterSection.js
+++ b/components/DiscoverFilterSection/DiscoverFilterSection.js
@@ -10,12 +10,9 @@ import { CustomLink } from 'components';
 
 const DiscoverFilterSection = ({ contentId, title }) => {
   const router = useRouter();
-  const { categories } = useDiscoverFilterCategoriesPreview({
+  const { contentItems } = useDiscoverFilterCategoriesPreview({
     variables: { id: contentId, first: 3 },
-    fetchPolicy: 'cache-and-network',
   });
-
-  const content = categories?.map(edge => edge.node);
 
   const handleSeeMore = event => {
     const [type, id] = contentId.split(':');
@@ -28,7 +25,7 @@ const DiscoverFilterSection = ({ contentId, title }) => {
     <Box my="s">
       <Box display="flex" justifyContent="space-between" mb="s">
         <Box as="h3">{title}</Box>
-        {content?.length > 2 ? (
+        {contentItems?.length > 2 ? (
           <Button variant="link" paddingRight={0} onClick={handleSeeMore}>
             See more
           </Button>
@@ -36,7 +33,7 @@ const DiscoverFilterSection = ({ contentId, title }) => {
       </Box>
 
       <CardGrid columns="3" mb="xl">
-        {content.map((n, i) => (
+        {contentItems.map((n, i) => (
           <CustomLink
             key={i}
             Component={DefaultCard}
@@ -45,7 +42,6 @@ const DiscoverFilterSection = ({ contentId, title }) => {
             coverImage={n?.coverImage?.sources[0]?.uri}
             description={n?.summary}
             href={getUrlFromRelatedNode(n)}
-            key={n?.id}
             scaleCard={false}
             scaleCoverImage={true}
             title={n?.title}

--- a/hooks/useDiscoverFilterCategoriesPreview.js
+++ b/hooks/useDiscoverFilterCategoriesPreview.js
@@ -4,7 +4,6 @@ export const GET_CATEGORIES_FILTER_PREVIEW = gql`
   query getFilterCategories($id: ID!, $first: Int) {
     node(id: $id) {
       id
-      title
       ... on ContentItem {
         title
         childContentItemsConnection(first: $first) {

--- a/pages/discover/[title].js
+++ b/pages/discover/[title].js
@@ -4,7 +4,16 @@ import startCase from 'lodash/startCase';
 import { getUrlFromRelatedNode } from 'utils';
 import { useDiscoverFilterCategoriesPreview } from 'hooks';
 
-import { Box, DefaultCard, CardGrid, Cell, Icon, Button, utils } from 'ui-kit';
+import {
+  Box,
+  DefaultCard,
+  CardGrid,
+  Cell,
+  Icon,
+  Button,
+  utils,
+  Loader,
+} from 'ui-kit';
 import { Layout, CustomLink } from 'components';
 
 export default function DiscoverFilterCategoriesPreview(props) {
@@ -12,7 +21,11 @@ export default function DiscoverFilterCategoriesPreview(props) {
   const type = 'UniversalContentItem';
   const contentId = type.concat(':', query?.id);
 
-  const { categoryTitle, contentItems } = useDiscoverFilterCategoriesPreview({
+  const {
+    categoryTitle,
+    contentItems,
+    loading,
+  } = useDiscoverFilterCategoriesPreview({
     variables: { id: contentId, first: 21 },
     fetchPolicy: 'cache-and-network',
   });
@@ -39,20 +52,25 @@ export default function DiscoverFilterCategoriesPreview(props) {
           </Button>
         </Box>
         <CardGrid columns="3" mb="xl">
-          {contentItems.map(n => (
-            <CustomLink
-              Component={DefaultCard}
-              as="a"
-              boxShadow="none"
-              coverImage={n?.coverImage?.sources[0]?.uri}
-              description={n?.summary}
-              href={getUrlFromRelatedNode(n)}
-              key={n?.id}
-              scaleCard={false}
-              scaleCoverImage={true}
-              title={n?.title}
-            />
-          ))}
+          {loading ? (
+            <Loader />
+          ) : (
+            contentItems.map(n => (
+              <CustomLink
+                Component={DefaultCard}
+                as="a"
+                boxShadow="none"
+                coverImage={n?.coverImage?.sources[0]?.uri}
+                description={n?.summary}
+                href={getUrlFromRelatedNode(n)}
+                key={n?.id}
+                scaleCard={false}
+                scaleCoverImage={true}
+                title={n?.title}
+                loading
+              />
+            ))
+          )}
         </CardGrid>
       </Cell>
     </Layout>

--- a/pages/discover/[title].js
+++ b/pages/discover/[title].js
@@ -18,7 +18,7 @@ export default function DiscoverFilterCategoriesPreview(props) {
   });
 
   return (
-    <Layout title={startCase(query?.title)}>
+    <Layout title={startCase(categoryTitle)}>
       <Cell
         as="main"
         maxWidth={utils.rem('1100px')}


### PR DESCRIPTION
## What's this for?
**Discover** broke when updating the `useDiscoverFilterCategoriesPreview` hook. This PR fixes the `DiscoverFilterSection`.