### PR TITLE
Fixed loading page margin on web mobile and changed text to Loading

### DIFF
--- a/providers/ContentItemProvider.js
+++ b/providers/ContentItemProvider.js
@@ -9,7 +9,7 @@ function ContentItemProvider({ Component, options, ...props }) {
   const { loading, error, item } = useContentItem(options);
 
   if (loading) {
-    return <Loader m="xxl" centered text="Loading" />;
+    return <Loader mt="xxl" mb="xxl" centered text="Loading" />;
   }
 
   if (!item) {

--- a/providers/ContentItemProvider.js
+++ b/providers/ContentItemProvider.js
@@ -9,7 +9,7 @@ function ContentItemProvider({ Component, options, ...props }) {
   const { loading, error, item } = useContentItem(options);
 
   if (loading) {
-    return <Loader mt="xxl" centered text="Loading Event" />;
+    return <Loader m="xxl" centered text="Loading" />;
   }
 
   if (!item) {


### PR DESCRIPTION
### About
Fixed loading page margin on web mobile and changed text to Loading

### Test Instructions
Open the So Good Sisterhood page 
Open one of the episodes
Loading page should look like screenshot below: correct margin and it only says "Loading" vs "Loading Event" 

### Screenshots
Before
<img width="584" alt="Screen Shot 2021-11-18 at 12 36 48 PM" src="https://user-images.githubusercontent.com/46769629/142467385-abf080d8-a91f-466f-8ea2-18533c90ec23.png">

After
<img width="598" alt="Screen Shot 2021-11-18 at 12 30 02 PM" src="https://user-images.githubusercontent.com/46769629/142467069-57e65f3d-419a-481e-97f9-77295bf72721.png">

### Closes Tickets
[CFDP-1822](https://christfellowshipchurch.atlassian.net/jira/software/projects/CFDP/boards/2?selectedIssue=CFDP-1822)

