### PR TITLE
Added Videos to Items (old Informational Content Items)

### DIFF
--- a/pages/items/[title].js
+++ b/pages/items/[title].js
@@ -2,6 +2,7 @@ import { isEmpty } from 'lodash';
 import { useRouter } from 'next/router';
 
 import { LegacyNodeRouter, ContentLayout, Layout } from 'components';
+import ContentVideo from '../../components/ContentSingle/ContentVideo';
 import { Box, Button, Card, Loader } from 'ui-kit';
 
 import { gql, useQuery } from '@apollo/client';
@@ -204,9 +205,17 @@ export default function Item() {
       <ContentLayout
         title={node?.title}
         summary={node?.summary}
-        coverImage={node?.coverImage?.sources[0]?.uri}
+        coverImage={
+          node?.videos.length > 0 ? null : node?.coverImage?.sources[0]?.uri
+        }
         htmlContent={node?.htmlContent}
         features={[]}
+        renderA={() => (
+          <ContentVideo
+            video={node?.videos[0]}
+            poster={node?.coverImage?.sources[0]?.uri}
+          />
+        )}
         renderContentE={() =>
           node?.callsToAction?.length > 0 && (
             <Card


### PR DESCRIPTION
### About
* Added `videos` to old Informational Content Items (Give Online item) - `/items/${id}`
* Give Online page will now load its' video accordingly.

### Test Instructions
* go to Give Online content item: `items/32ba6d13cf579fe8fdd86c5a9a5f47be`

### Screenshots
![image](https://user-images.githubusercontent.com/46049974/125104479-6ac11400-e0ab-11eb-8582-a3b793ca2d6e.png)

### Closes Tickets
[CFDP-1548]

[CFDP-1548]: https://christfellowshipchurch.atlassian.net/browse/CFDP-1548