### PR TITLE
Added "daily" option to Group Finder Schedule 

### DIFF
--- a/components/CommunityLeaderActions/CommunityLeaderActions.js
+++ b/components/CommunityLeaderActions/CommunityLeaderActions.js
@@ -45,6 +45,7 @@ export default function CommunityLeaderActions(props) {
               Already in a group? Log in to view your groups.
             </Box>
             <Button
+              as="a"
               size="s"
               variant="secondary"
               rounded={true}

--- a/providers/GroupFiltersProvider.js
+++ b/providers/GroupFiltersProvider.js
@@ -11,6 +11,7 @@ const GroupFiltersProviderDispatchContext = createContext();
 const options = Object.freeze({
   campuses: [],
   days: [
+    'Daily',
     'Sunday',
     'Monday',
     'Tuesday',


### PR DESCRIPTION
### About
Added "daily" option to Group Finder Schedule 

### Test Instructions
Open the group finder, you should see it on the left side under Meeting Days

### Screenshots
<img width="1440" alt="Screen Shot 2023-02-09 at 7 43 21 AM" src="https://user-images.githubusercontent.com/46769629/217815924-5b09ccf3-1771-4a7e-bdfe-e8a15cf5b83f.png">

### Closes Tickets
[CFDP-2435](https://christfellowshipchurch.atlassian.net/jira/software/projects/CFDP/boards/2?selectedIssue=CFDP-2435)

### Related Tickets
N/A


[CFDP-2435]: https://christfellowshipchurch.atlassian.net/browse/CFDP-2435?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ