### PR TITLE
Update GroupsResultsList.js

### DIFF
--- a/components/GroupsResultsList/GroupsResultsList.js
+++ b/components/GroupsResultsList/GroupsResultsList.js
@@ -102,7 +102,7 @@ function GroupsResultsList(props = {}) {
               action: group?.action,
               relatedNode: group?.relatedNode,
               modalProps: {
-                leaderName: group?.leaders[0].firstName,
+                leaderName: group?.leaders[0]?.firstName,
                 leaderAvatar: group?.leaders[0]?.photo?.uri,
                 width: utils.rem('450px'),
               },


### PR DESCRIPTION
Patches an error where Groups with no leaders were breaking when you would press "Contact"