### PR TITLE
Added Studies and Resources to Group Finder Home Page

### DIFF
--- a/components/CommunityLeaderActions/CommunityLeaderActions.js
+++ b/components/CommunityLeaderActions/CommunityLeaderActions.js
@@ -31,7 +31,7 @@ export default function CommunityLeaderActions(props) {
         display="grid"
         px={{ _: 'base', md: 'xxl' }}
         py={{ _: 'l', md: 'xxl' }}
-        gridTemplateColumns={{ _: 'repeat(1, 1fr)', md: 'repeat(2, 1fr)' }}
+        gridTemplateColumns={{ _: 'repeat(1, 1fr)', md: 'repeat(3, 1fr)' }}
         gridColumnGap="l"
         textAlign="center"
       >
@@ -51,6 +51,27 @@ export default function CommunityLeaderActions(props) {
               onClick={handleMyGroups}
             >
               View My Groups
+            </Button>
+          </Box>
+        </Box>
+
+        <Box mb={{ _: 'xl', md: 0 }}>
+          <Icon name="book" size="40" mb="s" color="subdued" />
+          <Box>
+            <Box as="h2" mb="s">
+              Studies and Resources
+            </Box>
+            <Box as="p" mb="base">
+              Looking for a study for your group or personal growth?
+            </Box>
+            <Button
+              as="a"
+              size="s"
+              variant="secondary"
+              href="/studies-and-resources"
+              rounded={true}
+            >
+              Preview Resources
             </Button>
           </Box>
         </Box>


### PR DESCRIPTION
### About
Added Studies and Resources to Group Finder Home Page

### Test Instructions
Open the test link + /groups and you will see it at the bottom, make sure that the text matches what's on the ticket and the button works correctly 

### Screenshots
<img width="1436" alt="Screen Shot 2023-02-08 at 8 26 59 AM" src="https://user-images.githubusercontent.com/46769629/217543049-5ecdcbf9-d288-4337-8e30-be307fac6ae2.png">

### Closes Tickets
[CFDP-2436](https://christfellowshipchurch.atlassian.net/jira/software/projects/CFDP/boards/2?selectedIssue=CFDP-2436)

### Related Tickets
N/A


[CFDP-2436]: https://christfellowshipchurch.atlassian.net/browse/CFDP-2436?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ