### PR TITLE
Single Card Format for VerticalCardList

### DIFF
--- a/components/VerticalCardListFeature/VerticalCardListFeature.js
+++ b/components/VerticalCardListFeature/VerticalCardListFeature.js
@@ -35,7 +35,7 @@ function VerticalCardListFeature(props = {}) {
                 coverImageOverlay={true}
                 title={card?.title}
                 description={card?.summary}
-                type="HIGHLIGHT_SMALL"
+                type={cards.length < 2 ? 'DEFAULT' : 'HIGHLIGHT_SMALL'}
                 label={transformISODates(card?.labelText)}
               />
             </Styled.CardSpacing>
@@ -48,11 +48,11 @@ function VerticalCardListFeature(props = {}) {
 
 VerticalCardListFeature.propTypes = {
   data: PropTypes.object,
-  Component: PropTypes.any
+  Component: PropTypes.any,
 };
 
 VerticalCardListFeature.defaultProps = {
-  Component: HorizontalHighlightCard
-}
+  Component: HorizontalHighlightCard,
+};
 
 export default VerticalCardListFeature;


### PR DESCRIPTION
### About
This PR adjusts the card size for the `VerticalCardListFeature` when there is only card to the `DEFAULT`  size so that the card will display a `16:9` format.

### Test Instructions
* run this branch locally
* go to `/pams-test` and scroll to bottom to see the "test one item" feature.

### Screenshots
![image](https://user-images.githubusercontent.com/46049974/141321561-ac4ce30e-a141-444e-9450-76ba988d2bb5.png)

### Closes Tickets
[CFDP-1811]


[CFDP-1811]: https://christfellowshipchurch.atlassian.net/browse/CFDP-1811?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ