### PR TITLE
Updated YA and Sisterhood links on the menu

### DIFF
--- a/config/mobile-nav-links.js
+++ b/config/mobile-nav-links.js
@@ -107,7 +107,7 @@ const navigation = {
         },
         {
           call: 'Young Adults',
-          action: '/discover/young-adults?id=1121835fdcef90201fb42675c92bd0a9',
+          action: '/young-adults',
         },
         {
           call: 'Men',
@@ -115,7 +115,7 @@ const navigation = {
         },
         {
           call: 'Sisterhood',
-          action: '/discover/sisterhood?id=49de7405752fb756e36856e32b732207',
+          action: '/sisterhood',
         },
         {
           call: 'Marriage',

--- a/config/new-nav-links.js
+++ b/config/new-nav-links.js
@@ -116,11 +116,11 @@ const navigation = {
         },
         {
           call: 'Young Adults',
-          action: '/discover/young-adults?id=1121835fdcef90201fb42675c92bd0a9',
+          action: 'young-adults',
         },
         {
           call: 'Sisterhood',
-          action: '/discover/sisterhood?id=49de7405752fb756e36856e32b732207',
+          action: 'sisterhood',
         },
         {
           call: 'Men',


### PR DESCRIPTION
### About
Updated YA and Sisterhood links on the menu

### Test Instructions
Open Young Adults or Sisterhood from the menu and it should take you to the new links:
'/sisterhood'
'/young-adults'

### Closes Tickets
CFDP-2226
CFDP-2227

