### PR TITLE
Sisterhood Link Tree

### DIFF
--- a/hooks/useLinkTree.js
+++ b/hooks/useLinkTree.js
@@ -2,8 +2,8 @@ import { useQuery } from '@apollo/client';
 import gql from 'graphql-tag';
 
 export const GET_LINK_TREE = gql`
-  query getLinkTree {
-    linkTree {
+  query getLinkTree($pathname: String!) {
+    linkTree(pathname: $pathname) {
       title
       action
       relatedNode {
@@ -21,6 +21,8 @@ const useLinkTree = options => {
     fetchPolicy: 'network-only',
     ...options,
   });
+
+  console.log({ query });
 
   return query;
 };

--- a/next.config.js
+++ b/next.config.js
@@ -1,7 +1,7 @@
 module.exports = {
   i18n: {
-    locales: ["en"],
-    defaultLocale: "en",
+    locales: ['en'],
+    defaultLocale: 'en',
   },
   images: {
     domains: ['cloudfront.christfellowship.church'],
@@ -52,6 +52,16 @@ module.exports = {
       {
         source: '/articles/boca-raton-heart-for-the-house',
         destination: '/locations/boca-raton',
+        permanent: true,
+      },
+      {
+        source: '/info',
+        destination: '/link-tree/info',
+        permanent: true,
+      },
+      {
+        source: '/sisterhood-night',
+        destination: '/link-tree/sisterhood-night',
         permanent: true,
       },
       // TODO: Uncomment these lines to hide Group Finder.

--- a/pages/link-tree/[title].js
+++ b/pages/link-tree/[title].js
@@ -1,13 +1,19 @@
-import { format } from 'date-fns';
-
+import { useRouter } from 'next/router';
 import { useLinkTree } from 'hooks';
-import { slugify, parseLiveStreamDates } from 'utils';
 
 import { Box, Cell, ContentBlock, Loader, utils } from 'ui-kit';
 import { Layout } from 'components';
 
 export default function Info(props = {}) {
-  const { loading, data } = useLinkTree();
+  const router = useRouter();
+  const { title } = router.query;
+
+  const options = {
+    variables: {
+      pathname: title,
+    },
+  };
+  const { loading, data } = useLinkTree(options);
 
   if (loading) {
     return (

--- a/pages/link-tree/index.js
+++ b/pages/link-tree/index.js
@@ -1,0 +1,43 @@
+import { useLinkTree } from 'hooks';
+
+import { Box, Cell, ContentBlock, Loader, utils } from 'ui-kit';
+import { Layout } from 'components';
+
+export default function Info(props = {}) {
+  const options = {
+    variables: {
+      pathname: 'info',
+    },
+  };
+  const { loading, data } = useLinkTree(options);
+
+  if (loading) {
+    return (
+      <Box
+        display="flex"
+        justifyContent="center"
+        alignContent="center"
+        alignItems="center"
+        width="100%"
+        minHeight="50vh"
+      >
+        <Loader />
+      </Box>
+    );
+  }
+
+  const actions = data?.linkTree;
+
+  return (
+    <Layout title="Link Tree">
+      <Cell
+        as="main"
+        maxWidth={utils.rem('1100px')}
+        px="base"
+        py={{ _: 'l', lg: 'xl' }}
+      >
+        <ContentBlock actions={actions} />
+      </Cell>
+    </Layout>
+  );
+}

--- a/public/_redirects
+++ b/public/_redirects
@@ -6,3 +6,5 @@
 /community/:title                       /groups/:title
 /items/42eda0fe3fbf3f200a2872df727d4440 /groups
 /baptism                                /articles/baptism-faqs
+/info                                   /link-tree/info
+/sisterhood-night                       /link-tree/sisterhood-night


### PR DESCRIPTION
### About
Added the new query for `linkTree` and redirects for `/sisterhood-nights` and `/info` to point towards `/link-tree` pages.

### Test Instructions
* run web locally
* go to `/info` or `/sisterhood-nights`

### Screenshots
<img width="1375" alt="image" src="https://user-images.githubusercontent.com/46049974/166748922-cb995c80-0915-4426-8f4b-5610c74a077a.png">

### Closes Tickets
[CFDP-2081]

[CFDP-2081]: https://christfellowshipchurch.atlassian.net/browse/CFDP-2081?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ