### PR TITLE
Added the ability to add buttons to content categories from rock

### DIFF
--- a/components/VerticalCardListFeature/VerticalCardListFeature.js
+++ b/components/VerticalCardListFeature/VerticalCardListFeature.js
@@ -3,7 +3,13 @@ import PropTypes from 'prop-types';
 import isEmpty from 'lodash/isEmpty';
 
 import { CustomLink } from 'components';
-import { Box, CardGrid, HorizontalHighlightCard, HtmlRenderer } from 'ui-kit';
+import {
+  Box,
+  Button,
+  CardGrid,
+  HorizontalHighlightCard,
+  HtmlRenderer,
+} from 'ui-kit';
 import { getUrlFromRelatedNode, transformISODates } from 'utils';
 import Styled from './VerticalCardListFeature.styles';
 
@@ -14,6 +20,8 @@ function VerticalCardListFeature(props = {}) {
     return null;
   }
 
+  let buttonTitle = data?.actions[0]?.title;
+  let buttonUrl = data?.actions[0]?.relatedNode.url;
   let title = data?.title;
   let subtitle = data?.subtitle;
   let cards = data?.cards;
@@ -42,6 +50,11 @@ function VerticalCardListFeature(props = {}) {
           ))}
         </CardGrid>
       )}
+      {buttonTitle ? (
+        <Button as="a" mt="base" href={buttonUrl}>
+          {buttonTitle}
+        </Button>
+      ) : null}
     </Box>
   );
 }

--- a/fragments/features.js
+++ b/fragments/features.js
@@ -292,6 +292,13 @@ const VERTICAL_CARD_LIST_FEATURE_FRAGMENT = gql`
     isFeatured
     title
     subtitle
+    actions {
+      title
+      action
+      relatedNode {
+        ...RelatedFeatureNodeFragment
+      }
+    }
     cards {
       id
       action


### PR DESCRIPTION
### About
Added the ability to add buttons to content categories from Rock

### Test Instructions
1. Open any content category like https://rock.christfellowship.church/page/1655?ContentItemId=7167
2. Add a Call to Action
3. You should see it on the website http://localhost:3000/christ-fellowship-kids

### Screenshots
<img width="1367" alt="Screen Shot 2022-11-17 at 2 24 20 PM" src="https://user-images.githubusercontent.com/46769629/202539553-297a77c4-fea1-4f6b-8c81-ff2ca9e5a6ea.png">

### Closes Tickets
[CFDP-2222](https://christfellowshipchurch.atlassian.net/browse/CFDP-2222)