### PR TITLE
Added "class" to group finder 

### DIFF
--- a/components/CommunityActionSection/CommunityActionSection.js
+++ b/components/CommunityActionSection/CommunityActionSection.js
@@ -23,7 +23,7 @@ export default function CommunityActionSection(props) {
         Search All Groups & Classes
       </Button>
       <CustomLink target="_blank" href="https://rock.gocf.org/page/2113">
-        Help Me Find a Group
+        Help Me Find a Group or Class
       </CustomLink>
     </Box>
   );


### PR DESCRIPTION
### About
Added class to "Help Me Find a Group"

### Test Instructions
Open any of the group finder pages under /groups and you'll see it at the bottom 

### Closes Tickets
[CFDP-2437](https://christfellowshipchurch.atlassian.net/jira/software/projects/CFDP/boards/2?selectedIssue=CFDP-2437)



[CFDP-2437]: https://christfellowshipchurch.atlassian.net/browse/CFDP-2437?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ