### PR TITLE
Added Redirects for Communion Article

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -64,6 +64,18 @@ module.exports = {
         destination: '/link-tree/sisterhood-night',
         permanent: true,
       },
+      {
+        source:
+          '/content/how-to-lead-communion-in-your-home-3cbe3357238650b7bbf3011f2356fb57',
+        destination: '/articles/how-to-lead-communion-in-your-home',
+        permanent: true,
+      },
+      {
+        source:
+          '/items/how-to-lead-communion-in-your-home-3cbe3357238650b7bbf3011f2356fb57',
+        destination: '/articles/how-to-lead-communion-in-your-home',
+        permanent: true,
+      },
       // TODO: Uncomment these lines to hide Group Finder.
       // NOTE: We can't get `config/flags` in this file.
       // {

--- a/public/_redirects
+++ b/public/_redirects
@@ -8,3 +8,6 @@
 /baptism                                /articles/baptism-faqs
 /info                                   /link-tree/info
 /sisterhood-night                       /link-tree/sisterhood-night
+/sisterhood-night                       /link-tree/sisterhood-night
+/content/how-to-lead-communion-in-your-home-3cbe3357238650b7bbf3011f2356fb57 /articles/how-to-lead-communion-in-your-home
+/items/how-to-lead-communion-in-your-home-3cbe3357238650b7bbf3011f2356fb57 /articles/how-to-lead-communion-in-your-home


### PR DESCRIPTION
### About
This is just to add a redirect for an article that is being referenced incorrectly on Google.

### Closes Tickets
[CFDP-2090](https://christfellowshipchurch.atlassian.net/browse/CFDP-2090?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ)
