### PR TITLE
Fetch Policy for Groups Search

### DIFF
--- a/hooks/useSearchGroups.js
+++ b/hooks/useSearchGroups.js
@@ -61,7 +61,7 @@ export const SEARCH_GROUPS = gql`
 
 function useSearchGroups(options = {}) {
   const [searchGroups, query] = useLazyQuery(SEARCH_GROUPS, {
-    fetchPolicy: 'cache-and-network',
+    fetchPolicy: 'netowrk-only',
     ...options,
   });
 


### PR DESCRIPTION
### About
Updates the Fetch Policy for the group search to be `network-only`

### Test Instructions
Just search for groups

### Screenshots
n/a

### Closes Tickets
n/a

### Related Tickets
[CFDP-1563]

[CFDP-1563]: https://christfellowshipchurch.atlassian.net/browse/CFDP-1563