### PR TITLE
Created modal for error message

### DIFF
--- a/components/Modals/GroupEmailConfirmationModal/GroupEmailConfirmationModal.js
+++ b/components/Modals/GroupEmailConfirmationModal/GroupEmailConfirmationModal.js
@@ -18,9 +18,9 @@ function GroupEmailConfirmationModal(props = {}) {
       <Icon
         name={props?.status === 'SUCCESS' ? 'paperPlane' : 'x'}
         color={props?.status === 'SUCCESS' ? 'success' : 'alert'}
-        size="72"
+        size="70"
       />
-      <Box as="h1" mt="base">
+      <Box as="h3" m="l">
         {props?.statusMessage}
       </Box>
 


### PR DESCRIPTION
### About
This PR displays a user friendly modal to show the error that does not allow leaders to change their own status on a group. 

### Test Instructions
Go to a group where you're a leader and try changing your own status, it should display an error/modal as seen on screenshot below.

### Screenshots
<img width="1440" alt="Screen Shot 2022-01-05 at 3 55 04 PM" src="https://user-images.githubusercontent.com/46769629/148288191-faf1217b-cd08-4c3d-b5b5-308e066ad042.png">

<img width="382" alt="Screen Shot 2022-01-05 at 3 55 11 PM" src="https://user-images.githubusercontent.com/46769629/148288195-772c30a5-af60-4db2-ad78-a248215727fd.png">

### Closes Tickets
[CFDP-1913](https://christfellowshipchurch.atlassian.net/browse/CFDP-1913)

### Related Tickets
N/A
