### PR TITLE
Content item search schema update

### DIFF
--- a/components/DiscoverItemsList/DiscoverItemsList.js
+++ b/components/DiscoverItemsList/DiscoverItemsList.js
@@ -6,7 +6,11 @@ import { getUrlFromRelatedNode } from 'utils';
 import { Box, CardGrid, DefaultCard, Loader } from 'ui-kit';
 import { CustomLink } from 'components';
 
+import useFeatureAction from 'hooks/useFeatureAction';
+
 function DiscoverItemsList(props = {}) {
+  const [onPressActionItem] = useFeatureAction();
+
   if (props.loading) return <Loader text="Loading your items" />;
 
   const noContentItems = props.data.length === 0;
@@ -22,11 +26,20 @@ function DiscoverItemsList(props = {}) {
           boxShadow="none"
           coverImage={contentItem?.coverImage?.sources[0]?.uri}
           description={contentItem?.summary}
-          href={getUrlFromRelatedNode(contentItem?.node)}
+          href={getUrlFromRelatedNode({
+            ...contentItem?.relatedNode,
+            routing: contentItem?.routing,
+          })}
           key={contentItem?.id}
           scaleCard={false}
           scaleCoverImage={true}
           title={contentItem?.title}
+          onClick={e =>
+            onPressActionItem(e, {
+              action: contentItem?.action,
+              relatedNode: contentItem?.relatedNode,
+            })
+          }
         />
       ))}
     </CardGrid>

--- a/hooks/useSearchContentItems.js
+++ b/hooks/useSearchContentItems.js
@@ -9,6 +9,7 @@ export const SEARCH_CONTENT_ITEMS = gql`
         endCursor
       }
       edges {
+        id
         cursor
         title
         summary
@@ -17,26 +18,32 @@ export const SEARCH_CONTENT_ITEMS = gql`
             uri
           }
         }
-        node {
-          ... on ContentItem {
-            id
-            __typename
-          }
-          ... on NodeRoute {
-            routing {
-              pathname
-            }
+
+        relatedNode {
+          id
+
+          ... on Url {
+            url
           }
         }
+        action
+
+        ...contentSearchResultNodeFragment
       }
+    }
+  }
+
+  fragment contentSearchResultNodeFragment on ContentItemSearchResult {
+    routing {
+      pathname
     }
   }
 `;
 
 function useSearchContentItems(options = {}) {
   const [search, query] = useLazyQuery(SEARCH_CONTENT_ITEMS, {
-    fetchPolicy: 'cache-and-network',
     ...options,
+    fetchPolicy: 'no-cache',
   });
 
   return [


### PR DESCRIPTION
### About
This PR updates the Content Item Search to pull in `action` and `relatedNode` from the search query in order to take advantage of the `useFeatureAction` hook so that we can route Search Results the same way that we do for Feature Feeds.

Practically, this PR enables us to open up both Content Items and Urls inside of Search.

Update Content Search Hook to support new ContentType
Search Results now uses useFeatureAction

### Test Instructions & Demo
https://www.loom.com/share/197f903a7b694ea39ac5be683493b457

### Closes Tickets


### Related Tickets
[CFDP-1562]


[CFDP-1562]: https://christfellowshipchurch.atlassian.net/browse/CFDP-1562