### PR TITLE
Fixed `<p>` Spacing in HTML Content

### DIFF
--- a/ui-kit/HtmlRenderer/HtmlRenderer.styles.js
+++ b/ui-kit/HtmlRenderer/HtmlRenderer.styles.js
@@ -1,34 +1,37 @@
 import styled, { css } from 'styled-components';
 import { themeGet } from '@styled-system/theme-get';
 import { system } from 'ui-kit';
-import { primaryHover } from 'ui-kit/Button/Button.styles'
+import { primaryHover } from 'ui-kit/Button/Button.styles';
 
 const HtmlRenderer = styled.div`
-    > ul,
-    > ol {
-        margin-left: ${themeGet('space.base')};
-    }
+  > ul,
+  > ol {
+    margin-left: ${themeGet('space.base')};
+  }
 
-    a {
-        color: ${themeGet('colors.primary')};
-        
-        &:active,
-        &:focus,
-        &:hover {
-            color: ${primaryHover};
-        }
-    }
+  a {
+    color: ${themeGet('colors.primary')};
 
-    p:not(:first-child) {
-        margin-top: ${themeGet('space.base')};
-        margin-bottom: ${themeGet('space.base')};
+    &:active,
+    &:focus,
+    &:hover {
+      color: ${primaryHover};
     }
+  }
 
-    img {
-        border-radius: ${themeGet('radii.base')};
-    }
+  p:not(:first-child) {
+    margin-top: ${themeGet('space.base')};
+  }
 
-    ${system};
+  p:not(:last-child) {
+    margin-bottom: ${themeGet('space.base')};
+  }
+
+  img {
+    border-radius: ${themeGet('radii.base')};
+  }
+
+  ${system};
 `;
 
 export default HtmlRenderer;

--- a/ui-kit/HtmlRenderer/HtmlRenderer.styles.js
+++ b/ui-kit/HtmlRenderer/HtmlRenderer.styles.js
@@ -6,12 +6,12 @@ import { primaryHover } from 'ui-kit/Button/Button.styles';
 const HtmlRenderer = styled.div`
   > ul,
   > ol {
-    margin-left: ${themeGet('space.base')};
+      margin-left: ${themeGet('space.base')};
   }
-
+  
   a {
     color: ${themeGet('colors.primary')};
-
+    
     &:active,
     &:focus,
     &:hover {
@@ -19,12 +19,17 @@ const HtmlRenderer = styled.div`
     }
   }
 
-  p:not(:first-child) {
-    margin-top: ${themeGet('space.base')};
-  }
-
-  p:not(:last-child) {
-    margin-bottom: ${themeGet('space.base')};
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6,
+  p {
+    &:not(:first-child) {
+      margin-top: ${themeGet('space.base')};
+      margin-bottom: ${themeGet('space.base')};
+    }
   }
 
   img {


### PR DESCRIPTION
### About
We needed bottom margin for the top paragraph(`<p>`) in a podcast article. This PR updates the styled component around the `HtmlRenderer` so that the all the first child has `top-margin` and all but the last child has `bottom-margin` for the `<p>` to fix and avoid spacing issues.

### Test Instructions
* run web locally
* go to `/so-good-sisterhood/episode-four`

I have went through other articles as well to make sure this does not break other items, but feel free to look through as many other articles as well.

### Screenshots
![image](https://user-images.githubusercontent.com/46049974/143902436-f88a7939-8d85-46f3-858e-a8ec008f34bb.png)