### PR TITLE
Added Metadata from Rock to Content Items

### DIFF
--- a/components/ContentSingle/ContentSingle.js
+++ b/components/ContentSingle/ContentSingle.js
@@ -10,6 +10,7 @@ import { getUrlFromRelatedNode } from 'utils';
 import ContentVideo from './ContentVideo';
 import ContentVideosList from './ContentVideosList';
 import Styled from './ContentSingle.styles';
+import { find, findIndex, includes, keyBy } from 'lodash';
 function ContentSingle(props = {}) {
   const [currentVideo, setCurrentVideo] = useState(
     Array.isArray(props.data?.videos) ? props.data.videos[0] : null
@@ -66,17 +67,24 @@ function ContentSingle(props = {}) {
     }
   };
 
+  const metadata = keyBy(props?.data?.metadata, 'name');
+
   return (
     <ContentLayout
       mode={mode}
       theme={props?.data?.theme}
       title={title}
       seoMetaTags={{
-        description: schedule?.friendlyScheduleText || summary,
+        description:
+          metadata?.description?.content ||
+          schedule?.friendlyScheduleText ||
+          summary,
         image: coverImageUri,
         author: authorName,
         url: typeof window !== 'undefined' ? window.location.href : undefined,
         video: currentVideo?.sources[0]?.uri,
+        keywords: metadata?.keywords?.content,
+        title: metadata?.title?.content || title,
       }}
       summary={schedule?.friendlyScheduleText || summary}
       coverImage={currentVideo ? null : coverImageUri}

--- a/components/SEO/SEO.js
+++ b/components/SEO/SEO.js
@@ -15,7 +15,7 @@ function getPageTitle(title) {
   if (includes(title, 'Christ Fellowship Church')) {
     return title;
   }
-  return `${title} - ${DEFAULT_TITLE}`;
+  return `${title} | Christ Fellowship Church`;
 }
 
 /**
@@ -28,6 +28,8 @@ function getPageTitle(title) {
  */
 function SEO(props = {}) {
   const pageTitle = getPageTitle(props.title);
+
+  console.log({ props });
 
   return (
     <Head>

--- a/hooks/useContentItem.js
+++ b/hooks/useContentItem.js
@@ -142,6 +142,13 @@ export const GET_CONTENT_ITEM = gql`
         ...publishFragment
       }
 
+      ... on MediaContentItem {
+        metadata {
+          name
+          content
+        }
+      }
+
       ... on FeaturesNode {
         featureFeed {
           ...FeatureFeedFragment


### PR DESCRIPTION
### About
This PR adds the `metadata` attribute to our `useContentItems` hook, allowing our Content Managers to manage the metadata(title, keywords, and description) for articles, devotionals, studies, and messages.

### Test Instructions
* run the https://github.com/christfellowshipchurch/services/pull/24 API branch locally with this one. 
* Go to `/articles/what-makes-jesus-different` or `/articles/pams-test-article` to see the metadata from Rock being used.

### Screenshots
![image](https://user-images.githubusercontent.com/46049974/185236139-36c79b19-0f64-4fec-b82f-54a3b1d6e14c.png)


### Closes Tickets
[CFDP-2196](https://christfellowshipchurch.atlassian.net/browse/CFDP-2196)