### PR TITLE
Changed Parenting Link to Correct One 

### DIFF
--- a/config/mobile-nav-links.js
+++ b/config/mobile-nav-links.js
@@ -53,7 +53,7 @@ const navigation = {
     },
     {
       call: 'Be a better parent',
-      action: '/christ-fellowship-kids#parenting',
+      action: '/christ-fellowship-kids#parenting-resources',
     },
     {
       call: 'Heal from past hurts',

--- a/config/new-nav-links.js
+++ b/config/new-nav-links.js
@@ -40,7 +40,7 @@ const navigation = {
     },
     {
       call: 'Be a better parent',
-      action: '/christ-fellowship-kids#parenting',
+      action: '/christ-fellowship-kids#parenting-resources',
     },
     {
       call: 'Heal from past hurts',


### PR DESCRIPTION
### About
The menu parenting link was broken so this PR changed to the correct link
from: #parenting
to: #parenting-resources

### Test Instructions
Open the Menu 
Click on "Be a better parent"
It should take you to the correct link 

### Closes Tickets
[CFDP-2298](https://christfellowshipchurch.atlassian.net/jira/software/projects/CFDP/boards/2?selectedIssue=CFDP-2298)

### Related Tickets
N/A

