### PR TITLE
Added filter to check for valid `eventGroupings`

### DIFF
--- a/components/EventSingle/EventGroupings/EventGroupings.js
+++ b/components/EventSingle/EventGroupings/EventGroupings.js
@@ -17,9 +17,15 @@ const EventGroupings = (props = {}) => {
     }
   }, [setValues, props.data.eventGroupings]);
 
+  // note : Checks to make sure there is a valid instance of each grouping, if not that means the grouping's date is invalid and should not show
+  const isValidGrouping = groupings =>
+    groupings.filter(group => group?.instances.length > 0);
+
+  const eventGroupings = isValidGrouping(props.data?.eventGroupings);
+
   return (
     <Box as="form" onSubmit={handleSubmit}>
-      {props.data?.eventGroupings?.length > 0 && (
+      {eventGroupings?.length > 0 && (
         <Card
           boxShadow="base"
           display="flex"
@@ -29,7 +35,7 @@ const EventGroupings = (props = {}) => {
           p={{ _: 's', md: 'base' }}
         >
           <Select
-            defaultValue={props.data?.eventGroupings[0]?.name}
+            defaultValue={eventGroupings[0]?.name}
             id="campusSelect"
             mb={selectedGroup?.instances?.length > 0 ? 'base' : '0'}
             name="campusSelect"
@@ -38,7 +44,7 @@ const EventGroupings = (props = {}) => {
             <Select.Option value="" disabled={true}>
               Select a campus...
             </Select.Option>
-            {props.data?.eventGroupings?.map(({ name }) => {
+            {eventGroupings?.map(({ name }) => {
               return (
                 <Select.Option key={name} value={name}>
                   {name}


### PR DESCRIPTION
### About
On our website, our Event content items were showing `eventGroupings` that contained expired dates. This PR adds a check to `EventGroupings.js` to make sure each grouping inside of `eventGroupings` has a valid instance and does not display if the date has expired.

### Test Instructions
* Go to `/events/christ-fellowship-kids-worship` to see that the expired dates are not longer showing.
* You can also go to `/events/24-hour-live-stream` to see an example event with one expired date and one non-expired date. It should only show one option in the dropdown.

### Screenshots
|Before|After|
|----|----|
|![image](https://user-images.githubusercontent.com/46049974/134972178-d2622f3b-6ee4-405c-b06d-64b39398e876.png)|![image](https://user-images.githubusercontent.com/46049974/134972242-b092d246-bc2e-4910-ba51-1f02138f70e2.png)|


### Closes Tickets
CFDP-1705
