### PR TITLE
Updates the merging of `edges` in Search Queries

### DIFF
--- a/lib/apolloClient/initCache.js
+++ b/lib/apolloClient/initCache.js
@@ -24,10 +24,7 @@ const initCache = initialState => {
                 ...existing,
                 totalResults: incoming.totalResults,
                 pageInfo: incoming.pageInfo,
-                edges: uniqBy(
-                  existing.edges.concat(incoming.edges),
-                  'node.__ref'
-                ),
+                edges: [...existing?.edges, ...incoming?.edges],
               };
             },
           },


### PR DESCRIPTION
### About
There was an error on the Group Finder where "Load More" was not properly working. This was because the cache merge method for Group Search was commented out (oops! my bad).

This PR enables the cache merge method, again, and also resolves an issue where the existing and incoming results were not getting merged together properly.

### Test Instructions
Navigate to `/groups/search` and scroll to the bottom of the page. You should see the results expand to 42 results.

### Screenshots
| Current | Patch |
| --- | --- |
| ![Screen Shot 2021-08-12 at 12 30 03 PM](https://user-images.githubusercontent.com/45076058/129233579-1c5018a7-45b7-46be-ab9e-654f95d83933.png) | ![Screen Shot 2021-08-12 at 12 29 40 PM](https://user-images.githubusercontent.com/45076058/129233575-2364fe84-6345-4548-9ea6-89df1e5caec1.png) |

### Closes Tickets
[CFDP-1636]

[CFDP-1636]: https://christfellowshipchurch.atlassian.net/browse/CFDP-1636