### PR TITLE
Fixed Mobile NavScreen to Fit Screen Properly

### DIFF
--- a/components/CommunitySingle/CommunitySingle.js
+++ b/components/CommunitySingle/CommunitySingle.js
@@ -129,13 +129,13 @@ function CommunitySingle(props = {}) {
   };
 
   return (
-    <>
-      <SEO
-        title={props.data?.title}
-        image={props.data?.coverImage?.sources[0]?.uri}
-        description={props.data?.summary}
-      />
-      <Header />
+    <Layout
+      title={props.data?.title}
+      seaMetaTags={{
+        image: props.data?.coverImage?.sources[0]?.uri,
+        description: props.data?.summary,
+      }}
+    >
       <Box width="100%" px="xxs" py={{ _: 's', lg: 'base' }}>
         <Styled.BackButton>
           <CustomLink
@@ -241,8 +241,7 @@ function CommunitySingle(props = {}) {
         />
         <CommunityLeaderActions />
       </Box>
-      <Footer />
-    </>
+    </Layout>
   );
 }
 

--- a/components/Header/DefaultHeader.js
+++ b/components/Header/DefaultHeader.js
@@ -18,7 +18,7 @@ function DefaultHeader(props = {}) {
             <Box as={Logo} mx={{ _: 'auto', md: '0' }} mb="0" />
           </a>
         </Link>
-        <NavigationProvider Component={Nav} {...props} />
+        <Nav {...props?.data} showMobileNav={props?.showMobileNav} />
       </Styled>
     </>
   );

--- a/components/Header/TransparentHeader.js
+++ b/components/Header/TransparentHeader.js
@@ -30,22 +30,16 @@ function TransparentHeader(props = {}) {
   });
 
   return (
-    <Box 
-      position="fixed"
-      zIndex={9}
-      width="100%"
-    >
+    <Box position="fixed" zIndex={9} width="100%">
       <ActionBannerProvider Component={ActionBanner} />
       <Styled
         boxShadow="none"
         bg={bgColor}
         opacity={navOpacity}
-        // position="fixed"
-        {...props}
         display="flex"
         flexDirection="column"
+        {...props}
       >
-        
         <Box
           display="flex"
           alignItems="center"
@@ -57,7 +51,11 @@ function TransparentHeader(props = {}) {
               <Box as={Logo} dark={true} mx={{ _: 'auto', md: '0' }} mb="0" />
             </a>
           </Link>
-          <NavigationProvider Component={Nav} {...props} transparentMode />
+          <Nav
+            transparentMode
+            showMobileNav={props?.showMobileNav}
+            {...props?.data}
+          />
         </Box>
       </Styled>
     </Box>

--- a/components/Header/index.js
+++ b/components/Header/index.js
@@ -6,6 +6,11 @@ import TransparentHeader from './TransparentHeader';
 
 import navData from 'config/new-nav-links';
 
+/**
+ * ! ----- WARNING ----- !
+ * This component must NOT be used by itself. It can only be used with the Layout component, due to the MobileNavScreen needing to render outside it's parent.
+ */
+
 const Header = ({ type, showMobileNav }) => {
   switch (type) {
     case 'transparent':

--- a/components/Header/index.js
+++ b/components/Header/index.js
@@ -4,13 +4,15 @@ import PropTypes from 'prop-types';
 import DefaultHeader from './DefaultHeader';
 import TransparentHeader from './TransparentHeader';
 
-const Header = ({ type }) => {
+import navData from 'config/new-nav-links';
+
+const Header = ({ type, showMobileNav }) => {
   switch (type) {
     case 'transparent':
-      return <TransparentHeader />;
+      return <TransparentHeader data={navData} showMobileNav={showMobileNav} />;
     case 'default ':
     default:
-      return <DefaultHeader />;
+      return <DefaultHeader data={navData} showMobileNav={showMobileNav} />;
   }
 };
 

--- a/components/Layout/Layout.js
+++ b/components/Layout/Layout.js
@@ -1,15 +1,22 @@
-import React from 'react';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 
-import { Box } from 'ui-kit';
+import { Box, Button } from 'ui-kit';
 import { Footer, SEO } from 'components';
-import { Header } from 'components';
+import { Header, MobileNavScreen } from 'components';
 function Layout(props = {}) {
-  return (
+  const [showMobileNav, setShowMobileNav] = useState(false);
+
+  return showMobileNav ? (
+    <MobileNavScreen onClose={() => setShowMobileNav(!showMobileNav)} />
+  ) : (
     <>
       {props.title && <SEO title={props.title} {...props?.seoMetaTags} />}
       <Box display="flex" flexDirection="column" height="100vh">
-        <Header type={props?.transparentHeader ? 'transparent' : null} />
+        <Header
+          type={props?.transparentHeader ? 'transparent' : null}
+          showMobileNav={() => setShowMobileNav(!showMobileNav)}
+        />
         <Box flexGrow="1">{props.children}</Box>
         <Footer />
       </Box>

--- a/components/MobileNavScreen/NavScreen.js
+++ b/components/MobileNavScreen/NavScreen.js
@@ -7,9 +7,37 @@ import Logo from 'components/Logo';
 import navData from 'config/mobile-nav-links';
 import MainMenu from './MainMenu';
 import SubMenu from './SubMenu';
+import { logout, useAuth } from 'providers/AuthProvider';
+import { showModal, useModalDispatch } from 'providers/ModalProvider';
+import { useRouter } from 'next/router';
 
 function NavScreen(props) {
+  const [{ authenticated }, authDispatch] = useAuth();
   const [screenState, setScreenState] = useState('Main');
+  const modalDispatch = useModalDispatch();
+  const router = useRouter();
+
+  /**
+   * todo : Update the handleRouterReload to take a list a specific pages that need to be reloaded after logging as user out. To skip the rest of the pages and continue to reduce the amount of unnecessary reloads.
+   */
+  function handleRouterReload(pathname) {
+    if (pathname === '/') {
+      return null;
+    }
+    return router.reload();
+  }
+
+  function handleAuthClick(event) {
+    event.preventDefault();
+    modalDispatch(showModal('Auth'));
+  }
+
+  function handleLogoutClick(event) {
+    event.preventDefault();
+    authDispatch(logout());
+    props?.onClose();
+    handleRouterReload(router.pathname);
+  }
 
   const screenStates = [
     {
@@ -67,18 +95,18 @@ function NavScreen(props) {
       >
         <Logo />
         <Box display="flex" alignItems="center">
-          <Box as="a" color="black" href="/discover" mr="0.8rem">
+          <Box as="a" color="black" href="/discover" mr="1rem">
             <Icon name="search" />
           </Box>
-          {props?.auth ? (
+          {authenticated ? (
             <Icon
               name="sign-out"
               size={18}
-              mr="0.8rem"
-              onClick={props?.handleLogout}
+              mr="1rem"
+              onClick={handleLogoutClick}
             />
           ) : (
-            <Icon name="user" mr="0.8rem" onClick={props?.handleAuth} />
+            <Icon name="user" mr="1rem" onClick={handleAuthClick} />
           )}
           <Icon name="x" onClick={props?.onClose} />
         </Box>

--- a/components/MobileNavScreen/NavScreen.js
+++ b/components/MobileNavScreen/NavScreen.js
@@ -95,18 +95,35 @@ function NavScreen(props) {
       >
         <Logo />
         <Box display="flex" alignItems="center">
-          <Box as="a" color="black" href="/discover" mr="1rem">
+          <Box as="a" color="black" href="/discover" mr="base">
             <Icon name="search" />
           </Box>
           {authenticated ? (
-            <Icon
-              name="sign-out"
-              size={18}
-              mr="1rem"
+            <Box
+              display="flex"
+              flexDirection="column"
+              mt="5px"
+              mr="base"
               onClick={handleLogoutClick}
-            />
+            >
+              <Icon name="sign-out" size={16} />
+              <Box as="span" fontSize="10px">
+                Sign Out
+              </Box>
+            </Box>
           ) : (
-            <Icon name="user" mr="1rem" onClick={handleAuthClick} />
+            <Box
+              display="flex"
+              flexDirection="column"
+              mt="5px"
+              mr="base"
+              onClick={handleAuthClick}
+            >
+              <Icon name="user" size={16} />
+              <Box as="span" fontSize="10px">
+                Sign In
+              </Box>
+            </Box>
           )}
           <Icon name="x" onClick={props?.onClose} />
         </Box>

--- a/components/MobileNavScreen/NavScreen.styles.js
+++ b/components/MobileNavScreen/NavScreen.styles.js
@@ -11,7 +11,6 @@ const NavScreen = styled.div`
   min-height: 100%;
   position: relative;
   background: ${themeGet('colors.paper')};
-  overflow: scroll;
 
   ${system};
 `;

--- a/components/MobileNavScreen/NavScreen.styles.js
+++ b/components/MobileNavScreen/NavScreen.styles.js
@@ -5,8 +5,6 @@ import { system } from 'ui-kit';
 
 const NavScreen = styled.div`
   position: absolute;
-  left: -45px;
-  top: -20px;
   width: 100vw;
   min-width: 100%;
   height: 100vh;
@@ -37,7 +35,7 @@ const SubNavLink = styled.a`
   font-weight: 600;
   font-size: ${themeGet('fontSizes.h3')};
   text-decoration: none;
-  margin-bottom: ${themeGet('space.s')};
+  margin-bottom: ${themeGet('space.base')};
 
   &:hover {
     color: ${themeGet('colors.primary')};

--- a/components/Nav/Nav.js
+++ b/components/Nav/Nav.js
@@ -6,13 +6,12 @@ import { CurrentUserProvider } from 'providers';
 import { logout, useAuth } from 'providers/AuthProvider';
 import { useModalDispatch, showModal } from 'providers/ModalProvider';
 import { Box, Button, Icon, Menu, systemPropTypes } from 'ui-kit';
-import { ClientSideComponent, MobileNavScreen, UserAvatar } from 'components';
+import { UserAvatar } from 'components';
 import Styled from './Nav.styles';
 import { useCurrentBreakpoint } from 'hooks';
 
 function Nav(props = {}) {
   const [{ authenticated }, authDispatch] = useAuth();
-  const [showMobileNav, setShowMobileNav] = useState(false);
   const currentBreakpoint = useCurrentBreakpoint();
   const modalDispatch = useModalDispatch();
   const router = useRouter();
@@ -29,7 +28,6 @@ function Nav(props = {}) {
 
   function handleAuthClick(event) {
     event.preventDefault();
-    setShowMobileNav(false);
     modalDispatch(showModal('Auth'));
   }
 
@@ -45,14 +43,23 @@ function Nav(props = {}) {
         variant="secondary"
         size="s"
         px="base"
+        mr="base"
         color={props?.transparentMode ? 'white' : 'primary'}
         borderColor={props?.transparentMode ? 'white' : 'primary'}
         hoverColor={props?.transparentMode ? 'neutrals.400' : null}
         display={{ _: 'none', md: 'inline' }}
-        data={props.data.quickAction}
+        data={{
+          call: 'Join Us Online',
+          action: 'https://cf.church/watchonline',
+        }}
       />
 
-      <Box as="a" href="/discover" display={{ _: 'none', md: 'inline' }}>
+      <Box
+        as="a"
+        href="/discover"
+        display={{ _: 'none', md: 'inline' }}
+        mr="base"
+      >
         <Icon
           name="search"
           color={props?.transparentMode ? 'white' : 'neutrals.800'}
@@ -64,9 +71,10 @@ function Nav(props = {}) {
         textDecoration="none"
         onClick={
           currentBreakpoint.isSmall
-            ? () => setShowMobileNav(!showMobileNav)
+            ? props?.showMobileNav
             : () => modalDispatch(showModal('NavMenu'))
         }
+        mr="s"
       >
         <Icon name="menu" color={props?.transparentMode ? 'white' : 'fg'} />
         <Box as="span" p="xs" color={props?.transparentMode ? 'white' : 'fg'}>
@@ -74,20 +82,11 @@ function Nav(props = {}) {
         </Box>
       </Box>
 
-      {authenticated && !showMobileNav && (
+      {authenticated && (
         <CurrentUserProvider
           Component={UserAvatar}
           handleAuthClick={handleAuthClick}
           size={40}
-        />
-      )}
-
-      {showMobileNav && (
-        <MobileNavScreen
-          onClose={() => setShowMobileNav(!showMobileNav)}
-          auth={authenticated}
-          handleAuth={handleAuthClick}
-          handleLogout={handleLogoutClick}
         />
       )}
     </Styled>

--- a/components/Nav/Nav.styles.js
+++ b/components/Nav/Nav.styles.js
@@ -8,10 +8,6 @@ const Nav = styled.nav`
   display: flex;
   justify-content: center;
 
-  > *:not(:last-child) {
-    margin-right: ${themeGet('space.base')};
-  }
-
   @media screen and (min-width: ${themeGet('breakpoints.md')}) {
     justify-content: flex-start;
   }

--- a/pages/about/index.js
+++ b/pages/about/index.js
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { Button, Box, Card, ContentBlock, List } from 'ui-kit';
 import { rem } from 'ui-kit/_utils';
-import { SEO, Header, Footer } from 'components';
+import { Layout } from 'components';
 
 import Styled from './About.styles';
 
@@ -10,33 +10,42 @@ import { htmlToReactParser } from 'utils';
 
 export default function About() {
   const [active, setActive] = useState('leadership');
-  
+
   return (
-    <Box width="100%">
-      <SEO title="About" />
-      <Box display="grid" gridTemplateRows="auto 1fr auto" height="100vh">
-        <Header />
-        <Styled.Hero>
-          <Box as="h1">About Christ Fellowship</Box>
-          <Box as="p" fontSize="l" maxWidth="840px">
-            Christ Fellowship is a church in South Florida with a passion to
-            help you know God and grow in your relationships so that you can
-            discover your purpose and impact the world. We believe that church
-            isn’t just a building you walk in to, but a family you can belong
-            to—so whether you call one of our many locations home or join from
-            home, church is wherever you are! Led by senior pastors Todd & Julie
-            Mullins, our mission is to impact the world with the love and
-            message of Jesus Christ—everyone, everyday,&nbsp;everywhere.
-          </Box>
-        </Styled.Hero>
-        <Styled.Section>
-          <Box as="h1">One Church with Many Locations</Box>
-          <Box as="p" fontSize="l" maxWidth="840px">
-            We believe that church isn’t just a building you walk in to, but a
-            family you can belong to—so whether you call one of our many
-            locations home or join from home, church is wherever you&nbsp;are!
-          </Box>
-        </Styled.Section>
+    <Layout
+      title="About Us"
+      seoMetaTags={{
+        description:
+          'Christ Fellowship is a church in South Florida with a passion to help you know God and grow in your relationships so that you can discover your purpose and impact the world. We believe that church isn’t just a building you walk in to, but a family you can belong to—so whether you call one of our many locations home or join from home, church is wherever you are! Led by senior pastors Todd & Julie Mullins, our mission is to impact the world with the love and message of Jesus Christ—everyone, everyday, everywhere.',
+      }}
+    >
+      <Styled.Hero>
+        <Box as="h1">About Christ Fellowship</Box>
+        <Box as="p" fontSize="l" maxWidth="840px">
+          Christ Fellowship is a church in South Florida with a passion to help
+          you know God and grow in your relationships so that you can discover
+          your purpose and impact the world. We believe that church isn’t just a
+          building you walk in to, but a family you can belong to—so whether you
+          call one of our many locations home or join from home, church is
+          wherever you are! Led by senior pastors Todd & Julie Mullins, our
+          mission is to impact the world with the love and message of Jesus
+          Christ—everyone, everyday,&nbsp;everywhere.
+        </Box>
+      </Styled.Hero>
+      <Styled.Section>
+        <Box as="h1">One Church with Many Locations</Box>
+        <Box as="p" fontSize="l" maxWidth="840px">
+          We believe that church isn’t just a building you walk in to, but a
+          family you can belong to—so whether you call one of our many locations
+          home or join from home, church is wherever you&nbsp;are!
+        </Box>
+      </Styled.Section>
+      <Box
+        display="flex"
+        flexDirection="column"
+        alignItems="center"
+        width="100vw"
+      >
         <List
           display="flex"
           py="l"
@@ -81,23 +90,15 @@ export default function About() {
             </Button>
           </Box>
         </List>
-        {active === 'leadership' &&
-          <Box
-            m="auto"
-            maxWidth="1000px"
-            p="base"
-          >
+        {active === 'leadership' && (
+          <Box m="auto" maxWidth="1000px" p="base">
             {data.leadership.map((item, i) => (
-              <Box
-                my="xl"
-              >
-                <ContentBlock
-                  {...item}
-                  key={i}
-                />
+              <Box my="xl">
+                <ContentBlock {...item} key={i} />
               </Box>
             ))}
-          </Box>}
+          </Box>
+        )}
         {active === 'beliefs' && (
           <Box
             display="flex"
@@ -178,8 +179,7 @@ export default function About() {
             <Box>{htmlToReactParser.parse(data.history)}</Box>
           </Box>
         )}
-        <Footer />
       </Box>
-    </Box>
+    </Layout>
   );
 }

--- a/pages/groups/index.js
+++ b/pages/groups/index.js
@@ -9,6 +9,7 @@ import {
   CommunityList,
   Footer,
   Header,
+  Layout,
   SearchField,
   SEO,
 } from 'components';
@@ -88,14 +89,6 @@ export default function Community(props = {}) {
 
   return (
     <>
-      <SEO
-        title="Christ Fellowship Church Groups"
-        image="/groups-cover-image.jpg"
-        description=" We want to help you find community, grow in your relationship with
-        God, and build the kind of friendships we all need to live out our
-        faith. Groups and classes help you know where to look for
-        direction and have the right people encouraging you along the way."
-      />
       <JsonLD
         schema={{
           '@type': 'WebSite',
@@ -111,95 +104,102 @@ export default function Community(props = {}) {
           },
         }}
       />
-      <Box display="grid" gridTemplateRows="auto 1fr auto" height="100vh">
-        <Header />
-        <Styled.Hero>
-          <Styled.Content mx="base">
-            <Styled.Title px="s">Groups & Classes</Styled.Title>
-            <Styled.Subtitle>Life is Better Together</Styled.Subtitle>
-            <SearchField
-              boxShadow="0 6px 1px rgba(0, 0, 0, 0.1), 0 0 5px rgba(0, 0, 0, 0.1),
-              0 1px 3px rgba(0, 0, 0, 0.3)"
-              maxWidth={800}
-              mx="auto"
-              handleSubmit={handleSubmit}
-              handleChange={handleChange}
-              handleClick={handleClick}
-              handleClear={() => reset()}
-              value={values.text || ''}
-              mb="base"
-            />
-            <Box
-              fontStyle="italic"
-              fontSize={{ _: '16px', md: '20px' }}
-              color="white"
-            >
-              Already in a group?{' '}
-              <Box
-                as="a"
-                color="white"
-                onClick={handleMyGroups}
-                href="/connect"
-              >
-                Log in
-              </Box>{' '}
-              to see your groups.
-            </Box>
-            <Box
-              fontStyle="italic"
-              fontSize={{ _: '16px', md: '20px' }}
-              color="white"
-            >
-              Interested in starting a Group?{' '}
-              <Box
-                as="a"
-                color="white"
-                target="_blank"
-                href="https://rock.christfellowship.church/groups/starting-a-group"
-              >
-                Learn More
-              </Box>{' '}
-            </Box>
-          </Styled.Content>
-        </Styled.Hero>
-        <Box bg="white" textAlign="center" py="xl">
-          <Box as="h1" color="secondary">
-            Why Groups?
-          </Box>
-          <Box px="l" mx="auto" maxWidth={800}>
-            You weren’t meant to do life alone. You were made for community. But
-            not just any community. Groups and classes help you find people to
-            do life with so that you can know where to look for direction, and
-            have someone to keep you accountable and encouraged as you grow in
-            your relationship with God and others.
-          </Box>
-        </Box>
+      <Layout
+        title="Christ Fellowship Church Groups"
+        seoMetaTags={{
+          image: '/groups-cover-image.jpg',
+          description:
+            ' We want to help you find community, grow in your relationship with God, and build the kind of friendships we all need to live out our faith. Groups and classes help you know where to look for direction and have the right people encouraging you along the way.',
+        }}
+      >
         <Box>
-          <Cell
-            maxWidth={DEFAULT_CONTENT_WIDTH}
-            px="base"
-            py={{ _: 'm', lg: 'l' }}
-          >
-            <Box as="section">
+          <Styled.Hero>
+            <Styled.Content mx="base">
+              <Styled.Title px="s">Groups & Classes</Styled.Title>
+              <Styled.Subtitle>Life is Better Together</Styled.Subtitle>
+              <SearchField
+                boxShadow="0 6px 1px rgba(0, 0, 0, 0.1), 0 0 5px rgba(0, 0, 0, 0.1),
+              0 1px 3px rgba(0, 0, 0, 0.3)"
+                maxWidth={800}
+                mx="auto"
+                handleSubmit={handleSubmit}
+                handleChange={handleChange}
+                handleClick={handleClick}
+                handleClear={() => reset()}
+                value={values.text || ''}
+                mb="base"
+              />
               <Box
-                as="h1"
-                color="secondary"
-                textAlign="center"
-                mt={{ _: 'l', lg: 0 }}
+                fontStyle="italic"
+                fontSize={{ _: '16px', md: '20px' }}
+                color="white"
               >
-                Discover All Kinds of Groups
+                Already in a group?{' '}
+                <Box
+                  as="a"
+                  color="white"
+                  onClick={handleMyGroups}
+                  href="/connect"
+                >
+                  Log in
+                </Box>{' '}
+                to see your groups.
               </Box>
-              <Box as="p" textAlign="center" mb="l">
-                Tap on a group category below to see what’s available.
+              <Box
+                fontStyle="italic"
+                fontSize={{ _: '16px', md: '20px' }}
+                color="white"
+              >
+                Interested in starting a Group?{' '}
+                <Box
+                  as="a"
+                  color="white"
+                  target="_blank"
+                  href="https://rock.christfellowship.church/groups/starting-a-group"
+                >
+                  Learn More
+                </Box>{' '}
               </Box>
-              <CommunitiesProvider Component={CommunityList} />
+            </Styled.Content>
+          </Styled.Hero>
+          <Box bg="white" textAlign="center" py="xl">
+            <Box as="h1" color="secondary">
+              Why Groups?
             </Box>
-          </Cell>
+            <Box px="l" mx="auto" maxWidth={800}>
+              You weren’t meant to do life alone. You were made for community.
+              But not just any community. Groups and classes help you find
+              people to do life with so that you can know where to look for
+              direction, and have someone to keep you accountable and encouraged
+              as you grow in your relationship with God and others.
+            </Box>
+          </Box>
+          <Box>
+            <Cell
+              maxWidth={DEFAULT_CONTENT_WIDTH}
+              px="base"
+              py={{ _: 'm', lg: 'l' }}
+            >
+              <Box as="section">
+                <Box
+                  as="h1"
+                  color="secondary"
+                  textAlign="center"
+                  mt={{ _: 'l', lg: 0 }}
+                >
+                  Discover All Kinds of Groups
+                </Box>
+                <Box as="p" textAlign="center" mb="l">
+                  Tap on a group category below to see what’s available.
+                </Box>
+                <CommunitiesProvider Component={CommunityList} />
+              </Box>
+            </Cell>
+          </Box>
+          <CommunityActionSection handleOnClick={handleOnClick} />
+          <CommunityLeaderActions />
         </Box>
-        <CommunityActionSection handleOnClick={handleOnClick} />
-        <CommunityLeaderActions />
-        <Footer />
-      </Box>
+      </Layout>
     </>
   );
 }

--- a/pages/groups/search/index.js
+++ b/pages/groups/search/index.js
@@ -13,13 +13,11 @@ import {
   utils,
 } from 'ui-kit';
 import {
-  Footer,
   GroupSearchFilters,
-  Header,
-  SEO,
   SearchField,
   GroupsResultsList,
   CustomLink,
+  Layout,
 } from 'components';
 
 import {
@@ -159,132 +157,127 @@ export default function CommunitySearch() {
   if (!flags.GROUP_FINDER) return null;
 
   return (
-    <>
-      <SEO title="Find your Community" />
-      <Box display="grid" gridTemplateRows="auto 1fr auto" height="100vh">
-        <Header />
-        <Cell
-          width="100%"
-          maxWidth={
-            !currentBreakpoint.isXLarge
-              ? DEFAULT_CONTENT_WIDTH
-              : LARGE_SCREEN_CONTENT_WIDTH
-          }
-          px="base"
-          py={{ _: 'base', lg: 'l' }}
+    <Layout title="Find your Community">
+      <Cell
+        width="100%"
+        maxWidth={
+          !currentBreakpoint.isXLarge
+            ? DEFAULT_CONTENT_WIDTH
+            : LARGE_SCREEN_CONTENT_WIDTH
+        }
+        px="base"
+        py={{ _: 'base', lg: 'l' }}
+      >
+        <CustomLink Component={BackButton} color="black" href="/groups" />
+
+        <Box
+          display="flex"
+          justifyContent="space-between"
+          alignItems="center"
+          mb="base"
         >
-          <CustomLink Component={BackButton} color="black" href="/groups" />
-
-          <Box
-            display="flex"
-            justifyContent="space-between"
-            alignItems="center"
-            mb="base"
-          >
-            <Box mt="base" as="h1">
-              Find your Community
-            </Box>
-            <Button
-              as="a"
-              rounded={true}
-              size="s"
-              variant="secondary"
-              href="https://rock.gocf.org/page/2113"
-              display={{ _: 'none', md: 'inline-block' }}
-            >
-              Need help finding a group?
-            </Button>
+          <Box mt="base" as="h1">
+            Find your Community
           </Box>
+          <Button
+            as="a"
+            rounded={true}
+            size="s"
+            variant="secondary"
+            href="https://rock.gocf.org/page/2113"
+            display={{ _: 'none', md: 'inline-block' }}
+          >
+            Need help finding a group?
+          </Button>
+        </Box>
 
-          <SearchField
-            border="2px solid #C4C4C4"
-            boxShadow="l"
-            handleSubmit={handleSubmit}
-            handleClear={handleClearAllClick}
-            handleClick={handleClick}
-            handleChange={handleChange}
-            value={values.text || ''}
-            mb="l"
-          >
-            Search
-          </SearchField>
-          <Divider mb="l" />
-          <Box
-            display="flex"
-            justifyContent={
-              !currentBreakpoint.isXLarge ? 'space-between' : 'flex-end'
-            }
-            alignItems="center"
-            mb="base"
-          >
-            {!currentBreakpoint.isXLarge && (
-              <GroupSearchFilters
-                loading={loading}
-                visibleResults={groups?.length}
-                totalResults={data?.searchGroups?.totalResults}
-                pageSize={PAGE_SIZE}
-              />
-            )}
-          </Box>
-          <Box
-            display={currentBreakpoint.isXLarge && 'grid'}
-            gridTemplateColumns="250px 1fr"
-            gridGap="28px"
-          >
-            {currentBreakpoint.isXLarge && <Sidebar />}
-            {showEmptyState && (
-              <Box my="xxl" pb="xxl" textAlign="center">
-                <Box as="h2">Looks like we couldn't find any results</Box>
-                <Box mb="base">
-                  Consider reducing the number of filters or modifying your
-                  search criteria.
-                </Box>
-                <Box
-                  display="flex"
-                  alignItems="center"
-                  flexDirection="column"
-                  mt="l"
-                  textAlign="center"
-                >
-                  <Button
-                    variant="secondary"
-                    onClick={handleClearAllClick}
-                    mb="s"
-                  >
-                    Clear Search
-                  </Button>
-                  <CustomLink href="https://rock.gocf.org/page/2113">
-                    Need help?
-                  </CustomLink>
-                </Box>
+        <SearchField
+          border="2px solid #C4C4C4"
+          boxShadow="l"
+          handleSubmit={handleSubmit}
+          handleClear={handleClearAllClick}
+          handleClick={handleClick}
+          handleChange={handleChange}
+          value={values.text || ''}
+          mb="l"
+        >
+          Search
+        </SearchField>
+        <Divider mb="l" />
+        <Box
+          display="flex"
+          justifyContent={
+            !currentBreakpoint.isXLarge ? 'space-between' : 'flex-end'
+          }
+          alignItems="center"
+          mb="base"
+        >
+          {!currentBreakpoint.isXLarge && (
+            <GroupSearchFilters
+              loading={loading}
+              visibleResults={groups?.length}
+              totalResults={data?.searchGroups?.totalResults}
+              pageSize={PAGE_SIZE}
+            />
+          )}
+        </Box>
+        <Box
+          display={currentBreakpoint.isXLarge && 'grid'}
+          gridTemplateColumns="250px 1fr"
+          gridGap="28px"
+        >
+          {currentBreakpoint.isXLarge && <Sidebar />}
+          {showEmptyState && (
+            <Box my="xxl" pb="xxl" textAlign="center">
+              <Box as="h2">Looks like we couldn't find any results</Box>
+              <Box mb="base">
+                Consider reducing the number of filters or modifying your search
+                criteria.
               </Box>
+              <Box
+                display="flex"
+                alignItems="center"
+                flexDirection="column"
+                mt="l"
+                textAlign="center"
+              >
+                <Button
+                  variant="secondary"
+                  onClick={handleClearAllClick}
+                  mb="s"
+                >
+                  Clear Search
+                </Button>
+                <CustomLink href="https://rock.gocf.org/page/2113">
+                  Need help?
+                </CustomLink>
+              </Box>
+            </Box>
+          )}
+          <Box>
+            {hasResults && (
+              <>
+                <Box py="base" display="flex" justifyContent="flex-end">
+                  {renderPagination()}
+                </Box>
+
+                <GroupsProvider data={groups} Component={GroupsResultsList} />
+
+                <Box py="base" display="flex" justifyContent="center">
+                  {renderPagination()}
+                </Box>
+              </>
             )}
             <Box>
-              {hasResults && (
-                <>
-                  <Box py="base" display="flex" justifyContent="flex-end">
-                    {renderPagination()}
-                  </Box>
-
-                  <GroupsProvider data={groups} Component={GroupsResultsList} />
-
-                  <Box py="base" display="flex" justifyContent="center">
-                    {renderPagination()}
-                  </Box>
-                </>
+              {loading && (
+                <Box display="flex" justifyContent="center" my="xxl">
+                  <Loader />
+                </Box>
               )}
-              <Box>
-                {loading && (
-                  <Box display="flex" justifyContent="center" my="xxl">
-                    <Loader />
-                  </Box>
-                )}
-              </Box>
             </Box>
           </Box>
-        </Cell>
-        <Footer mt="xxl" />
-      </Box>
-    </>
+        </Box>
+      </Cell>
+    </Layout>
   );
 }


### PR DESCRIPTION
### About
This PR fixes the mobile NavScreen component. We needed to change where the component was being rendered so it could replace the entire screen and not scroll into the page it's on. This PR also fixes additional styling and bugs with the new Nav Menu.

### Test Instructions
* test the Nav menu on a mobile device.

### Screenshots
<img width="431" alt="image" src="https://user-images.githubusercontent.com/46049974/187515244-366639c6-8d85-4009-8050-fb840ef6f29a.png">

### Closes Tickets
[CFDP-2243]


[CFDP-2243]: https://christfellowshipchurch.atlassian.net/browse/CFDP-2243?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ