### PR TITLE
Segment Categories and Content Tags

### DIFF
--- a/components/ContentSingle/ContentSingle.js
+++ b/components/ContentSingle/ContentSingle.js
@@ -1,20 +1,22 @@
 import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import { format } from 'date-fns';
+import { get, keyBy } from 'lodash';
 
-import { Box, Avatar, Loader, Card, Button } from 'ui-kit';
+import { Box, Avatar, Loader, Button } from 'ui-kit';
 import { ContentLayout, Share } from 'components';
 import { useNodeActions } from 'hooks';
 import { getUrlFromRelatedNode } from 'utils';
+import { useAnalytics } from 'providers/AnalyticsProvider';
 
 import ContentVideo from './ContentVideo';
 import ContentVideosList from './ContentVideosList';
 import Styled from './ContentSingle.styles';
-import { find, findIndex, includes, keyBy } from 'lodash';
 function ContentSingle(props = {}) {
   const [currentVideo, setCurrentVideo] = useState(
     Array.isArray(props.data?.videos) ? props.data.videos[0] : null
   );
+  const analytics = useAnalytics();
 
   const { actions } = useNodeActions({
     variables: {
@@ -29,6 +31,19 @@ function ContentSingle(props = {}) {
       setCurrentVideo(props.data.videos[0]);
     }
   }, [props.data?.videos, currentVideo]);
+
+  /**
+   * note : Page view tracking for Segment Analytics
+   */
+  if (props?.data?.segmentData) {
+    analytics.page({
+      name: props?.data?.title,
+      properties: {
+        category: get(props?.data?.segmentData, 'category', null),
+        contentTags: get(props?.data?.segmentData, 'contentTags', null),
+      },
+    });
+  }
 
   if (props.loading) {
     return (

--- a/hooks/useContentItem.js
+++ b/hooks/useContentItem.js
@@ -130,6 +130,35 @@ export const INFORMATIONAL_ITEM_FRAGMENT = gql`
   }
 `;
 
+export const SEGMENT_FRAGMENT = gql`
+  fragment segmentFragment on ContentItem {
+    ... on ContentSeriesContentItem {
+      segmentData {
+        category
+        contentTags
+      }
+    }
+    ... on UniversalContentItem {
+      segmentData {
+        category
+        contentTags
+      }
+    }
+    ... on DevotionalContentItem {
+      segmentData {
+        category
+        contentTags
+      }
+    }
+    ... on MediaContentItem {
+      segmentData {
+        category
+        contentTags
+      }
+    }
+  }
+`;
+
 export const GET_CONTENT_ITEM = gql`
   query getContentItem($pathname: String) {
     getNodeByPathname(pathname: $pathname) {
@@ -140,6 +169,7 @@ export const GET_CONTENT_ITEM = gql`
         ...eventContentItemFragment
         ...informationalContentItemFragment
         ...publishFragment
+        ...segmentFragment
       }
 
       ... on MediaContentItem {
@@ -169,6 +199,7 @@ export const GET_CONTENT_ITEM = gql`
   ${CONTENT_ITEM_FRAGMENT}
   ${PUBLISH_FRAGMENT}
   ${INFORMATIONAL_ITEM_FRAGMENT}
+  ${SEGMENT_FRAGMENT}
 
   ${ACTION_BAR_FEATURE_FRAGMENT}
   ${ACTION_LIST_FEATURE_FRAGMENT}


### PR DESCRIPTION
### About
This PR adds the `categories` and `contentTags` attributes to our ContentItems for Segment so we can track our pageviews with more properties.

### Test Instructions
* go to `/articles/peace-in-relationships`
* Using the [Segment Tracker](https://chrome.google.com/webstore/detail/segment-event-tracker/hbanigoffkilibdakdmmlgefndpjmajl?hl=en) plugin for Google Chrome, you'll see the new attributes on that page under `properties`.

### Screenshots
<img width="1560" alt="image" src="https://user-images.githubusercontent.com/46049974/210015413-d8de2f22-96bc-442d-bd50-1d2f86ba9247.png">

### Closes Tickets
[CFDP-2264](https://christfellowshipchurch.atlassian.net/browse/CFDP-2264)
