### PR TITLE
Fixed spelling of Pastor Ryan's last name

### DIFF
--- a/lib/aboutData.js
+++ b/lib/aboutData.js
@@ -205,7 +205,7 @@ const teachingTeam = {
       },
     },
     {
-      title: 'Ryan Mcdermont',
+      title: 'Ryan McDermott',
       summary: 'Teaching Pastor',
       coverImage: {
         sources: [


### PR DESCRIPTION
### About
Fixed spelling of Pastor Ryan's last name, from McDermont to McDermott

### Test Instructions
Open the about page and confirm the last name is spelled correctly 

### Closes Tickets
No ticket 

### Related Tickets
N/A
