### PR TITLE
Adds the dateTime back to the Group Finder Card

### DIFF
--- a/components/GroupsResultsList/GroupsResultsList.js
+++ b/components/GroupsResultsList/GroupsResultsList.js
@@ -91,6 +91,7 @@ function GroupsResultsList(props = {}) {
           campus={group?.campusName}
           coverImage={group.coverImage?.sources[0]?.uri}
           meetingDay={group.meetingDay}
+          dateTime={group?.dateTime}
           heroAvatars={group?.leaders?.map(node => ({ node }))}
           preferences={group?.preferences}
           subPreference={group.subPreferences.join(', ')}

--- a/hooks/useSearchGroups.js
+++ b/hooks/useSearchGroups.js
@@ -37,6 +37,7 @@ export const SEARCH_GROUPS = gql`
     meetingDay
     meetingType
     campusName
+    dateTime
     leaders {
       firstName
       lastName


### PR DESCRIPTION
### About
The `dateTime` has been added back to the resolver of the API. This front end patch includes 

### Test Instructions
Navigate to `/groups/search`

### Screenshots
![Screen Shot 2021-08-18 at 4 36 51 PM](https://user-images.githubusercontent.com/45076058/130077010-b9d4fee6-a6f2-416d-9685-22d057654b78.png)

### Closes Tickets
[CFDP-1637]