### PR TITLE
Updated the header image for About page

### DIFF
--- a/pages/about/About.styles.js
+++ b/pages/about/About.styles.js
@@ -14,7 +14,7 @@ const Hero = styled.div`
       rgba(000, 000, 000, 0.3) 0%,
       rgba(000, 000, 000, 0.6) 100%
     ),
-    url(about/about-christ-fellowship-church.jpg);
+    url(about/Christ-Fellowship-Church-Locations.jpeg);
   background-position: center;
   background-size: cover;
   color: ${themeGet('colors.white')} ${system};

--- a/pages/about/index.js
+++ b/pages/about/index.js
@@ -30,15 +30,11 @@ export default function About() {
         </Styled.Hero>
         <Styled.Section>
           <Box as="h1">One Church with Many Locations</Box>
-          <Box as="p" mb="xl" fontSize="l" maxWidth="840px">
+          <Box as="p" fontSize="l" maxWidth="840px">
             We believe that church isn’t just a building you walk in to, but a
             family you can belong to—so whether you call one of our many
             locations home or join from home, church is wherever you&nbsp;are!
           </Box>
-          <Image
-            maxWidth="800px"
-            source={'about/Christ-Fellowship-Church-Locations.jpeg'}
-          />
         </Styled.Section>
         <List
           display="flex"


### PR DESCRIPTION
### About
This PR updates the header image for the About page.

### Test Instructions
Open the About page 
The page should look like the screenshot below with the cross equals love picture as the header image 

### Screenshots
Mobile 
<img width="317" alt="Screen Shot 2021-09-16 at 2 54 47 PM" src="https://user-images.githubusercontent.com/46769629/133669701-f8fa6483-877b-4d71-aa4a-5864c90f9cbe.png">

Web 
<img width="1436" alt="Screen Shot 2021-09-16 at 2 52 55 PM" src="https://user-images.githubusercontent.com/46769629/133669712-80816cdc-9400-4e9f-bd2f-baecad685dba.png">

### Closes Tickets
[CFDP-1693](https://christfellowshipchurch.atlassian.net/browse/CFDP-1693)

### Related Tickets
N/A
