### PR TITLE
Changed Ministries and YA links

### DIFF
--- a/components/LocationBlockFeature/defaultBlockData.js
+++ b/components/LocationBlockFeature/defaultBlockData.js
@@ -74,7 +74,7 @@ const locationBlockData = [
         relatedNode: {
           __typename: 'Url',
           id: 'Url:f4974a223763b3a06ea2cd73ff30952be89d6281e05bc41f7ee423cd227a2b00ac473ab51d6349eb947f770d463c04fc83a72f8b7a0522333e94950a0fc721fc10f4fb466bd6d032935690b552c306ca3b00fdd2fe74edeadb0f0b65b8070e31',
-          url: 'https://www.christfellowship.church/events/cf-young-adults',
+          url: 'https://www.christfellowship.church/young-adults',
         },
         title: 'LEARN MORE',
       },

--- a/config/new-nav-links.js
+++ b/config/new-nav-links.js
@@ -103,7 +103,7 @@ const navigation = {
     {
       headerLink: {
         call: 'Ministries',
-        action: '/discover?c=ministries',
+        action: '/ministries',
       },
       subLinks: [
         {


### PR DESCRIPTION
### About
Changed Ministries and YA links

### Test Instructions
Go to the menu and open Ministries (web only) should take you to /ministries 
Go to a location page and click on LEARN MORE under YA, it should take you to /young-adults 

### Closes Tickets
[CFDP-2309](https://christfellowshipchurch.atlassian.net/jira/software/projects/CFDP/boards/2?selectedIssue=CFDP-2309)
[CFDP-2310](https://christfellowshipchurch.atlassian.net/jira/software/projects/CFDP/boards/2?selectedIssue=CFDP-2310)

