### PR TITLE
Added Rock Content Block to Westlake Landing Page

### DIFF
--- a/hooks/index.js
+++ b/hooks/index.js
@@ -7,6 +7,7 @@ import useCampus from './useCampus';
 import useCampuses from './useCampuses';
 import useCheckIn from './useCheckIn';
 import useContactGroupLeader from './useContactGroupLeader';
+import useContentBlockFeature from './useContentBlockFeature';
 import useContentFeed from './useNodeRoute';
 import useContentItem from './useContentItem';
 import useCurrentBreakpoint from './useCurrentBreakpoint';
@@ -77,6 +78,7 @@ export {
   useCampuses,
   useCheckIn,
   useContactGroupLeader,
+  useContentBlockFeature,
   useContentFeed,
   useContentItem,
   useCurrentBreakpoint,

--- a/hooks/useContentBlockFeature.js
+++ b/hooks/useContentBlockFeature.js
@@ -1,0 +1,32 @@
+import { gql, useQuery } from '@apollo/client';
+import {
+  CONTENT_BLOCK_FEATURE_FRAGMENT,
+  RELATED_FEATURE_NODE_FRAGMENT,
+} from 'fragments';
+
+export const GET_CONTENT_BLOCK = gql`
+  query getContentBlock($id: ID!) {
+    node(id: $id) {
+      ... on ContentBlockFeature {
+        ...ContentBlockFeatureFragment
+      }
+    }
+  }
+
+  ${CONTENT_BLOCK_FEATURE_FRAGMENT}
+  ${RELATED_FEATURE_NODE_FRAGMENT}
+`;
+
+function getContentBlock(options = {}) {
+  const query = useQuery(GET_CONTENT_BLOCK, {
+    fetchPolicy: 'cache-and-network',
+    ...options,
+  });
+
+  return {
+    block: query?.data?.node || {},
+    ...query,
+  };
+}
+
+export default getContentBlock;

--- a/pages/locations/westlake/index.js
+++ b/pages/locations/westlake/index.js
@@ -2,9 +2,17 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { FAQ, HeroLanding, Layout } from 'components';
 import { Box, CardCarousel, ContentBlock, Image } from 'ui-kit';
+import { useContentBlockFeature } from 'hooks';
 import faqData from 'components/FAQ/faqData';
 
 const Westlake = props => {
+  //Grabs Upcoming Events Content Block from Rock
+  const { block } = useContentBlockFeature({
+    variables: {
+      id: 'ContentBlockFeature:d0d7407920381ab5b3b4d32cd65762c6f75ed64f8616c1ca5784f8c79bb069b7',
+    },
+  });
+
   return (
     <Layout
       contentMaxWidth={'100vw'}
@@ -71,11 +79,14 @@ const Westlake = props => {
       <Box px="base" py="l">
         <Box mt={{ _: '-0.5rem', md: 'base' }} mx="auto" maxWidth={900}>
           <ContentBlock
-            title={`Upcoming Events`}
-            htmlContent={`</br> Learn more about Christ Fellowship Westlake—including meeting the Campus Pastors—at an upcoming interest meeting near you! </br> </br> Sunday, October 2 | Christ Fellowship <a href="palm-beach-gardens">Palm Beach Gardens</a> in the Luncheon - Cafe Multipurpose Room. </br> </br>`}
-            image="/westlake/campus_pastors.png"
-            imageRatio="4by3"
-            contentLayout="left"
+            title={block?.title}
+            subtitle={block?.subtitle}
+            actions={block?.actions}
+            contentLayout={block?.orientation}
+            htmlContent={block?.htmlContent}
+            image={block?.coverImage?.sources[0]?.uri}
+            imageRatio={block?.imageRatio}
+            videos={block?.videos}
           />
         </Box>
       </Box>


### PR DESCRIPTION
### About
This PR adds a custom Rock Content Block to Westlake Page. It also adds a new `hook` called `useContentBlockFeature`, so we can pull in single ContentBlocks when needed for custom pages like this one.

### Test Instructions
* go to `/locations/westlake` to see the "Upcoming Events" content block using data from Rock.

### Screenshots
![image](https://user-images.githubusercontent.com/46049974/194594049-eb798783-81f9-4b06-a7d3-38f970fe69d9.png)

### Closes Tickets
[CFDP-2281]


[CFDP-2281]: https://christfellowshipchurch.atlassian.net/browse/CFDP-2281?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ