### PR TITLE
Added So Good Sisterhood URL

### DIFF
--- a/pages/so-good-sisterhood/[title].js
+++ b/pages/so-good-sisterhood/[title].js
@@ -1,0 +1,61 @@
+import { useRouter } from 'next/router';
+import { ContentItemProvider } from 'providers';
+import { ContentSingle, Layout } from 'components';
+
+import { GET_CONTENT_ITEM } from 'hooks/useContentItem';
+import { initializeApollo } from 'lib/apolloClient';
+
+function getItemId(slug) {
+  const id = slug.split('-').pop();
+  return `MediaContentItem:${id}`;
+}
+
+export default function Article(props) {
+  const router = useRouter();
+  const { title } = router.query;
+
+  const options = {
+    variables: {
+      pathname: `so-good-sisterhood/${title}`,
+    },
+  };
+
+  return (
+    <Layout title={title}>
+      <ContentItemProvider Component={ContentSingle} options={options} />
+    </Layout>
+  );
+}
+
+// This function gets called at build time to generate the titles for _all_ messages
+export async function getStaticPaths() {
+  // todo : make this a Network request so that it's dynamic
+  const titles = [];
+
+  return {
+    paths: titles.map(title => `so-good-sisterhood/${title}`),
+    // Enable statically generating additional pages
+    // For example: `/messages/another-great-sermon`
+    fallback: true,
+  };
+}
+
+// This also gets called at build time
+export async function getStaticProps({ params }) {
+  const apolloClient = initializeApollo();
+
+  await apolloClient.query({
+    query: GET_CONTENT_ITEM,
+    variables: { pathname: `so-good-sisterhood/${params.title}` },
+  });
+
+  // Pass post data to the page via props
+  return {
+    props: {
+      initialApolloState: apolloClient.cache.extract(),
+    },
+    // Re-generate the post at most once per second
+    // if a request comes in
+    revalidate: 1,
+  };
+}

--- a/pages/so-good-sisterhood/index.js
+++ b/pages/so-good-sisterhood/index.js
@@ -1,0 +1,46 @@
+import React from 'react';
+import { kebabCase, toLower, capitalize } from 'lodash';
+
+import { initializeApollo } from 'lib/apolloClient';
+import { GET_CONTENT_ITEM } from 'hooks/useContentItem';
+import { FeatureFeedProvider, ContentItemProvider } from 'providers';
+import { Layout, FeatureFeed, PageSingle } from 'components';
+
+// note : We need to create this file to make sure the URL still pulls in the correct Page Builder page for So Good Sisterhood
+
+export default function SoGoodSisterhoodPage() {
+  const title = 'so-good-sisterhood';
+  const formatTitleAsUrl = title => kebabCase(toLower(title));
+
+  const options = {
+    variables: {
+      pathname: title,
+    },
+  };
+
+  if (title && title.length) {
+    return <ContentItemProvider Component={PageSingle} options={options} />;
+  }
+
+  return (
+    <Layout title={capitalize(title)}>
+      <FeatureFeedProvider Component={FeatureFeed} options={options} />
+    </Layout>
+  );
+}
+
+export async function getStaticProps() {
+  const apolloClient = initializeApollo();
+
+  await apolloClient.query({
+    query: GET_CONTENT_ITEM,
+    variables: { pathname: 'so-good-sisterhood' },
+  });
+
+  return {
+    props: {
+      initialApolloState: apolloClient.cache.extract(),
+    },
+    revalidate: 1,
+  };
+}


### PR DESCRIPTION
### About
We needed to add a new URL endpoint for the So Good Sisterhood URL. This PR adds a Page Builder page for the `/so-good-sisterhood` page and a URL endpoint for the So Good Sisterhood content channel.

### Test Instructions
* Run the api PR branch locally: https://github.com/christfellowshipchurch/apollos-api/pull/337
* Load `/so-good-sisterhood` and `/so-good-sisterhood/sisterhood-demo`

### Screenshots
![image](https://user-images.githubusercontent.com/46049974/137192516-a90df961-48b1-4b53-8e64-a09e8fa2c133.png)
![image](https://user-images.githubusercontent.com/46049974/137192575-d58b5fe2-36c3-4bea-a935-080eb38db66d.png)

### Closes Tickets
[CFDP-1733]
