### PR TITLE
Update AddToCalendar.js

### DIFF
--- a/components/AddToCalendar/AddToCalendar.js
+++ b/components/AddToCalendar/AddToCalendar.js
@@ -90,4 +90,5 @@ AddToCalendar.defaultProps = {
   alternateDescription: 'Join us for an event at Christ Fellowship!',
 };
 
-export default AddToCalendar;
+// todo : resolve the error being caused by this
+export default () => null;


### PR DESCRIPTION
There is an error being thrown on some groups caused by the AddToCalendar button.

Until we can get into the details of it and fix the issue, this PR hides the button.