### PR TITLE
Non Clickable Redirect Cards

### DIFF
--- a/components/VerticalCardListFeature/VerticalCardListFeature.js
+++ b/components/VerticalCardListFeature/VerticalCardListFeature.js
@@ -28,22 +28,37 @@ function VerticalCardListFeature(props = {}) {
       <HtmlRenderer htmlContent={subtitle} />
       {cards && cards.length > 0 && (
         <CardGrid marginBottom="base" marginTop="base" columns={'12'}>
-          {cards.map((card, i) => (
-            <Styled.CardSpacing key={i} index={i} total={cards.length}>
-              <CustomLink
-                as="a"
-                key={i}
-                href={getUrlFromRelatedNode(card?.relatedNode)}
-                Component={props?.Component ?? HorizontalHighlightCard}
-                coverImage={card?.coverImage?.sources[0]?.uri}
-                coverImageOverlay={true}
-                title={card?.title}
-                description={card?.summary}
-                type={cards.length < 2 ? 'DEFAULT' : 'HIGHLIGHT_SMALL'}
-                label={transformISODates(card?.labelText)}
-              />
-            </Styled.CardSpacing>
-          ))}
+          {cards.map((card, i) => {
+            const url = getUrlFromRelatedNode(card?.relatedNode);
+            const nonClickable = url === '#no-click';
+            return (
+              <Styled.CardSpacing key={i} index={i} total={cards.length}>
+                {nonClickable ? (
+                  <HorizontalHighlightCard
+                    coverImage={card?.coverImage?.sources[0]?.uri}
+                    coverImageOverlay={true}
+                    title={card?.title}
+                    description={card?.summary}
+                    type={cards.length < 2 ? 'DEFAULT' : 'HIGHLIGHT_SMALL'}
+                    label={transformISODates(card?.labelText)}
+                  />
+                ) : (
+                  <CustomLink
+                    as="a"
+                    href={url}
+                    key={i}
+                    Component={props?.Component ?? HorizontalHighlightCard}
+                    coverImage={card?.coverImage?.sources[0]?.uri}
+                    coverImageOverlay={true}
+                    title={card?.title}
+                    description={card?.summary}
+                    type={cards.length < 2 ? 'DEFAULT' : 'HIGHLIGHT_SMALL'}
+                    label={transformISODates(card?.labelText)}
+                  />
+                )}
+              </Styled.CardSpacing>
+            );
+          })}
         </CardGrid>
       )}
       {actions &&


### PR DESCRIPTION
### About
Added support for Non Clickable Redirect Cards. When creating a Redirect Card set the URL value to `#no-click` and this will disable to the card.

### Test Instructions
* go to `/pams-test` and see the "Non Clickable Card Test" under "Test Order"

### Screenshots
![image](https://user-images.githubusercontent.com/46049974/215174496-2262a561-59ff-4a3b-8425-e824ac934cd1.png)

### Closes Tickets
[CFDP-2185](https://christfellowshipchurch.atlassian.net/browse/CFDP-2185)

[CFDP-2185]: https://christfellowshipchurch.atlassian.net/browse/CFDP-2185?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ