### PR TITLE
Removes the callback from the Track Event

### DIFF
--- a/providers/AnalyticsProvider.js
+++ b/providers/AnalyticsProvider.js
@@ -141,12 +141,7 @@ const AnalyticsProvider = ({ children }) => {
             .logEvent(
                 event?.key,
                 event?.props,
-                () => {
-                    dispatchEvent({ ...event, processed: true })
-                    if (event?.optCallback && typeof event?.optCallback === "function") {
-                        event?.optCallback()
-                    }
-                },
+                () => dispatchEvent({ ...event, processed: true }),
                 (e) => console.warn("Error", { e })
             )
     }
@@ -230,11 +225,10 @@ const AnalyticsProvider = ({ children }) => {
 
     return <AnalyticsContext.Provider 
         value={{
-            trackEvent: (key, props, optCallback) => dispatchEvent({ 
+            trackEvent: (key, props) => dispatchEvent({ 
                 processed: false, 
                 key, 
-                props,
-                optCallback
+                props
             }),
             eventKeys: EVENT_KEYS,
             trackingDisabled: _isNotValidClient || !amplitudeJS || !fingerprintJS || !isReady.all

--- a/ui-kit/Button/Button.js
+++ b/ui-kit/Button/Button.js
@@ -32,7 +32,7 @@ function childrenIcons(children) {
   return null
 }
 function Button(props = {}) {
-  const { trackEvent, eventKeys, trackingDisabled } = useAnalytics()
+  const { trackEvent, eventKeys } = useAnalytics()
 
   if (props.status === 'LOADING') {
     return (
@@ -52,23 +52,20 @@ function Button(props = {}) {
         }
       }
 
-      if (trackingDisabled) {
-        handleClick()
-        return
-      }
-
       if (!isEmpty(props?.href)) {
         trackEvent(eventKeys.openLink, {
           text: childrenText(props?.children),
           icon: childrenIcons(props?.children),
           link: props?.href,
-        }, handleClick)
+        })
       } else {
         trackEvent(eventKeys.clickButton, {
           text: childrenText(props?.children),
           icon: childrenIcons(props?.children),
-        }, handleClick)
+        })
       }
+
+      handleClick()
     }}
   />;
 }


### PR DESCRIPTION
Analytic events should be fired off in the background instead of after analytics are collected