### PR TITLE
Only renders the Video button on Group Preference if a `uri` exists

### DIFF
--- a/components/CommunitySingle/VideoPlayButton.js
+++ b/components/CommunitySingle/VideoPlayButton.js
@@ -1,10 +1,12 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import camelCase from 'lodash/camelCase';
+import isEmpty from 'lodash/isEmpty';
 
 import { Box, Button, Icon } from 'ui-kit';
 import { useModalDispatch, showModal } from 'providers/ModalProvider';
 
+// todo : the quickest way to ship this feature was to hardcode these values. A more elegant solution should be worked out at some point in the future.
 const VIDEO_URI = {
   sisterhood:
     'https://link.theplatform.com/s/IfSiAC/media/gMIs5lxTQwK1/file.m3u8?format=redirect&formats=m3u,mpeg4',
@@ -20,21 +22,38 @@ const VIDEO_URI = {
     'https://link.theplatform.com/s/IfSiAC/media/ulPNeyTh2y55/file.m3u8?format=redirect&formats=m3u,mpeg4',
 };
 
-function VideoPlayButton(props = {}) {
+/**
+ * Convenience hook that returns the onClick method for the Video Button.
+ *
+ * @param {string} uri    | The uri of the video that you want played
+ * @param {string} poster | The uri of the poster image for the video
+ * @returns {array}       | Function that runs on click
+ */
+function useHandleButtonClick(uri, poster) {
   const modalDispatch = useModalDispatch();
 
-  function handleOnClick() {
+  const method = () => {
+    if (isEmpty(uri)) return;
+
     modalDispatch(
       showModal('Video', {
         step: 0,
-        uri: VIDEO_URI[camelCase(props?.title)],
-        poster: props?.poster,
+        uri,
+        poster,
       })
     );
-  }
+  };
+
+  return [method];
+}
+function VideoPlayButton(props = {}) {
+  const videoUri = VIDEO_URI[camelCase(props?.title)];
+  const [onClick] = useHandleButtonClick(videoUri, props?.poster);
+
+  if (isEmpty(videoUri)) return null;
 
   return (
-    <Button variant="tertiary" rounded={true} onClick={handleOnClick}>
+    <Button variant="tertiary" rounded={true} onClick={onClick}>
       <Box display="flex" alignItems="center" justifyContent="space-between">
         <Icon name="play" mr="s" />
         {`Watch Video`}


### PR DESCRIPTION
### About
On a Group Hub, users should not see a “Play Video” button when there is no video associated with the Hub

### Test Instructions
Navigate to `/groups`
Click on the “Classes” hub
A “Play Video” button should _not_ show up

### Screenshots
| Crew : with video | Classes : without video |
| --- | --- |
| ![Screen Shot 2021-08-11 at 9 54 45 AM](https://user-images.githubusercontent.com/45076058/129042168-b725f823-1352-4934-8e83-f863306c8f7d.png) | ![Screen Shot 2021-08-11 at 9 54 20 AM](https://user-images.githubusercontent.com/45076058/129042162-e9278f51-2eac-4a9e-a6a0-8fb9b508bc78.png) |

### Closes Tickets
[CFDP-1628]

### Related Tickets



[CFDP-1628]: https://christfellowshipchurch.atlassian.net/browse/CFDP-1628