### PR TITLE
Blob breaking Add to Calendar - removing temporarily

### DIFF
--- a/components/AddToCalendar/utils.js
+++ b/components/AddToCalendar/utils.js
@@ -89,8 +89,6 @@ export const icsLink = event => {
     'END:VCALENDAR',
   ].join('\n');
 
-  //Although blob makes this method compatible with safari it makes it break for all other browsers so I'm removing it temporarily
-
   // We use blob method and removed `charset=utf8` in order to be compatible with Safari IOS
   let blob = new Blob([icsString], { type: 'text/calendar' });
   let calendarLink = window.URL.createObjectURL(blob);

--- a/components/AddToCalendar/utils.js
+++ b/components/AddToCalendar/utils.js
@@ -71,32 +71,29 @@ export const icsLink = event => {
     endTime = parseISO(endTime);
   }
 
-  return (
-    'data:text/calendar;charset=utf8,' +
-    [
-      'BEGIN:VCALENDAR',
-      'VERSION:2.0',
-      'PRODID:-//www.cf.church//Christ Fellowship Church',
-      'CALSCALE:GREGORIAN',
-      'BEGIN:VEVENT',
-      `DTSTAMP:${format(new Date(), 'yyyyMMddhhmmss')}Z`,
-      `UID:${uniqueId()}-@christfellowship.church`,
-      `DTSTART;TZID=America/New_York:${format(startTime, "yyyyMMdd'T'HHmmss")}`,
-      `DTEND;TZID=America/New_York:${format(endTime, "yyyyMMdd'T'HHmmss")}`,
-      `SUMMARY:${title}`,
-      `URL:${url ?? document?.URL ?? 'https://www.christfellowship.church'}`,
-      `DESCRIPTION:${description}`,
-      `LOCATION:${address}`,
-      'END:VEVENT',
-      'END:VCALENDAR',
-    ].join('\n')
-  );
+  const icsString = [
+    'BEGIN:VCALENDAR',
+    'VERSION:2.0',
+    'PRODID:-//www.cf.church//Christ Fellowship Church',
+    'CALSCALE:GREGORIAN',
+    'BEGIN:VEVENT',
+    `DTSTAMP:${format(new Date(), 'yyyyMMddhhmmss')}Z`,
+    `UID:${uniqueId()}-@christfellowship.church`,
+    `DTSTART;TZID=America/New_York:${format(startTime, "yyyyMMdd'T'HHmmss")}`,
+    `DTEND;TZID=America/New_York:${format(endTime, "yyyyMMdd'T'HHmmss")}`,
+    `SUMMARY:${title}`,
+    `URL:${url ?? document?.URL ?? 'https://www.christfellowship.church'}`,
+    `DESCRIPTION:${description}`,
+    `LOCATION:${address}`,
+    'END:VEVENT',
+    'END:VCALENDAR',
+  ].join('\n');
 
   //Although blob makes this method compatible with safari it makes it break for all other browsers so I'm removing it temporarily
 
   // We use blob method and removed `charset=utf8` in order to be compatible with Safari IOS
-  // let blob = new Blob([icsString], { type: 'text/calendar' });
-  // let calendarLink = window.URL.createObjectURL(blob);
+  let blob = new Blob([icsString], { type: 'text/calendar' });
+  let calendarLink = window.URL.createObjectURL(blob);
 
-  // return calendarLink;
+  return calendarLink;
 };

--- a/components/AddToCalendar/utils.js
+++ b/components/AddToCalendar/utils.js
@@ -71,27 +71,32 @@ export const icsLink = event => {
     endTime = parseISO(endTime);
   }
 
-  const icsString = [
-    'BEGIN:VCALENDAR',
-    'VERSION:2.0',
-    'PRODID:-//www.cf.church//Christ Fellowship Church',
-    'CALSCALE:GREGORIAN',
-    'BEGIN:VEVENT',
-    `DTSTAMP:${format(new Date(), 'yyyyMMddhhmmss')}Z`,
-    `UID:${uniqueId()}-@christfellowship.church`,
-    `DTSTART;TZID=America/New_York:${format(startTime, "yyyyMMdd'T'HHmmss")}`,
-    `DTEND;TZID=America/New_York:${format(endTime, "yyyyMMdd'T'HHmmss")}`,
-    `SUMMARY:${title}`,
-    `URL:${url ?? document?.URL ?? 'https://www.christfellowship.church'}`,
-    `DESCRIPTION:${description}`,
-    `LOCATION:${address}`,
-    'END:VEVENT',
-    'END:VCALENDAR',
-  ].join('\n');
+  return (
+    'data:text/calendar;charset=utf8,' +
+    [
+      'BEGIN:VCALENDAR',
+      'VERSION:2.0',
+      'PRODID:-//www.cf.church//Christ Fellowship Church',
+      'CALSCALE:GREGORIAN',
+      'BEGIN:VEVENT',
+      `DTSTAMP:${format(new Date(), 'yyyyMMddhhmmss')}Z`,
+      `UID:${uniqueId()}-@christfellowship.church`,
+      `DTSTART;TZID=America/New_York:${format(startTime, "yyyyMMdd'T'HHmmss")}`,
+      `DTEND;TZID=America/New_York:${format(endTime, "yyyyMMdd'T'HHmmss")}`,
+      `SUMMARY:${title}`,
+      `URL:${url ?? document?.URL ?? 'https://www.christfellowship.church'}`,
+      `DESCRIPTION:${description}`,
+      `LOCATION:${address}`,
+      'END:VEVENT',
+      'END:VCALENDAR',
+    ].join('\n')
+  );
+
+  //Although blob makes this method compatible with safari it makes it break for all other browsers so I'm removing it temporarily
 
   // We use blob method and removed `charset=utf8` in order to be compatible with Safari IOS
-  let blob = new Blob([icsString], { type: 'text/calendar' });
-  let calendarLink = window.URL.createObjectURL(blob);
+  // let blob = new Blob([icsString], { type: 'text/calendar' });
+  // let calendarLink = window.URL.createObjectURL(blob);
 
-  return calendarLink;
+  // return calendarLink;
 };

--- a/components/EventSingle/EventGroupings/DateTime.js
+++ b/components/EventSingle/EventGroupings/DateTime.js
@@ -4,11 +4,12 @@ import { format } from 'date-fns';
 
 import { AddToCalendar } from 'components';
 import { Box, Icon } from 'ui-kit';
+import { icsLink } from 'components/AddToCalendar/utils';
 
 const DateTime = ({ start, end, title, ...props }) => {
   const event = {
-    title: `${title} - Christ Fellowship Church`,
-    alternateDescription: `Join us for ${title} at Christ Fellowship!`,
+    title: `${title}`,
+    address: 'Christ Fellowship Church',
     startTime: start,
     endTime: end,
   };
@@ -34,7 +35,12 @@ const DateTime = ({ start, end, title, ...props }) => {
           </Box>
         </Box>
       </Box>
-      <AddToCalendar event={event} mb="base" />
+      {/* <AddToCalendar event={event} mb="base" /> */}
+
+      {/* We are temporarily using ICS only for the time being, until we fix the AddToCalendar component */}
+      <Box as="a" download="ChristFellowshipChurch.ics" href={icsLink(event)}>
+        <Icon name="calendar-plus" />
+      </Box>
     </Box>
   );
 };

--- a/components/EventSingle/EventGroupings/EventGroupings.js
+++ b/components/EventSingle/EventGroupings/EventGroupings.js
@@ -61,6 +61,7 @@ const EventGroupings = (props = {}) => {
                 key={n.id}
                 start={n.start}
                 title={props.data.title}
+                campus={values?.campusSelect}
                 mb={i === selectedGroup?.instances?.length - 1 ? '0' : 'base'}
               />
             ))}


### PR DESCRIPTION
### About
The blob method that allows for icsLink to work on Safari is breaking Add to Calendar on the rest of the browsers, so I'm removing it temporarily 

### Test Instructions
Open any event and Add to Calendar - Apple or Outlook should be working on any browser but Safari

### Closes Tickets


### Related Tickets
N/A
