### PR TITLE
Fixed Prayer card and Avatar component

### DIFF
--- a/ui-kit/Avatar/Avatar.js
+++ b/ui-kit/Avatar/Avatar.js
@@ -14,7 +14,7 @@ function Avatar(props = {}) {
   if (!props.src || error) {
     return (
       <Box
-        bg="subdued"
+        bg="neutrals.600"
         borderRadius="50%"
         height={props.height}
         width={props.width}

--- a/ui-kit/Avatar/Avatar.styles.js
+++ b/ui-kit/Avatar/Avatar.styles.js
@@ -4,6 +4,7 @@ import { system } from 'ui-kit';
 
 const Avatar = styled.img`
   border-radius: 50%;
+  object-fit: cover;
 
   ${system}
 `;

--- a/ui-kit/PrayerCard/PrayerCard.js
+++ b/ui-kit/PrayerCard/PrayerCard.js
@@ -25,7 +25,12 @@ const PrayerCard = (props = {}) => {
             </Box>
           )}
           {props?.coverImage && (
-            <Avatar src={props?.coverImage} maxWidth="20%" />
+            <Avatar
+              src={props?.coverImage}
+              objectFit="cover"
+              height="60px"
+              width="60px"
+            />
           )}
         </Box>
 


### PR DESCRIPTION
### About
The avatars in the PrayerCards on the `/connect` page were displaying in an odd shape, this PR fixes the `PrayerCard` and `Avatar` component and removes the bug on `/connect`.

### Test Instructions
* Login
* Go to `/connect` and look at the PrayerCards.

### Screenshots
| Before  | After |
| ------------- | ------------- |
| ![image](https://user-images.githubusercontent.com/46049974/129033941-3a295f7d-5a02-462c-9ffe-d3124cc9196e.png)  | ![image](https://user-images.githubusercontent.com/46049974/129033851-4c489be5-a06a-4aea-93d4-8321fa30e211.png) |


### Closes Tickets
[CFDP-1630]