### PR TITLE
Added logic to remove white space and show correct content

### DIFF
--- a/ui-kit/DefaultCard/DefaultCard.js
+++ b/ui-kit/DefaultCard/DefaultCard.js
@@ -6,7 +6,13 @@ import { Box } from 'ui-kit';
 import Styled from 'ui-kit/Card/Card.styles';
 
 const DefaultCard = (props = {}) => {
-  const hasContent = props.title || props.description || props.children;
+  //These variables are used below to fix spacing issues
+  const mobileView = window.matchMedia('(max-width: 768px)').matches;
+  const deskView = window.matchMedia('(min-width: 769px)').matches;
+
+  const hasContent = mobileView
+    ? props.title || props.description || props.children || props.coverImage
+    : props.title || props.description || props.children;
 
   return (
     <Styled {...props}>
@@ -51,19 +57,38 @@ const DefaultCard = (props = {}) => {
           ) : null}
         </Styled.Cover>
       ) : null}
-      <Styled.Content {...props.contentProps}>
-        {props.title ? (
-          <Box as="h3" mb={{ _: 'xs', md: 's' }}>
-            {props.title}
-          </Box>
-        ) : null}
-        {props.description ? (
-          <Styled.Description color="neutrals.600" fontSize="s">
-            {props.description}
-          </Styled.Description>
-        ) : null}
-        {props.children ? props.children : null}
-      </Styled.Content>
+
+      {mobileView && props.title && (
+        <Styled.Content {...props.contentProps}>
+          {props.title ? (
+            <Box as="h3" mb={{ _: 'xs', md: 's' }}>
+              {props.title}
+            </Box>
+          ) : null}
+          {props.description ? (
+            <Styled.Description color="neutrals.600" fontSize="s">
+              {props.description}
+            </Styled.Description>
+          ) : null}
+          {props.children ? props.children : null}
+        </Styled.Content>
+      )}
+
+      {deskView && (
+        <Styled.Content {...props.contentProps}>
+          {props.title ? (
+            <Box as="h3" mb={{ _: 'xs', md: 's' }}>
+              {props.title}
+            </Box>
+          ) : null}
+          {props.description ? (
+            <Styled.Description color="neutrals.600" fontSize="s">
+              {props.description}
+            </Styled.Description>
+          ) : null}
+          {props.children ? props.children : null}
+        </Styled.Content>
+      )}
     </Styled>
   );
 };


### PR DESCRIPTION
### About
Originally, if a content item had no title and subtitle the image would not show on mobile view. This PR fixes that issue and removes extra white spacing from card on mobile view when there's no title or subtitle.

### Test Instructions
1. User is on their Mobile Device > Goes to Our Website
2. Clicks Menu > Search
3. Clicks on Filter “Ministries”
4. All of the cards should display correctly, if a card has no title and no subtitle it should have no visible padding or margins.

This does not work if you don't refresh the page on device-view-change (when viewing the web page nobody switches to mobile and vice versa so this should not be a problem as long as you refresh.)

### Screenshots
<img width="572" alt="Screen Shot 2022-09-13 at 10 53 08 PM" src="https://user-images.githubusercontent.com/46769629/190047844-f7954e6a-80aa-4b58-a10a-e7bff568f72b.png">

### Closes Tickets
[CFDP-2239](https://christfellowshipchurch.atlassian.net/jira/software/projects/CFDP/boards/2?selectedIssue=CFDP-2239)

### Related Tickets
N/A
