### PR TITLE
Limits emails to 10,000 characters

### DIFF
--- a/components/GroupEmailComposer/GroupEmailComposer.js
+++ b/components/GroupEmailComposer/GroupEmailComposer.js
@@ -15,6 +15,7 @@ import isEmpty from 'lodash/isEmpty';
 import { useModalDispatch, showModal } from 'providers/ModalProvider';
 import { useSendGroupEmail } from 'hooks';
 import { Box, Button, Card, Icon, RichTextEditor } from 'ui-kit';
+import { sanitizeAllTags } from 'utils/sanitizeHtml'
 
 import Styled from './GroupEmailComposer.styles';
 import AvatarRow from './AvatarRow';
@@ -56,7 +57,11 @@ const GroupEmailComposer = (props = {}) => {
   const [statusMessage, setStatusMessage] = useState('STATUS MESSAGE');
   const fromEmail = currentUser?.profile?.email;
   const allSelected = recipients.length >= groupMembers?.length;
-  const disabled = submitting || isEmpty(emailBody) || recipients?.length < 1;
+  const bodyExceedsCharacterCount = sanitizeAllTags(emailBody).length > 10000
+  const disabled = submitting 
+    || isEmpty(emailBody) 
+    || recipients?.length < 1
+    || bodyExceedsCharacterCount;
   const groupId = props?.data?.id;
 
   const [sendEmailMutation] = useSendGroupEmail();
@@ -223,6 +228,16 @@ const GroupEmailComposer = (props = {}) => {
                 onChange={e => setEmailSubject(e.target.value)}
               />
             </Box>
+
+            {bodyExceedsCharacterCount && <Box
+              position="relative"
+              color="danger"
+              my="base"
+            >
+              <Box as="i" color="alert">
+                We're unable to send your email because it exceeds 10,000 characters. Please shorten and try again.
+              </Box>
+            </Box>}
 
             <Box position="relative" mt="base">
               <RichTextEditor value={emailBody} onChange={setEmailBody} />

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "react-player": "^2.9.0",
     "react-quill": "^1.3.5",
     "react-simple-typewriter": "^3.0.0",
+    "sanitize-html": "^2.7.0",
     "storybook": "^6.3.7",
     "stream-chat": "3.1.x",
     "stream-chat-react": "^4.1.3",

--- a/utils/sanitizeHtml.js
+++ b/utils/sanitizeHtml.js
@@ -1,0 +1,12 @@
+import sanitizeHtml from 'sanitize-html';
+
+/**
+ * Accepts a string of HTML and removes all tags so you're left with just the raw text.
+ * @param {string} dirty - HTML that should be sanitized
+ * @returns {string}
+ */
+export function sanitizeAllTags(dirty) {
+    return sanitizeHtml(dirty, {
+      allowedTags: [],
+    });
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -7856,7 +7856,7 @@ htmlparser2@^5.0:
     domutils "^2.4.2"
     entities "^2.0.0"
 
-htmlparser2@^6.1.0:
+htmlparser2@^6.0.0, htmlparser2@^6.1.0:
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-6.1.0.tgz#c4d762b6c3371a05dbe65e94ae43a9f845fb8fb7"
   integrity sha512-gyyPk6rgonLFEDGoeRgQNaEUvdJ4ktTmmUh/h2t7s+M8oPpIPxgNACWa+6ESR57kXstwqPiCut0V8NRpcwgU7A==
@@ -8446,6 +8446,11 @@ is-plain-object@^2.0.3, is-plain-object@^2.0.4:
   integrity sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==
   dependencies:
     isobject "^3.0.1"
+
+is-plain-object@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/is-plain-object/-/is-plain-object-5.0.0.tgz#4427f50ab3429e9025ea7d52e9043a9ef4159344"
+  integrity sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==
 
 is-potential-custom-element-name@^1.0.1:
   version "1.0.1"
@@ -10053,6 +10058,11 @@ nanoid@^3.1.23:
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.1.25.tgz#09ca32747c0e543f0e1814b7d3793477f9c8e152"
   integrity sha512-rdwtIXaXCLFAQbnfqDRnI6jaRHp9fTcYBjtFKE8eezcZ7LuLjhUaQGNeMXf1HmRoCH32CLz6XwX0TtxEOS/A3Q==
 
+nanoid@^3.2.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.0.tgz#5906f776fd886c66c24f3653e0c46fcb1d4ad6b0"
+  integrity sha512-JzxqqT5u/x+/KOFSd7JP15DOo9nOoHpx6DYatqIHUW2+flybkm+mdcraotSQR5WcnZr+qhGVh8Ted0KdfSMxlg==
+
 nanomatch@^1.2.9:
   version "1.2.13"
   resolved "https://registry.yarnpkg.com/nanomatch/-/nanomatch-1.2.13.tgz#b87a8aa4fc0de8fe6be88895b38983ff265bd119"
@@ -10732,6 +10742,11 @@ parse-json@^5.0.0:
     json-parse-even-better-errors "^2.3.0"
     lines-and-columns "^1.1.6"
 
+parse-srcset@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/parse-srcset/-/parse-srcset-1.0.2.tgz#f2bd221f6cc970a938d88556abc589caaaa2bde1"
+  integrity sha1-8r0iH2zJcKk42IVWq8WJyqqiveE=
+
 parse5@6.0.1, parse5@^6.0.0:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/parse5/-/parse5-6.0.1.tgz#e1a1c085c569b3dc08321184f19a39cc27f7c30b"
@@ -10842,6 +10857,11 @@ performance-now@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
   integrity sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=
+
+picocolors@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.0.0.tgz#cb5bdc74ff3f51892236eaf79d68bc44564ab81c"
+  integrity sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==
 
 picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.2.3, picomatch@^2.3.0:
   version "2.3.0"
@@ -11049,6 +11069,15 @@ postcss@^8.2.15:
     colorette "^1.2.2"
     nanoid "^3.1.23"
     source-map-js "^0.6.2"
+
+postcss@^8.3.11:
+  version "8.4.6"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.4.6.tgz#c5ff3c3c457a23864f32cb45ac9b741498a09ae1"
+  integrity sha512-OovjwIzs9Te46vlEx7+uXB0PLijpwjXGKXjVGGPIGubGpq7uh5Xgf6D6FiJ/SzJMBosHDp6a2hiXOS97iBXcaA==
+  dependencies:
+    nanoid "^3.2.0"
+    picocolors "^1.0.0"
+    source-map-js "^1.0.2"
 
 prelude-ls@^1.2.1:
   version "1.2.1"
@@ -12412,6 +12441,18 @@ sane@^4.0.3:
     minimist "^1.1.1"
     walker "~1.0.5"
 
+sanitize-html@^2.7.0:
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/sanitize-html/-/sanitize-html-2.7.0.tgz#e106205b468aca932e2f9baf241f24660d34e279"
+  integrity sha512-jfQelabOn5voO7FAfnQF7v+jsA6z9zC/O4ec0z3E35XPEtHYJT/OdUziVWlKW4irCr2kXaQAyXTXDHWAibg1tA==
+  dependencies:
+    deepmerge "^4.2.2"
+    escape-string-regexp "^4.0.0"
+    htmlparser2 "^6.0.0"
+    is-plain-object "^5.0.0"
+    parse-srcset "^1.0.2"
+    postcss "^8.3.11"
+
 saxes@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/saxes/-/saxes-5.0.1.tgz#eebab953fa3b7608dbe94e5dadb15c888fa6696d"
@@ -12733,6 +12774,11 @@ source-map-js@^0.6.2:
   version "0.6.2"
   resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-0.6.2.tgz#0bb5de631b41cfbda6cfba8bd05a80efdfd2385e"
   integrity sha512-/3GptzWzu0+0MBQFrDKzw/DvvMTUORvgY6k6jd/VS6iCR4RDTKWH6v6WPwQoUO8667uQEf9Oe38DxAYWY5F/Ug==
+
+source-map-js@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.0.2.tgz#adbc361d9c62df380125e7f161f71c826f1e490c"
+  integrity sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==
 
 source-map-resolve@^0.5.0:
   version "0.5.3"


### PR DESCRIPTION
### About
We want to limit emails sent from our group email composer to 10,000 characters. As users type, we strip all HTML tags from the input and display an error message when the characters typed exceeds 10,000.

### Test Instructions
Type 10,000 characters into the email composer. You'll see the error message show up at 10,001

### Screenshots
| Valid Input | Invalid Input |
| --- | --- |
| ![Screen Shot 2022-02-16 at 4 27 03 PM](https://user-images.githubusercontent.com/45076058/154360785-d2f30945-008a-4815-8475-0de79755fc79.png) | ![Screen Shot 2022-02-16 at 4 27 12 PM](https://user-images.githubusercontent.com/45076058/154360790-ab7527d0-c812-4dc5-922c-42b033120de5.png) |

### Closes Tickets
[CFDP-1986]

### Related Tickets
[CFDP-1985]
[CFDP-1987]

[CFDP-1986]: https://christfellowshipchurch.atlassian.net/browse/CFDP-1986?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CFDP-1985]: https://christfellowshipchurch.atlassian.net/browse/CFDP-1985?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CFDP-1987]: https://christfellowshipchurch.atlassian.net/browse/CFDP-1987?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ