### PR TITLE
Action Banner Color Update

### DIFF
--- a/components/ActionBanner/ActionBanner.styles.js
+++ b/components/ActionBanner/ActionBanner.styles.js
@@ -44,7 +44,7 @@ const PrimaryButton = styled(Button)`
 
 const SecondaryButton = styled(Button)`
   background-color: ${props =>
-    props?.isLight ? themeGet('colors.neutrals.500') : 'white'};
+    props?.isLight ? themeGet('colors.neutrals.800') : 'white'};
   color: ${themeGet('colors.secondary')};
 
   &:hover {

--- a/components/Nav/Nav.js
+++ b/components/Nav/Nav.js
@@ -84,7 +84,7 @@ function Nav(props = {}) {
         <CurrentUserProvider
           Component={UserAvatar}
           handleAuthClick={handleAuthClick}
-          size={40}
+          size={'40'}
         />
       )}
     </Styled>


### PR DESCRIPTION
### About
Updated neutral color for secondary button when color is light.

### Test Instructions
* run web and look at banner.

### Screenshots
![image](https://user-images.githubusercontent.com/46049974/207906915-c96d491c-9c2e-49d5-b928-9b93cf077ba1.png)

### Closes Tickets
[CFDP-2384](https://christfellowshipchurch.atlassian.net/browse/CFDP-2384)

