### PR TITLE
Removed pagination for the time being

### DIFF
--- a/pages/discover/index.js
+++ b/pages/discover/index.js
@@ -17,7 +17,7 @@ import {
   DiscoverFiltersCategoriesProvider,
 } from 'providers';
 
-const PAGE_SIZE = 21;
+const PAGE_SIZE = 100;
 
 const Discover = () => {
   const router = useRouter();
@@ -47,16 +47,17 @@ const Discover = () => {
   const showEmptyState = !loading && !hasResults;
   const hasMorePages = contentItems?.length < data?.search?.totalResults;
 
-  const handleLoadMore = () => {
-    if (!loading && hasMorePages) {
-      fetchMore({
-        variables: {
-          first: PAGE_SIZE,
-          after: data?.search?.pageInfo?.endCursor,
-        },
-      });
-    }
-  };
+  // NOT IN USE FOR NOW 
+  // const handleLoadMore = () => {
+  //   if (!loading && hasMorePages) {
+  //     fetchMore({
+  //       variables: {
+  //         first: PAGE_SIZE,
+  //         after: data?.search?.pageInfo?.endCursor,
+  //       },
+  //     });
+  //   }
+  // };
 
   const handleClick = event => {
     setSearchVisible(true);
@@ -171,13 +172,14 @@ const Discover = () => {
             <Loader />
           </Box>
         )}
+        {/* NOT IN USE FOR NOW 
         {!loading && hasMorePages && searchVisible && (
           <Box display="flex" justifyContent="center" mt="xl">
             <Button variant="tertiary" onClick={handleLoadMore}>
               Load more
             </Button>
           </Box>
-        )}
+        )} */}
 
         {!loading && !searchVisible && (
           <Box>


### PR DESCRIPTION
### About
This PR removes the pagination of the results of a search on the /discover page 

The main issue with this ticket comes from a pagination function called fetchMore that is part of the Apollo Client API, after researching the Apollo Cache and following the documentation it seems like the behavior is still finicky, so we decided to remove pagination for the time being and show 100 items when a search is performed.

The Load More button is temporarily removed as well. 

### Test Instructions
Go to /discover
Search for something, for example "love"
You should see 100 cards, no more no less, and no Load more button

### Screenshots
<img width="1431" alt="Screen Shot 2022-01-10 at 3 29 10 PM" src="https://user-images.githubusercontent.com/46769629/148834717-6cdadb70-9b52-4d1f-b2f5-8efe709bc34d.png">

### Closes Tickets
[CFDP-1888](https://christfellowshipchurch.atlassian.net/jira/software/projects/CFDP/boards/2?selectedIssue=CFDP-1888)

### Related Tickets
N/A
