### PR TITLE
Fixed Baptism Redirect

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -42,7 +42,7 @@ module.exports = {
       },
       {
         source: '/baptism',
-        destination: '/baptism-faqs',
+        destination: '/articles/baptism-faqs',
         permanent: true,
       },
       // TODO: Uncomment these lines to hide Group Finder.

--- a/public/_redirects
+++ b/public/_redirects
@@ -5,4 +5,4 @@
 /group                                  /groups
 /community/:title                       /groups/:title
 /items/42eda0fe3fbf3f200a2872df727d4440 /groups
-/baptism                                /baptism-faqs
+/baptism                                /articles/baptism-faqs


### PR DESCRIPTION
### About
`/baptism` was pointing to the wrong url. This PR updates it to point to the correct URL.

NOTE: The old direct will be cached, so your cache must be cleared or use incognito to test.

### Test Instructions
* go to `/baptism` in incognito.

### Screenshots
![image](https://user-images.githubusercontent.com/46049974/145482733-22f92488-e59a-4e4b-b911-b612e0e11607.png)

### Closes Tickets
[CFDP-1850]


[CFDP-1850]: https://christfellowshipchurch.atlassian.net/browse/CFDP-1850?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ