### PR TITLE
Updates default messaging for Group Cards

### DIFF
--- a/components/Modals/ConnectModal/ConnectForm.js
+++ b/components/Modals/ConnectModal/ConnectForm.js
@@ -6,7 +6,12 @@ import { showStep, hideModal, useModalDispatch } from 'providers/ModalProvider';
 
 import { useContactGroupLeader, useGroupMemberStatus } from 'hooks';
 
-import { Avatar, Box, Button, Loader } from 'ui-kit';
+import { Avatar, Box, Button, Icon, Loader } from 'ui-kit';
+import {
+  generateTitle,
+  generateSummary,
+  generateButtonTitle,
+} from './ConnectModal.utils';
 
 function ConnectForm(props = {}) {
   const { data, loading } = useGroupMemberStatus({
@@ -15,6 +20,7 @@ function ConnectForm(props = {}) {
       groupId: props?.groupId,
     },
   });
+  const hasLeader = !isEmpty(props.leaderName);
   const [status, setStatus] = useState('LOADING');
   const modalDispatch = useModalDispatch();
   const [contactGroupLeader] = useContactGroupLeader();
@@ -45,50 +51,6 @@ function ConnectForm(props = {}) {
     }
   };
 
-  const generateTitle = key => {
-    switch (key) {
-      case 'LOADING':
-        return 'Loading';
-      case 'FULL':
-        return 'Sorry, this group is now full.';
-      case 'PENDING':
-        return `${props.leaderName} will be in contact soon!`;
-      case 'MEMBER':
-        return `You're already a member of this group.`;
-      case 'OPEN':
-      default:
-        return `Connect with ${props.leaderName}`;
-    }
-  };
-
-  const generateSummary = key => {
-    switch (key) {
-      case 'OPEN':
-        return `Contact the leader to let them know you’re interested.`;
-      case 'PENDING':
-        return `Your status in this group is "pending".`;
-      case 'MEMBER':
-        return `Contact ${props.leaderName} if you have any questions.`;
-      case 'LOADING':
-      case 'FULL':
-      default:
-        return ``;
-    }
-  };
-
-  const generateButtonTitle = key => {
-    switch (key) {
-      case 'OPEN':
-        return `Send`;
-      case 'LOADING':
-      case 'PENDING':
-      case 'MEMBER':
-      case 'FULL':
-      default:
-        return `Find Another Group`;
-    }
-  };
-
   useEffect(() => {
     if (!loading && data?.groupMemberStatus) {
       const { groupMemberStatus } = data;
@@ -100,23 +62,27 @@ function ConnectForm(props = {}) {
   return (
     <Box display="flex" flexDirection="column">
       <Box display="flex" alignItems="center" flexDirection="column" mb="base">
-        <Avatar
-          src={props.leaderAvatar}
-          name={props.leaderName}
-          height="100px"
-          width="100px"
-        />
+        {hasLeader ? (
+          <Avatar
+            src={props.leaderAvatar}
+            name={props.leaderName}
+            height="100px"
+            width="100px"
+          />
+        ) : (
+          <Icon name="users" size={100} color="tertiary" />
+        )}
       </Box>
 
       <Box textAlign="center" as="h2">
         {status === 'LOADING' ? (
           <Loader justifyContent="center" />
         ) : (
-          generateTitle(status)
+          generateTitle(status, { leaderName: props?.leaderName })
         )}
       </Box>
       <Box textAlign="center" as="p" mb="l" px="m">
-        {generateSummary(status)}
+        {generateSummary(status, { leaderName: props?.leaderName })}
       </Box>
 
       {status !== 'MEMBER' && status !== 'PENDING' && status !== 'LOADING' && (
@@ -125,7 +91,7 @@ function ConnectForm(props = {}) {
           mb="base"
           status={status === 'LOADING' ? 'LOADING' : 'IDLE'}
         >
-          {generateButtonTitle(status)}
+          {generateButtonTitle(status, { leaderName: props?.leaderName })}
         </Button>
       )}
     </Box>

--- a/components/Modals/ConnectModal/ConnectModal.utils.js
+++ b/components/Modals/ConnectModal/ConnectModal.utils.js
@@ -1,0 +1,55 @@
+import isEmpty from 'lodash/isEmpty';
+
+export const generateTitle = (key, args) => {
+  const leaderName = args?.leaderName || '';
+  const hasLeader = !isEmpty(leaderName);
+
+  switch (key) {
+    case 'LOADING':
+      return 'Loading';
+    case 'FULL':
+      return 'Sorry, this group is now full.';
+    case 'PENDING':
+      return hasLeader
+        ? `${leaderName} will be in contact soon!`
+        : `You will be contacted soon!`;
+    case 'MEMBER':
+      return `You're already a member of this group.`;
+    case 'OPEN':
+    default:
+      return hasLeader ? `Connect with ${leaderName}` : 'Get connected!';
+  }
+};
+
+export const generateSummary = (key, args) => {
+  const leaderName = args?.leaderName || '';
+  const hasLeader = !isEmpty(leaderName);
+
+  switch (key) {
+    case 'OPEN':
+      return `Contact the leader to let them know you're interested.`;
+    case 'PENDING':
+      return `Your status in this group is "pending".`;
+    case 'MEMBER':
+      return hasLeader
+        ? `Contact ${leaderName} if you have any questions.`
+        : `Contact your leader if you have any questions.`;
+    case 'LOADING':
+    case 'FULL':
+    default:
+      return ``;
+  }
+};
+
+export const generateButtonTitle = key => {
+  switch (key) {
+    case 'OPEN':
+      return `Send`;
+    case 'LOADING':
+    case 'PENDING':
+    case 'MEMBER':
+    case 'FULL':
+    default:
+      return `Find Another Group`;
+  }
+};

--- a/components/Modals/ConnectModal/__tests__/ConnectModal.utils.tests.js
+++ b/components/Modals/ConnectModal/__tests__/ConnectModal.utils.tests.js
@@ -1,0 +1,153 @@
+import {
+  generateTitle,
+  generateSummary,
+  generateButtonTitle,
+} from '../ConnectModal.utils';
+
+const mockWithLeader = {
+  leaderName: 'Ted',
+};
+
+const mockWithoutLeader = {
+  leaderName: '',
+};
+
+describe('generateTitle', () => {
+  it('returns a string for "LOADING" key', () => {
+    const result = generateTitle('LOADING', mockWithLeader);
+
+    expect(result).toBe('Loading');
+  });
+
+  it('returns a string for "FULL" key', () => {
+    const result = generateTitle('FULL', mockWithLeader);
+
+    expect(result).toBe('Sorry, this group is now full.');
+  });
+
+  it('returns a string for "PENDING" key', () => {
+    const result = generateTitle('PENDING', mockWithLeader);
+
+    expect(result).toBe('Ted will be in contact soon!');
+  });
+
+  it('returns a string for "PENDING" key without a leader', () => {
+    const result = generateTitle('PENDING', mockWithoutLeader);
+
+    expect(result).toBe('You will be contacted soon!');
+  });
+
+  it('returns a string for "MEMBER" key', () => {
+    const result = generateTitle('MEMBER', mockWithLeader);
+
+    expect(result).toBe("You're already a member of this group.");
+  });
+
+  it('returns a string for "OPEN" key', () => {
+    const result = generateTitle('OPEN', mockWithLeader);
+
+    expect(result).toBe('Connect with Ted');
+  });
+
+  it('returns a string for "OPEN" key without a leader', () => {
+    const result = generateTitle('OPEN', mockWithoutLeader);
+
+    expect(result).toBe('Get connected!');
+  });
+
+  it('returns a default string value', () => {
+    const result = generateTitle('some reandom value', mockWithLeader);
+
+    expect(result).toBe('Connect with Ted');
+  });
+
+  it('returns a default string value without a leader', () => {
+    const result = generateTitle('some reandom value', mockWithoutLeader);
+
+    expect(result).toBe('Get connected!');
+  });
+});
+
+describe('generateSummary', () => {
+  it('returns a string for "LOADING" key', () => {
+    const result = generateSummary('LOADING', mockWithLeader);
+
+    expect(result).toBe('');
+  });
+
+  it('returns a string for "FULL" key', () => {
+    const result = generateSummary('FULL', mockWithLeader);
+
+    expect(result).toBe('');
+  });
+
+  it('returns a string for "PENDING" key', () => {
+    const result = generateSummary('PENDING', mockWithLeader);
+
+    expect(result).toBe('Your status in this group is "pending".');
+  });
+
+  it('returns a string for "MEMBER" key', () => {
+    const result = generateSummary('MEMBER', mockWithLeader);
+
+    expect(result).toBe('Contact Ted if you have any questions.');
+  });
+
+  it('returns a string for "MEMBER" key without a leader', () => {
+    const result = generateSummary('MEMBER', mockWithoutLeader);
+
+    expect(result).toBe('Contact your leader if you have any questions.');
+  });
+
+  it('returns a string for "OPEN" key', () => {
+    const result = generateSummary('OPEN', mockWithLeader);
+
+    expect(result).toBe(
+      "Contact the leader to let them know you're interested."
+    );
+  });
+
+  it('returns a default string value', () => {
+    const result = generateSummary('some random value', mockWithLeader);
+
+    expect(result).toBe('');
+  });
+});
+
+describe('generateButtonTitle', () => {
+  it('returns a string for "LOADING" key', () => {
+    const result = generateButtonTitle('LOADING', mockWithLeader);
+
+    expect(result).toBe('Find Another Group');
+  });
+
+  it('returns a string for "FULL" key', () => {
+    const result = generateButtonTitle('FULL', mockWithLeader);
+
+    expect(result).toBe('Find Another Group');
+  });
+
+  it('returns a string for "PENDING" key', () => {
+    const result = generateButtonTitle('PENDING', mockWithLeader);
+
+    expect(result).toBe('Find Another Group');
+  });
+
+  it('returns a string for "MEMBER" key', () => {
+    const result = generateButtonTitle('MEMBER', mockWithLeader);
+
+    expect(result).toBe('Find Another Group');
+  });
+
+  it('returns a string for "OPEN" key', () => {
+    const result = generateButtonTitle('OPEN', mockWithLeader);
+
+    expect(result).toBe('Send');
+  });
+
+  it('returns a default string value', () => {
+    const result = generateButtonTitle('some random value', mockWithLeader);
+
+    expect(result).toBe('Find Another Group');
+  });
+});


### PR DESCRIPTION
### About
When a Group on the Group Finder does not have a Group Leader, we want to display a contextually relevant message.

### Test Instructions
Load up the Group Finder
Search around until you find a Group that does not have any Leaders visible on the card
Press "Contact"

### Tests Written
Yes! I moved all of the text generation methods over to a `utils.js` so that we could test them.

### Screenshots
| Current | Updated |
| --- | --- |
| ![Screen Shot 2021-09-01 at 3 36 43 PM](https://user-images.githubusercontent.com/45076058/131862942-027d3fc0-acb4-4968-b549-2971bc405d6c.png) | ![Screen Shot 2021-09-02 at 9 43 13 AM](https://user-images.githubusercontent.com/45076058/131862973-02c0f7f0-c4e4-4988-b34d-892dfe4706f2.png) |

### Closes Tickets
[CFDP-1689]