### PR TITLE
Fixed Mobile Card with No Title

### DIFF
--- a/ui-kit/Card/Card.styles.js
+++ b/ui-kit/Card/Card.styles.js
@@ -6,53 +6,71 @@ import { system } from 'ui-kit';
 const DEFAULT_COVER_HEIGHT = '250px';
 const HERO_COVER_HEIGHT = '350px';
 
-const link = ({ as }) => props => {
-  if (as === 'a') {
-    return css`
-      cursor: pointer;
-      text-decoration: none;
-      transition: 0.2s ease-in-out;
+const link =
+  ({ as }) =>
+  props => {
+    if (as === 'a') {
+      return css`
+        cursor: pointer;
+        text-decoration: none;
+        transition: 0.2s ease-in-out;
 
-      &:focus,
-      &:hover {
-        box-shadow: ${themeGet('shadows.xxl')};
-        transform: scale(1.02);
-      }
+        &:focus,
+        &:hover {
+          box-shadow: ${themeGet('shadows.xxl')};
+          transform: scale(1.02);
+        }
 
-      &:active {
-        transform: scale(1);
-      }
-    `;
-  }
-};
+        &:active {
+          transform: scale(1);
+        }
+      `;
+    }
+  };
 
-const scaleLink = ({ scaleCard }) => props => {
-  // Does not scale card if prop set to false
-  if (scaleCard === false) {
-    return css`
-      &:focus,
-      &:hover {
-        transform: none;
-      }
+const scaleLink =
+  ({ scaleCard }) =>
+  props => {
+    // Does not scale card if prop set to false
+    if (scaleCard === false) {
+      return css`
+        &:focus,
+        &:hover {
+          transform: none;
+        }
 
-      &:active {
-        transform: none;
-      }
-    `;
-  }
-};
+        &:active {
+          transform: none;
+        }
+      `;
+    }
+  };
 
-const removeBoxShadow = ({ boxShadow }) => props => {
-  // Removes box-shadow on hover if box-shadow is set to none
-  if (boxShadow === 'none') {
-    return css`
-      &:focus,
-      &:hover {
-        box-shadow: none;
-      }
-    `;
-  }
-};
+const removeBoxShadow =
+  ({ boxShadow }) =>
+  props => {
+    // Removes box-shadow on hover if box-shadow is set to none
+    if (boxShadow === 'none') {
+      return css`
+        &:focus,
+        &:hover {
+          box-shadow: none;
+        }
+      `;
+    }
+  };
+
+const mobileCardNoTitle =
+  ({ title }) =>
+  props => {
+    if (!title) {
+      return css`
+        @media screen and (max-width: ${themeGet('breakpoints.md')}) {
+          height: 312px;
+        }
+      `;
+    }
+  };
 
 const Card = styled.div`
   background-color: ${themeGet('colors.paper')};
@@ -65,6 +83,7 @@ const Card = styled.div`
   ${link}
   ${scaleLink}
   ${removeBoxShadow}
+  ${mobileCardNoTitle}
 
   ${system}
 `;
@@ -79,67 +98,73 @@ const Content = styled.div`
   ${system}
 `;
 
-const content = ({ hasContent }) => props => {
-  if (hasContent) {
+const content =
+  ({ hasContent }) =>
+  props => {
+    if (hasContent) {
+      return css`
+        border-top-left-radius: ${themeGet('radii.base')};
+        border-top-right-radius: ${themeGet('radii.base')};
+        height: ${props =>
+          props.height ||
+          (props.largeCard ? HERO_COVER_HEIGHT : DEFAULT_COVER_HEIGHT)};
+      `;
+    }
+
     return css`
-      border-top-left-radius: ${themeGet('radii.base')};
-      border-top-right-radius: ${themeGet('radii.base')};
-      height: ${props =>
-        props.height ||
-        (props.largeCard ? HERO_COVER_HEIGHT : DEFAULT_COVER_HEIGHT)};
+      border-radius: ${themeGet('radii.base')};
+      height: 100%;
     `;
-  }
+  };
 
-  return css`
-    border-radius: ${themeGet('radii.base')};
-    height: 100%;
-  `;
-};
+const overlay =
+  ({ overlay }) =>
+  props => {
+    if (overlay) {
+      return css`
+        &::after {
+          background: linear-gradient(
+            to bottom,
+            rgba(0, 0, 0, 0),
+            ${themeGet('colors.fg')}
+          );
+          bottom: 0;
+          content: '';
+          height: 100%;
+          left: 0;
+          opacity: 0.8;
+          position: absolute;
+          right: 0;
+          top: 0;
+          width: 100%;
+          z-index: 1;
+        }
+      `;
+    }
+  };
 
-const overlay = ({ overlay }) => props => {
-  if (overlay) {
-    return css`
-      &::after {
-        background: linear-gradient(
-          to bottom,
-          rgba(0, 0, 0, 0),
-          ${themeGet('colors.fg')}
-        );
-        bottom: 0;
-        content: '';
-        height: 100%;
-        left: 0;
-        opacity: 0.8;
-        position: absolute;
-        right: 0;
-        top: 0;
-        width: 100%;
-        z-index: 1;
-      }
-    `;
-  }
-};
-
-const scaleCover = ({ scaleCoverImage }) => props => {
-  // Scales Cover Image of card if prop set to true
-  if (scaleCoverImage) {
-    return css`
-      transform: scale(1);
-      transition: 0.2s ease-in-out;
-
-      &:focus,
-      &:hover {
-        transform: scale(1.02);
-        transition: 0.2s ease-out;
-      }
-
-      &:active {
+const scaleCover =
+  ({ scaleCoverImage }) =>
+  props => {
+    // Scales Cover Image of card if prop set to true
+    if (scaleCoverImage) {
+      return css`
         transform: scale(1);
-        transition: 0.2s ease-out;
-      }
-    `;
-  }
-};
+        transition: 0.2s ease-in-out;
+
+        &:focus,
+        &:hover {
+          transform: scale(1.02);
+          transition: 0.2s ease-out;
+        }
+
+        &:active {
+          transform: scale(1);
+          transition: 0.2s ease-out;
+        }
+      `;
+    }
+  };
 
 const Cover = styled.div`
   align-items: flex-end;
@@ -160,32 +185,34 @@ const Cover = styled.div`
   ${system}
 `;
 
-const position = ({ position, size }) => props => {
-  if (position === 'bottomLeft') {
-    if (size === 's') {
+const position =
+  ({ position, size }) =>
+  props => {
+    if (position === 'bottomLeft') {
+      if (size === 's') {
+        return css`
+          padding: ${themeGet('space.base')};
+        `;
+      }
       return css`
-        padding: ${themeGet('space.base')};
+        /* backdrop-filter: blur(30px);
+      background-color: rgba(255, 255, 255, 0.15); */
+        padding: ${themeGet('space.s')};
+
+        @media screen and (min-width: ${themeGet('breakpoints.md')}) {
+          padding: ${themeGet('space.base')};
+        }
+      `;
+    } else if (position === 'center') {
+      return css`
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        align-content: center;
+        height: 100%;
       `;
     }
-    return css`
-      /* backdrop-filter: blur(30px);
-      background-color: rgba(255, 255, 255, 0.15); */
-      padding: ${themeGet('space.s')};
-
-      @media screen and (min-width: ${themeGet('breakpoints.md')}) {
-        padding: ${themeGet('space.base')};
-      }
-    `;
-  } else if (position === 'center') {
-    return css`
-      display: flex;
-      justify-content: center;
-      align-items: center;
-      align-content: center;
-      height: 100%;
-    `;
-  }
-};
+  };
 
 const CoverContent = styled.div`
   border-bottom-left-radius: ${themeGet('radii.base')};
@@ -198,7 +225,7 @@ const CoverContent = styled.div`
 `;
 
 const CoverLabel = styled.b`
-  background-color: ${themeGet('colors.primary')};;
+  background-color: ${themeGet('colors.primary')};
   backdrop-filter: blur(25px);
   box-shadow: ${themeGet('shadows.l')};
   border-radius: ${themeGet('radii.xxl')};


### PR DESCRIPTION
### About
This PR fixes a current bug on our website, where cards that have not title(_Page Builder pages_) disappear in mobile view on discover. This patch adds a height styling to fix the issue.

### Test Instructions
Go to `/discover` and click on **Ministries** filter in mobile view to see the Kids card now display properly.

### Screenshots
|Before|After|
|-|-|
|![image](https://user-images.githubusercontent.com/46049974/190680905-317ce4b1-c7d3-4be2-97e3-7684aaa48645.png)|![image](https://user-images.githubusercontent.com/46049974/190681013-96054891-b6e3-44f9-b427-b27ffcf31eeb.png)|

### Closes Tickets
[CFDP-2239]


[CFDP-2239]: https://christfellowshipchurch.atlassian.net/browse/CFDP-2239?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ