### PR TITLE
Added link tree redirect

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -56,7 +56,7 @@ module.exports = {
       },
       {
         source: '/info',
-        destination: '/link-tree/info',
+        destination: 'https://lnk.bio/christfellowship.church',
         permanent: true,
       },
       {
@@ -79,11 +79,6 @@ module.exports = {
       {
         source: '/devotionals/dont-let-anyone-despise-you',
         destination: '/devotionals/dont-let-anyone-look-down-on-you',
-        permanent: true,
-      },
-      {
-        source: '/link-tree/info',
-        destination: 'https://lnk.bio/christfellowship.church',
         permanent: true,
       },
       // TODO: Uncomment these lines to hide Group Finder.

--- a/next.config.js
+++ b/next.config.js
@@ -81,6 +81,11 @@ module.exports = {
         destination: '/devotionals/dont-let-anyone-look-down-on-you',
         permanent: true,
       },
+      {
+        source: '/link-tree/info',
+        destination: 'https://lnk.bio/christfellowship.church',
+        permanent: true,
+      },
       // TODO: Uncomment these lines to hide Group Finder.
       // NOTE: We can't get `config/flags` in this file.
       // {

--- a/public/_redirects
+++ b/public/_redirects
@@ -12,3 +12,4 @@
 /content/how-to-lead-communion-in-your-home-3cbe3357238650b7bbf3011f2356fb57 /articles/how-to-lead-communion-in-your-home
 /items/how-to-lead-communion-in-your-home-3cbe3357238650b7bbf3011f2356fb57 /articles/how-to-lead-communion-in-your-home
 /devotionals/dont-let-anyone-despise-you   /devotionals/dont-let-anyone-look-down-on-you
+/link-tree/info                         https://lnk.bio/christfellowship.church

--- a/public/_redirects
+++ b/public/_redirects
@@ -6,10 +6,9 @@
 /community/:title                       /groups/:title
 /items/42eda0fe3fbf3f200a2872df727d4440 /groups
 /baptism                                /articles/baptism-faqs
-/info                                   /link-tree/info
+/info                                   https://lnk.bio/christfellowship.church
 /sisterhood-night                       /link-tree/sisterhood-night
 /sisterhood-night                       /link-tree/sisterhood-night
 /content/how-to-lead-communion-in-your-home-3cbe3357238650b7bbf3011f2356fb57 /articles/how-to-lead-communion-in-your-home
 /items/how-to-lead-communion-in-your-home-3cbe3357238650b7bbf3011f2356fb57 /articles/how-to-lead-communion-in-your-home
-/devotionals/dont-let-anyone-despise-you   /devotionals/dont-let-anyone-look-down-on-you
-/link-tree/info                         https://lnk.bio/christfellowship.church
+/devotionals/dont-let-anyone-despise-you   /devotionals/dont-let-anyone-look-down-on-you                     


### PR DESCRIPTION
### About
This PR redirect users from /info to the new link tree link: https://lnk.bio/christfellowship.church

### Test Instructions
Open the testing link + /info and it should take you to https://lnk.bio/christfellowship.church

### Screenshots
N/A

### Closes Tickets
[CFDP-2351](https://christfellowshipchurch.atlassian.net/jira/software/projects/CFDP/boards/2?selectedIssue=CFDP-2351)

### Related Tickets
N/A

