### PR TITLE
updated videos CTA bug

### DIFF
--- a/components/ContentSingle/ContentVideo.js
+++ b/components/ContentSingle/ContentVideo.js
@@ -25,8 +25,7 @@ export default function ContentVideo(props = {}) {
       height={{ _: '258px', md: '596px' }}
       cursor="pointer"
       contentProps={{
-        height: '100%',
-        p: '0 !important',
+        p: '0 !important'
       }}
       onClick={handlePlay}
       scaleCoverImage={!playClicked && !currentBreakpoint.isSmall}


### PR DESCRIPTION
### About
Playing a video on web was preventing a user from interacting with the rest of the page, the issue is now resolved!

### Test Instructions
1. Go to a content item
2. Play a video
3. Click on a CTA or hyperlink

### Screenshots 
(see Pushpay selected)
<img width="1156" alt="Screen Shot 2021-07-29 at 2 56 04 PM" src="https://user-images.githubusercontent.com/46769629/127550165-ff296f5f-2e45-4d9a-bb09-0c046bc3a520.png">

### Closes Tickets
[CFDP-1616]

### Related Tickets
N/A


[CFDP-1616]: https://christfellowshipchurch.atlassian.net/browse/CFDP-1616