### PR TITLE
Updated footer

### DIFF
--- a/components/Footer/Footer.js
+++ b/components/Footer/Footer.js
@@ -19,7 +19,7 @@ function Footer(props = {}) {
             <Resources />
             <Connect />
             <About />
-            <More />
+            <Opportunities />
           </Box>
         </Cell>
       </Box>
@@ -66,6 +66,9 @@ function Resources() {
         <Box as="li">
           <Styled.Link target="_blank" href={links.giveOnline}>Give Online</Styled.Link>
         </Box>
+        <Box as="li">
+          <Styled.Link target="_blank" href={links.shopOnline}>Shop Online</Styled.Link>
+        </Box>
       </List>
     </Box>
   );
@@ -110,9 +113,7 @@ function About() {
           <Styled.Link href="/about">Our Leadership</Styled.Link>
         </Box>
         <Box as="li">
-          <Styled.Link href="/career-opportunities">
-            Career Opportunities
-          </Styled.Link>
+          <Styled.Link href="/locations">Locations</Styled.Link>
         </Box>
         <Box as="li">
           <CustomLink href="/privacy-policy" Component={Styled.Link}>
@@ -129,21 +130,23 @@ function About() {
   );
 }
 
-function More() {
+function Opportunities() {
   return (
     <Box mb={{ _: 'base', lg: '0' }}>
       <Box as="h4" fontSize="h3">
-        More
+        Opportunities
       </Box>
       <List as="ul" space="xs">
+        <Box as="li">
+          <Styled.Link href="/career-opportunities">
+            Careers
+          </Styled.Link>
+        </Box>
         <Box as="li">
           <Styled.Link target="_blank" href={links.cfConf}>CF Conference</Styled.Link>
         </Box>
         <Box as="li">
           <Styled.Link target="_blank" href={links.cfSeu}>Get Your Degree</Styled.Link>
-        </Box>
-        <Box as="li">
-          <Styled.Link target="_blank" href={links.shopOnline}>Shop Online</Styled.Link>
         </Box>
       </List>
     </Box>


### PR DESCRIPTION
### About
This ticket updates the footer links according to the following points: 

1. change “More” heading to “Opportunities”
2. move “Career Opportunities” to the top under “Opportunities” heading & change that link name to “Careers”
3. leave “CF Conference” & also “Get Your Degree” under “Opportunities” as well
4. move “Shop Online” to the bottom of “Resources”
5. add “Locations” to “About”, under “Our Leadership” and link it to our location page
6. update the Figma project to reflect these changes

### Test Instructions
Look at the footer 
Compare with the above request points.

### Screenshots
Before 
<img width="1437" alt="Screen Shot 2021-08-02 at 2 56 20 PM" src="https://user-images.githubusercontent.com/46769629/127910035-64112425-bfcf-4218-a2ff-4cf5b91d0afa.png">

After 
<img width="1432" alt="Screen Shot 2021-08-02 at 1 54 06 PM" src="https://user-images.githubusercontent.com/46769629/127910041-00499811-95c5-461a-8c4e-4d0ee7d663cb.png">

### Closes Tickets
[CFDP-1613]

### Related Tickets
N/A

[CFDP-1613]: https://christfellowshipchurch.atlassian.net/browse/CFDP-1613