### PR TITLE
Updated CollectionPreview to use title set in Rock

### DIFF
--- a/components/CollectionPreview/CollectionPreview.js
+++ b/components/CollectionPreview/CollectionPreview.js
@@ -17,29 +17,30 @@ import { CustomLink } from 'components';
 
 const CollectionPreview = ({
   contentId,
-  title,
-  center,
   summary,
   cardType,
   hideButton,
   buttonOverride,
 }) => {
   const router = useRouter();
-  const { contentItems, loading } = useDiscoverFilterCategoriesPreview({
-    variables: { id: contentId, first: 3 },
-  });
+  const { categoryTitle, contentItems, loading } =
+    useDiscoverFilterCategoriesPreview({
+      variables: { id: contentId, first: 3 },
+    });
+
+  console.log({ contentItems });
 
   const handleSeeMore = event => {
     const [type, id] = contentId.split(':');
 
     event.preventDefault();
-    router.push(`/discover/${slugify(title)}?id=${slugify(id)}`);
+    router.push(`/discover/${slugify(categoryTitle)}?id=${slugify(id)}`);
   };
 
   return (
     <Box>
       <Box color="secondary" textAlign={'center'} as="h1" mb="l">
-        {title}
+        {categoryTitle}
       </Box>
       {summary && (
         <Box
@@ -95,7 +96,6 @@ const CollectionPreview = ({
 
 CollectionPreview.propTypes = {
   contentId: PropTypes.string,
-  title: PropTypes.string,
   buttonOverride: PropTypes.string,
 };
 

--- a/components/CollectionPreview/CollectionPreview.js
+++ b/components/CollectionPreview/CollectionPreview.js
@@ -28,8 +28,6 @@ const CollectionPreview = ({
       variables: { id: contentId, first: 3 },
     });
 
-  console.log({ contentItems });
-
   const handleSeeMore = event => {
     const [type, id] = contentId.split(':');
 

--- a/pages/external-home.js
+++ b/pages/external-home.js
@@ -132,18 +132,16 @@ export default function ExternalLandingPage(props = {}) {
       <Box px="base" py={BASE_VERITCAL_PADDING} bg="neutrals.100">
         <Box mx="auto" maxWidth={1200}>
           <CollectionPreview
-            title="Relevant Messages"
             contentId="UniversalContentItem:e45a213bba4f171708ef051041a22046"
             buttonOverride="/discover/relevant-messages?id=47a5a31f61ac5a4fb65576d0d47564e0"
           />
         </Box>
       </Box>
 
-      {/* Events for You */}
+      {/* Just for You */}
       <Box px="base" py={BASE_VERITCAL_PADDING} bg="neutrals.100">
         <Box mx="auto" maxWidth={1200}>
           <CollectionPreview
-            title="Events for You"
             contentId="UniversalContentItem:d29e24e1873b0c4f4f645218ca3338ea"
             buttonOverride="/events"
           />


### PR DESCRIPTION
### About
This PR updates the CollectionPreview to use title set in Rock. Due to the marketing team updating the title for these items we want the changes they make in Rock to relfect on the website.

### Test Instructions
* go to external home and see the new title for the Events collection.

### Screenshots
![image](https://user-images.githubusercontent.com/46049974/144925173-70aeb3ae-76a3-4453-829a-f5090e38758c.png)

