### PR TITLE
Copied the pre-rendering methods to articles, locations, and studies

### DIFF
--- a/pages/articles/[title].js
+++ b/pages/articles/[title].js
@@ -59,22 +59,3 @@ export async function getStaticProps({ params }) {
     revalidate: 1,
   };
 }
-
-/**
- * todo : Need to fix ServerSideProps, currenlty breaking page.
- */
-
-// export async function getServerSideProps(context) {
-//   const apolloClient = initializeApollo();
-
-//   await apolloClient.query({
-//     query: GET_CONTENT_ITEM,
-//     variables: { itemId: getItemId(context.params.title) },
-//   });
-
-//   return {
-//     props: {
-//       initialApolloState: apolloClient.cache.extract(),
-//     },
-//   };
-// }

--- a/pages/articles/[title].js
+++ b/pages/articles/[title].js
@@ -2,6 +2,9 @@ import { useRouter } from 'next/router';
 import { ContentItemProvider } from 'providers';
 import { ContentSingle, Layout } from 'components';
 
+import { GET_CONTENT_ITEM } from 'hooks/useContentItem';
+import { initializeApollo } from 'lib/apolloClient';
+
 function getItemId(slug) {
   const id = slug.split('-').pop();
   return `MediaContentItem:${id}`;
@@ -22,6 +25,39 @@ export default function Article(props) {
       <ContentItemProvider Component={ContentSingle} options={options} />
     </Layout>
   );
+}
+
+// This function gets called at build time to generate the titles for _all_ messages
+export async function getStaticPaths() {
+  // todo : make this a Network request so that it's dynamic
+  const titles = [];
+
+  return {
+    paths: titles.map(title => `articles/${title}`),
+    // Enable statically generating additional pages
+    // For example: `/messages/another-great-sermon`
+    fallback: true,
+  };
+}
+
+// This also gets called at build time
+export async function getStaticProps({ params }) {
+  const apolloClient = initializeApollo();
+
+  await apolloClient.query({
+    query: GET_CONTENT_ITEM,
+    variables: { pathname: `articles/${params.title}` },
+  });
+
+  // Pass post data to the page via props
+  return {
+    props: {
+      initialApolloState: apolloClient.cache.extract(),
+    },
+    // Re-generate the post at most once per second
+    // if a request comes in
+    revalidate: 1,
+  };
 }
 
 /**

--- a/pages/devotionals/[title].js
+++ b/pages/devotionals/[title].js
@@ -23,22 +23,3 @@ export default function Devotionals(props) {
     </Layout>
   );
 }
-
-/**
- * todo : Need to fix ServerSideProps, currenlty breaking page.
- */
-
-// export async function getServerSideProps(context) {
-//   const apolloClient = initializeApollo();
-
-//   await apolloClient.query({
-//     query: GET_CONTENT_ITEM,
-//     variables: { itemId: getItemId(context.params.title) },
-//   });
-
-//   return {
-//     props: {
-//       initialApolloState: apolloClient.cache.extract(),
-//     },
-//   };
-// }

--- a/pages/locations/[title].js
+++ b/pages/locations/[title].js
@@ -4,6 +4,9 @@ import { useRouter } from 'next/router';
 import { ContentItemProvider } from 'providers';
 import { LocationSingle } from 'components';
 
+import { GET_CONTENT_ITEM } from 'hooks/useContentItem';
+import { initializeApollo } from 'lib/apolloClient';
+
 export default function Location(props = {}) {
   const router = useRouter();
   const { query } = router;
@@ -17,3 +20,37 @@ export default function Location(props = {}) {
 
   return <ContentItemProvider Component={LocationSingle} options={options} />;
 }
+
+// This function gets called at build time to generate the titles for _all_ messages
+export async function getStaticPaths() {
+  // todo : make this a Network request so that it's dynamic
+  const titles = [];
+
+  return {
+    paths: titles.map(title => `locations/${title}`),
+    // Enable statically generating additional pages
+    // For example: `/messages/another-great-sermon`
+    fallback: true,
+  };
+}
+
+// This also gets called at build time
+export async function getStaticProps({ params }) {
+  const apolloClient = initializeApollo();
+
+  await apolloClient.query({
+    query: GET_CONTENT_ITEM,
+    variables: { pathname: `locations/${params.title}` },
+  });
+
+  // Pass post data to the page via props
+  return {
+    props: {
+      initialApolloState: apolloClient.cache.extract(),
+    },
+    // Re-generate the post at most once per second
+    // if a request comes in
+    revalidate: 1,
+  };
+}
+

--- a/pages/messages/[title].js
+++ b/pages/messages/[title].js
@@ -54,22 +54,3 @@ export async function getStaticProps({ params }) {
     revalidate: 1,
   };
 }
-
-/**
- * todo : Need to fix ServerSideProps, currenlty breaking page.
- */
-
-// export async function getServerSideProps(context) {
-//   const apolloClient = initializeApollo();
-
-//   await apolloClient.query({
-//     query: GET_CONTENT_ITEM,
-//     variables: { itemId: getItemId(context.params.title) },
-//   });
-
-//   return {
-//     props: {
-//       initialApolloState: apolloClient.cache.extract(),
-//     },
-//   };
-// }

--- a/pages/studies/[title].js
+++ b/pages/studies/[title].js
@@ -2,6 +2,9 @@ import { useRouter } from 'next/router';
 import { ContentItemProvider } from 'providers';
 import { ContentSingle, Layout } from 'components';
 
+import { GET_CONTENT_ITEM } from 'hooks/useContentItem';
+import { initializeApollo } from 'lib/apolloClient';
+
 function getItemId(slug) {
   const id = slug.split('-').pop();
   return `MediaContentItem:${id}`;
@@ -22,6 +25,39 @@ export default function Study(props) {
       <ContentItemProvider Component={ContentSingle} options={options} />
     </Layout>
   );
+}
+
+// This function gets called at build time to generate the titles for _all_ messages
+export async function getStaticPaths() {
+  // todo : make this a Network request so that it's dynamic
+  const titles = [];
+
+  return {
+    paths: titles.map(title => `locations/${title}`),
+    // Enable statically generating additional pages
+    // For example: `/messages/another-great-sermon`
+    fallback: true,
+  };
+}
+
+// This also gets called at build time
+export async function getStaticProps({ params }) {
+  const apolloClient = initializeApollo();
+
+  await apolloClient.query({
+    query: GET_CONTENT_ITEM,
+    variables: { pathname: `locations/${params.title}` },
+  });
+
+  // Pass post data to the page via props
+  return {
+    props: {
+      initialApolloState: apolloClient.cache.extract(),
+    },
+    // Re-generate the post at most once per second
+    // if a request comes in
+    revalidate: 1,
+  };
 }
 
 /**

--- a/pages/studies/[title].js
+++ b/pages/studies/[title].js
@@ -59,22 +59,3 @@ export async function getStaticProps({ params }) {
     revalidate: 1,
   };
 }
-
-/**
- * todo : Need to fix ServerSideProps, currenlty breaking page.
- */
-
-// export async function getServerSideProps(context) {
-//   const apolloClient = initializeApollo();
-
-//   await apolloClient.query({
-//     query: GET_CONTENT_ITEM,
-//     variables: { itemId: getItemId(context.params.title) },
-//   });
-
-//   return {
-//     props: {
-//       initialApolloState: apolloClient.cache.extract(),
-//     },
-//   };
-// }

--- a/pages/studies/[title].js
+++ b/pages/studies/[title].js
@@ -33,7 +33,7 @@ export async function getStaticPaths() {
   const titles = [];
 
   return {
-    paths: titles.map(title => `locations/${title}`),
+    paths: titles.map(title => `studies/${title}`),
     // Enable statically generating additional pages
     // For example: `/messages/another-great-sermon`
     fallback: true,
@@ -46,7 +46,7 @@ export async function getStaticProps({ params }) {
 
   await apolloClient.query({
     query: GET_CONTENT_ITEM,
-    variables: { pathname: `locations/${params.title}` },
+    variables: { pathname: `studies/${params.title}` },
   });
 
   // Pass post data to the page via props


### PR DESCRIPTION
### About
The pre-rendering methods (getStaticPaths and getStaticProps) were copied from Messages, Events, and title.js pages to articles, locations, studies pages. 
