### PR TITLE
Group Finder Sub Preference bug fixed

### DIFF
--- a/components/CommunitySingle/CommunitySingle.js
+++ b/components/CommunitySingle/CommunitySingle.js
@@ -120,7 +120,8 @@ function CommunitySingle(props = {}) {
   // }
 
   // Bypassing group filter modal temporarily
-  const handleSubPreferenceSelect = () => {
+  const handleSubPreferenceSelect = subPreference => {
+    filtersDispatch(update({ subPreferences: [subPreference.title] }));
     router.push({
       pathname: `/groups/search`,
       query: filtersState.valuesSerialized,


### PR DESCRIPTION
### About
This bug happened when we received the request to hide the Group Finder filter modal, we removed the modal piece of code and the sub-preference went with it. I just passed in the sub-preference to the current function and now it updates the filter. 

### Test Instructions
Test link below or clone branch. 

See "Scenario" [here](https://christfellowshipchurch.atlassian.net/jira/software/projects/CFDP/boards/2?selectedIssue=CFDP-2230) for testing instructions 

### Screenshots
![Screen Shot 2022-08-19 at 3 11 44 PM](https://user-images.githubusercontent.com/46769629/185690589-4a570f7b-9ac9-4524-9d11-2da904448610.png)

### Closes Tickets
[CFDP-2230](https://christfellowshipchurch.atlassian.net/jira/software/projects/CFDP/boards/2?selectedIssue=CFDP-2230)

### Related Tickets
N/A