### PR TITLE
Temporarily adds back the Group Leader Toolbox link

### DIFF
--- a/components/CommunityLeaderActions/CommunityLeaderActions.js
+++ b/components/CommunityLeaderActions/CommunityLeaderActions.js
@@ -31,7 +31,7 @@ export default function CommunityLeaderActions(props) {
         display="grid"
         px={{ _: 'base', md: 'xxl' }}
         py={{ _: 'l', md: 'xxl' }}
-        gridTemplateColumns={{ _: 'repeat(1, 1fr)', md: 'repeat(2, 1fr)' }}
+        gridTemplateColumns={{ _: 'repeat(1, 1fr)', md: 'repeat(3, 1fr)' }}
         gridColumnGap="l"
         textAlign="center"
       >
@@ -72,6 +72,27 @@ export default function CommunityLeaderActions(props) {
               rounded={true}
             >
               Learn More
+            </Button>
+          </Box>
+        </Box>
+
+        <Box mb={{ _: 'xl', md: 0 }}>
+          <Icon name="book" size="40" mb="s" color="subdued" />
+          <Box>
+            <Box as="h2" mb="s">
+              Toolbox Resources
+            </Box>
+            <Box as="p" mb="base">
+              Access all your leader and member resources.
+            </Box>
+            <Button
+              as="a"
+              size="s"
+              variant="secondary"
+              href="https://rock.christfellowship.church/myaccount"
+              rounded={true}
+            >
+              Access Toolbox
             </Button>
           </Box>
         </Box>


### PR DESCRIPTION
### About
Group leaders still need to be able to access the Group Leader toolbox until they are trained in the new one. This PR temporarily adds back the link to the bottom of the `/groups` page