### PR TITLE
Fixed PSL Location Page

### DIFF
--- a/components/LocationSingle/LocationSingle.js
+++ b/components/LocationSingle/LocationSingle.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { find, includes, startCase, upperFirst } from 'lodash';
+import { find, includes, replace, startCase, upperFirst } from 'lodash';
 
 import {
   CollectionPreview,
@@ -51,6 +51,11 @@ function LocationSingle(props = {}) {
 
   // note : Gets Campus Name from pathname
   let campus = startCase(routing?.pathname.substring(10));
+
+  // note : Fixes campus name for Port St. Lucie
+  if (includes(campus, 'St ')) {
+    campus = replace(campus, 'St ', 'St. ');
+  }
 
   // note : We need to override the campus name to for CFE to properly format it for querying purposes
   if (includes(campus, 'Español')) {


### PR DESCRIPTION
### About
This PR fixes the PSL Location Page by adding a catch for Port St. Lucie Campus Name.

### Test Instructions
* go to `/locations/port-st-lucie` and see that the Campus Info now loads correctly.

### Screenshots
![image](https://user-images.githubusercontent.com/46049974/198038410-e2bf4898-1d9a-466e-b368-edb3c0101bf2.png)

### Closes Tickets
[CFDP-2308](https://christfellowshipchurch.atlassian.net/browse/CFDP-2308)
