### PR TITLE
Video Player Fix

### DIFF
--- a/components/Video/Video.js
+++ b/components/Video/Video.js
@@ -21,12 +21,15 @@ export default function Video(props = {}) {
   const notPlaying = () => setIsPlaying(false);
 
   return (
-    <Box position="relative" height="100%" width="100%" className='react-player'>
+    <Box
+      position="relative"
+      height="100%"
+      width="100%"
+      className="react-player"
+    >
       <ReactPlayer
         url={props?.src}
         controls={true}
-        width="100%"
-        height="100%"
         playing={isPlaying}
         onPause={notPlaying}
         onSeek={playing}

--- a/components/Video/Video.js
+++ b/components/Video/Video.js
@@ -23,11 +23,13 @@ export default function Video(props = {}) {
   return (
     <Box
       position="relative"
-      height="100%"
-      width="100%"
+      height={props?.height}
+      width={props?.width}
       className="react-player"
     >
       <ReactPlayer
+        height="100%"
+        width="100%"
         url={props?.src}
         controls={true}
         playing={isPlaying}
@@ -60,3 +62,8 @@ export default function Video(props = {}) {
     </Box>
   );
 }
+
+Video.defaultProps = {
+  height: '100%',
+  width: '100%',
+};

--- a/ui-kit/ContentBlock/ContentBlock.js
+++ b/ui-kit/ContentBlock/ContentBlock.js
@@ -72,6 +72,9 @@ function ContentBlock(props = {}) {
 
           <Conditional condition={hasVideo}>
             <Video
+              // for some reason width and height are not responding correctly in this component so we must set them manually here
+              height={{ _: 180, md: 325, lg: 450 }}
+              width={{ _: 300, md: 600, lg: 800 }}
               src={props?.videos[0]?.sources[0]?.uri}
               autoPlay={false}
               playsInline={true}


### PR DESCRIPTION
### About
Updated Video styling to fix player size for Content Blocks.

### Test Instructions
* go to `/get-there-first` and see that the video is not super small anymore.

### Screenshots
![image](https://user-images.githubusercontent.com/46049974/216115234-b1ceeec6-a0c7-4291-9f53-5e4b95036ff0.png)

### Closes Tickets
[CFDP-2442](https://christfellowshipchurch.atlassian.net/browse/CFDP-2442)
[CFDP-2018](https://christfellowshipchurch.atlassian.net/browse/CFDP-2018)


[CFDP-2442]: https://christfellowshipchurch.atlassian.net/browse/CFDP-2442?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CFDP-2018]: https://christfellowshipchurch.atlassian.net/browse/CFDP-2018?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ