### PR TITLE
Feature email composer confirmation

### DIFF
--- a/components/GroupEmailComposer/GroupEmailComposer.js
+++ b/components/GroupEmailComposer/GroupEmailComposer.js
@@ -8,14 +8,11 @@
  */
 
 import React, { useState } from 'react';
-import PropTypes from 'prop-types';
 import { useRouter } from 'next/router';
 import take from 'lodash/take'
-import { slugify } from 'utils';
 
 import { useModalDispatch, showModal } from 'providers/ModalProvider';
-import { CustomLink } from 'components';
-import { Box, Button, Card, Icon, RichTextEditor, SquareAvatar, TextArea } from 'ui-kit'
+import { Box, Button, Card, Icon, RichTextEditor, SquareAvatar } from 'ui-kit'
 
 import Styled from './GroupEmailComposer.styles'
 

--- a/components/GroupEmailComposer/GroupEmailComposer.js
+++ b/components/GroupEmailComposer/GroupEmailComposer.js
@@ -7,13 +7,14 @@
  * Email composer for a specified Group.
  */
 
-import React from 'react';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import take from 'lodash/take'
 import { slugify } from 'utils';
 
-import { Box, Button, Card, Icon, SquareAvatar, TextArea } from 'ui-kit'
+import { useModalDispatch, showModal } from 'providers/ModalProvider';
 import { CustomLink } from 'components';
+import { Box, Button, Card, Icon, SquareAvatar, TextArea } from 'ui-kit'
 
 import Styled from './GroupEmailComposer.styles'
 
@@ -33,6 +34,8 @@ const StyledCard = (props) => <Card
 />
 
 const GroupEmailComposer = (props = {}) => {
+    const modalDispatch = useModalDispatch();
+    const [submitting, setSubmitting] = useState(false)
     const fromEmail = "my.email@domain.com"
     // Recipients
     const recipients = [
@@ -61,6 +64,20 @@ const GroupEmailComposer = (props = {}) => {
         { type: "image", src: "https://picsum.photos/200" },
     ]
     const visibleAttachments = take(attachments, 5)
+    const disabled = submitting;
+
+    const handleSubmit = () => {
+        if (submitting) return
+
+        setSubmitting(true)
+        
+        setTimeout(() => {
+            modalDispatch(showModal("GroupEmailComposerConfirmation", { 
+                memberCount: recipients?.length ?? 0 
+            }))
+            setSubmitting(false)
+        }, 1000);
+    }
 
     return <Box>
         <Box 
@@ -73,7 +90,10 @@ const GroupEmailComposer = (props = {}) => {
             mb={{ _: "s", md: "l"}}
         >
             <Box flex="1">
-                <CustomLink href={`/group/${slugify(props?.data?.title)}`}>
+                <CustomLink 
+                    href={`/group/${slugify(props?.data?.title)}`} 
+                    disabled={disabled}
+                >
                     &larr; Back
                 </CustomLink>
                 <Box as="h1">{props?.data?.title}</Box>
@@ -88,9 +108,11 @@ const GroupEmailComposer = (props = {}) => {
             >
                 <Button
                     size="s"
-                    onClick={() => console.log("SEND EMAIL")}
+                    onClick={handleSubmit}
+                    status={submitting ? "LOADING" : "IDLE"}
+                    disabled={disabled}
                 >
-                    <Icon name="paperPlane" size="18px" /> Send
+                    {!submitting && <Icon name="paperPlane" size="18px" />} Send
                 </Button>
             </Box>
         </Box>
@@ -126,6 +148,7 @@ const GroupEmailComposer = (props = {}) => {
                         variant="link"
                         size="s"
                         margin="0"
+                        disabled={disabled}
                     >
                         {`${recipients?.length > 0 ? "Edit" : "Select"} Recipients`}
                     </Button>
@@ -177,6 +200,7 @@ const GroupEmailComposer = (props = {}) => {
                         variant="link"
                         size="s"
                         margin="0"
+                        disabled={disabled}
                     >
                         {`${attachments?.length > 0 ? "Edit" : "Select"} Attachments`}
                     </Button>
@@ -219,6 +243,7 @@ const GroupEmailComposer = (props = {}) => {
                 >
                     <Styled.SubjectInput 
                         placeholder="Subject"
+                        disabled={disabled}
                     />
                 </Box>
 

--- a/components/Modals/GroupEmailComposerConfirmationModal/GroupEmailComposerConfirmationModal.js
+++ b/components/Modals/GroupEmailComposerConfirmationModal/GroupEmailComposerConfirmationModal.js
@@ -1,0 +1,56 @@
+/**
+ * GroupEmailComposerConfirmationModal.js
+ * 
+ * Author: Caleb Panza
+ * Created: Dec 08, 2021
+ * 
+ * Confirmation message for the Group Email Composer component
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import { useRouter } from 'next/router';
+
+import { Box, Button, Icon, Modal } from 'ui-kit';
+
+const GroupEmailComposerConfirmationModal = ({ memberCount }) => {
+    const router = useRouter();
+    const handleClose = () => router.back()
+
+    return <Modal
+        onClose={handleClose}
+        width="280px"
+    >
+        <Box 
+            display="flex"
+            flexDirection="column"
+            gridGap="1rem"
+            textAlign="center"
+        >
+            <Icon 
+                name="paper-plane" 
+                color="success" 
+                size="5rem"
+            />
+
+            <Box as="h3">
+                Email successfully sent{memberCount > 0 ? ` to ${memberCount} members` : ""}
+            </Box>
+
+            <Button
+                onClick={handleClose}
+            >
+                Done
+            </Button>
+        </Box>
+    </Modal>
+};
+
+GroupEmailComposerConfirmationModal.propTypes = {
+    memberCount: PropTypes.number
+}
+GroupEmailComposerConfirmationModal.defaultProps = {
+    memberCount: 0
+}
+
+export default GroupEmailComposerConfirmationModal;

--- a/components/Modals/GroupEmailComposerConfirmationModal/GroupEmailComposerConfirmationModal.js
+++ b/components/Modals/GroupEmailComposerConfirmationModal/GroupEmailComposerConfirmationModal.js
@@ -10,12 +10,18 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { useRouter } from 'next/router';
+import { useModalDispatch, hideModal } from 'providers/ModalProvider';
 
 import { Box, Button, Icon, Modal } from 'ui-kit';
 
 const GroupEmailComposerConfirmationModal = ({ memberCount }) => {
     const router = useRouter();
-    const handleClose = () => router.back()
+    const modalDispatch = useModalDispatch();
+    const handleClose = () => {
+        const cleanPath = router.asPath.split("/")
+
+        router.push(cleanPath.filter(p => p !== "email").join("/"))
+    }
 
     return <Modal
         onClose={handleClose}
@@ -38,7 +44,10 @@ const GroupEmailComposerConfirmationModal = ({ memberCount }) => {
             </Box>
 
             <Button
-                onClick={handleClose}
+                onClick={() => {
+                    modalDispatch(hideModal())
+                    handleClose()
+                }}
             >
                 Done
             </Button>

--- a/components/Modals/GroupEmailComposerConfirmationModal/index.js
+++ b/components/Modals/GroupEmailComposerConfirmationModal/index.js
@@ -1,0 +1,3 @@
+import GroupEmailComposerConfirmationModal from "./GroupEmailComposerConfirmationModal";
+
+export default GroupEmailComposerConfirmationModal;

--- a/components/Modals/index.js
+++ b/components/Modals/index.js
@@ -2,6 +2,7 @@ import AddGroupMemberModal from './AddGroupMemberModal';
 import AuthModal from './AuthModal';
 import ConnectModal from './ConnectModal';
 import GroupDetailsModal from './GroupDetailsModal';
+import GroupEmailComposerConfirmationModal from './GroupEmailComposerConfirmationModal'
 import GroupFilterModal from './GroupFilterModal';
 import GroupMemberDetailsModal from './GroupMemberDetailsModal';
 import GroupNotifyMeModal from './GroupNotifyMeModal';
@@ -14,6 +15,7 @@ export {
   AuthModal,
   ConnectModal,
   GroupDetailsModal,
+  GroupEmailComposerConfirmationModal,
   GroupFilterModal,
   GroupMemberDetailsModal,
   GroupNotifyMeModal,

--- a/config/modals.js
+++ b/config/modals.js
@@ -4,6 +4,7 @@ import {
   AuthModal,
   ConnectModal,
   GroupDetailsModal,
+  GroupEmailComposerConfirmationModal,
   GroupFilterModal,
   GroupMemberDetailsModal,
   GroupNotifyMeModal,
@@ -32,6 +33,10 @@ const modals = [
   {
     title: 'GroupDetails',
     component: GroupDetailsModal,
+  },
+  {
+    title: "GroupEmailComposerConfirmation",
+    component: GroupEmailComposerConfirmationModal
   },
   {
     title: 'GroupFilter',


### PR DESCRIPTION
### About
When you click on the "Send" button on the Group Email Composer, it will disable all inputs and display a loading indicator within the button in place of the paper plane icon.

When the message successfully sends, it will display a modal that shows the number of recipients of the email.

Clicking the "X" on the modal or the "Done" button will navigate the user back to the previous screen

### Test Instructions
Navigate to `/group/{{ group name }}/email` and press the "Send" button

### Screenshots
| Desktop | Mobile |
| --- | --- |
| ![Screen Shot 2021-12-09 at 8 30 46 AM](https://user-images.githubusercontent.com/45076058/145406714-01b8def1-8182-41bb-bd8c-b1cf3a4f3ba8.png) | ![Screen Shot 2021-12-09 at 8 31 03 AM](https://user-images.githubusercontent.com/45076058/145406795-01e83c12-b865-4955-9a7c-3d11fbde57a2.png) |

### Closes Tickets
[CFDP-1878]


[CFDP-1878]: https://christfellowshipchurch.atlassian.net/browse/CFDP-1878?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ