### PR TITLE
Hide Group Leader with No Photos

### DIFF
--- a/ui-kit/GroupCard/GroupCard.js
+++ b/ui-kit/GroupCard/GroupCard.js
@@ -56,7 +56,10 @@ const GroupCard = (props = {}) => {
   };
 
   const labelType = get(labelTypes, camelCase(props?.meetingType));
-  const heroAvatars = props.heroAvatars.slice(0, maxAvatars);
+  const heroAvatars = props.heroAvatars
+    .slice(0, maxAvatars)
+    // only show group leaders with photos
+    .filter(avatar => avatar?.photo?.uri);
   const renderDateTime = _props => {
     if (_props.dateTime) {
       return format(new Date(props.dateTime), "EEEE 'at' h:mm a");
@@ -76,20 +79,17 @@ const GroupCard = (props = {}) => {
                 <Icon size="18" name={labelType.icon} ml="xs" />
               </Styled.Label>
             )}
-            {/* Only shows group leaders with photos */}
             {heroAvatars ? (
-              heroAvatars.slice(0, maxAvatars).map((n, i) => {
-                n?.photo?.uri && (
-                  <SquareAvatar
-                    height={heroAvatars.length > 3 ? '80px' : '100px'}
-                    width={heroAvatars.length > 3 ? '60px' : '80px'}
-                    key={i}
-                    mr={props.heroAvatars.length > 1 ? 'xs' : null}
-                    name={`${n?.firstName} ${n?.lastName}`}
-                    src={n?.photo?.uri}
-                  />
-                );
-              })
+              heroAvatars.map((n, i) => (
+                <SquareAvatar
+                  height={heroAvatars.length > 3 ? '80px' : '100px'}
+                  width={heroAvatars.length > 3 ? '60px' : '80px'}
+                  key={i}
+                  mr={props.heroAvatars.length > 1 ? 'xs' : null}
+                  name={`${n?.firstName} ${n?.lastName}`}
+                  src={n?.photo?.uri}
+                />
+              ))
             ) : (
               <SquareAvatar
                 height="100px"


### PR DESCRIPTION
### About
This PR updates the search results in the Group Finder to hide group leaders who do not have a profile picture.

### Test Instructions
* run a local instance of the api in a with `CONTENT=stage`
* run this branch locally and search for any groups with a placeholder photo, you should see none.

### Screenshots
|Before|After|
|---|---|
|![image](https://user-images.githubusercontent.com/46049974/171673814-c22b73cc-d63f-4030-977b-caa38339cb6f.png)|![image](https://user-images.githubusercontent.com/46049974/171673918-7a41cf66-f4bf-4836-a56b-5697bf5bc866.png)|

### Related Tickets
[CFDP-2109]


[CFDP-2109]: https://christfellowshipchurch.atlassian.net/browse/CFDP-2109?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ