### PR TITLE
deleted toolbox resources

### DIFF
--- a/components/CommunityLeaderActions/CommunityLeaderActions.js
+++ b/components/CommunityLeaderActions/CommunityLeaderActions.js
@@ -31,7 +31,7 @@ export default function CommunityLeaderActions(props) {
         display="grid"
         px={{ _: 'base', md: 'xxl' }}
         py={{ _: 'l', md: 'xxl' }}
-        gridTemplateColumns={{ _: 'repeat(1, 1fr)', md: 'repeat(3, 1fr)' }}
+        gridTemplateColumns={{ _: 'repeat(1, 1fr)', md: 'repeat(2, 1fr)' }}
         gridColumnGap="l"
         textAlign="center"
       >
@@ -72,27 +72,6 @@ export default function CommunityLeaderActions(props) {
               rounded={true}
             >
               Learn More
-            </Button>
-          </Box>
-        </Box>
-
-        <Box mb={{ _: 'xl', md: 0 }}>
-          <Icon name="book" size="40" mb="s" color="subdued" />
-          <Box>
-            <Box as="h2" mb="s">
-              Toolbox Resources
-            </Box>
-            <Box as="p" mb="base">
-              Access all your leader and member resources.
-            </Box>
-            <Button
-              as="a"
-              size="s"
-              variant="secondary"
-              href="https://rock.christfellowship.church/myaccount"
-              rounded={true}
-            >
-              Access Toolbox
             </Button>
           </Box>
         </Box>


### PR DESCRIPTION
### About
Deleted Toolbox Resources from /groups

### Test Instructions
Open /groups and you won't see it. 

### Screenshots
<img width="1428" alt="Screen Shot 2022-01-05 at 3 59 24 PM" src="https://user-images.githubusercontent.com/46769629/148289079-aec9490b-f3bd-459a-8c03-3934352d5f69.png">

### Closes Tickets
N/A

### Related Tickets
N/A
