### PR TITLE
Forces a 16:9 aspect ratio on all Content Single videos

### DIFF
--- a/components/ContentSingle/ContentSingle.styles.js
+++ b/components/ContentSingle/ContentSingle.styles.js
@@ -15,10 +15,13 @@ const VideoContainer = styled.div`
   margin-bottom: ${themeGet('space.base')};
   border-radius: ${themeGet('radii.base')};
   overflow: hidden;
+  position: relative;
+  padding-top: 56.25%; /* Player ratio: 100 / (1280 / 720) */
 
-  & > .shaka-video-container {
-    height: 100%;
-    width: 100%;
+  .react-player {
+    position: absolute;
+    top: 0;
+    left: 0;
   }
 `;
 

--- a/components/Video/Video.js
+++ b/components/Video/Video.js
@@ -21,7 +21,7 @@ export default function Video(props = {}) {
   const notPlaying = () => setIsPlaying(false);
 
   return (
-    <Box position="relative" height="100%" width="100%">
+    <Box position="relative" height="100%" width="100%" className='react-player'>
       <ReactPlayer
         url={props?.src}
         controls={true}


### PR DESCRIPTION
### About
Resolves an issue where the aspect ratio of the video was being used by the Cover Image of the video, too
| Old        | New |
| --- | --- |
| ![Screen Shot 2021-12-01 at 10 40 19 AM](https://user-images.githubusercontent.com/45076058/144265722-c230028f-7321-4f22-91d5-a5961ccdb6d1.png) | ![Screen Shot 2021-12-01 at 10 40 24 AM](https://user-images.githubusercontent.com/45076058/144265765-f86ed7fa-4c0f-4d5d-89dc-a36b0c9b2e09.png) |

### Test Instructions
Test out `devotionals/december-1-countdown-to-christmas` in order to see this in action

### Closes Tickets
[CFDP-1847]

[CFDP-1847]: https://christfellowshipchurch.atlassian.net/browse/CFDP-1847?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ