### PR TITLE
Update getUrlFromRelatedNode.js

### DIFF
--- a/utils/getUrlFromRelatedNode.js
+++ b/utils/getUrlFromRelatedNode.js
@@ -10,6 +10,9 @@ function getUrlFromRelatedNode(relatedNode) {
   }
 
   if (relatedNode?.routing?.pathname) {
+    if (relatedNode?.routing?.pathname?.startsWith('http')) {
+      return relatedNode?.routing?.pathname;
+    }
     return `/${relatedNode?.routing?.pathname}`;
   }
 


### PR DESCRIPTION
### About
Adds a check for the `getUrlFromRelatedNode` method to check for external URLs that contain `http`.

### Test Instructions
* Run the api branch https://github.com/christfellowshipchurch/apollos-api/pull/345 locally
* Go to homepage and click in the first card inside Relevant Messages.
