### PR TITLE
Fixed all addresses to be in 2 lines and updated a link 

### DIFF
--- a/components/ExternalHome/StartHere.js
+++ b/components/ExternalHome/StartHere.js
@@ -40,7 +40,7 @@ const StartHere = ({ maxWidth }) => {
       subtitle:
         'We’ve designed a path for you and your family to grow in your faith, find friends, and serve others.',
       image: 'discover-whats-here.jpeg',
-      url: '/discover-whats-here',
+      url: '/it-all-starts-here',
     },
     {
       title: 'Ask a Question',

--- a/components/LocationSingle/CampusInfo.js
+++ b/components/LocationSingle/CampusInfo.js
@@ -111,8 +111,6 @@ const CampusInfo = ({
   const handleCampusDirections =
     name === 'Trinity' ? trinityCampusDirections : allCampusesDirections;
 
-  console.log(street1);
-
   return (
     <Box bg="white">
       {/* Campus Information */}

--- a/components/LocationSingle/CampusInfo.js
+++ b/components/LocationSingle/CampusInfo.js
@@ -60,7 +60,8 @@ const CampusInfo = ({
   additionalInfo,
 }) => {
   const modalDispatch = useModalDispatch();
-  const address = `${street1} ${city}, ${state} ${postalCode?.substring(0, 5)}`;
+  const addressFirst = `${street1}`;
+  const addressLast = `${city}, ${state} ${postalCode?.substring(0, 5)}`;
 
   const icsLinkEvents = serviceTimes?.map(({ day, time }) => {
     const dayKey = DAY_KEYS[day.toUpperCase()] ?? 0;
@@ -76,7 +77,7 @@ const CampusInfo = ({
       event: {
         title: 'Sunday service at Christ Fellowship Church',
         description: `Join us this Sunday!`,
-        address,
+        addressFirst,
         startTime: sunday,
         endTime: addMinutes(sunday, 90),
       },
@@ -101,7 +102,7 @@ const CampusInfo = ({
   /** Directions to all Campuses except Trinity Campus (has special link) */
   const allCampusesDirections = campusLink?.googleMap
     ? campusLink?.googleMap
-    : `https://www.google.com/maps/place/${address?.replace(' ', '+')}`;
+    : `https://www.google.com/maps/place/${addressFirst?.replace(' ', '+')}`;
 
   /** Trinity Campus Directions Link */
   const trinityCampusDirections =
@@ -109,6 +110,8 @@ const CampusInfo = ({
 
   const handleCampusDirections =
     name === 'Trinity' ? trinityCampusDirections : allCampusesDirections;
+
+  console.log(street1);
 
   return (
     <Box bg="white">
@@ -161,7 +164,7 @@ const CampusInfo = ({
               </Styled.InfoBox>
             )}
             {/* Address and Church You Call Home */}
-            {address && (
+            {addressFirst && (
               <>
                 <Box
                   display="flex"
@@ -185,7 +188,8 @@ const CampusInfo = ({
                     maxWidth={300}
                     flex="1"
                   >
-                    {address}
+                    <Box>{addressFirst}</Box>
+                    <Box>{addressLast}</Box>
                   </Box>
                   <Box textAlign="right" flex="1">
                     <Button


### PR DESCRIPTION
### About
This PR:
1. Makes all campus address have 2 lines where the city, state and zip code display on a second line always (mobile, desktop and all screen sizes)
2. Updates the Discover What's Here Link from [this one](https://www.christfellowship.church/discover-whats-here) to [this one](https://www.christfellowship.church/it-all-starts-here) 

### Test Instructions
Open the campus pages to test addresses
Open the external web page to test link 

See more details on the ticket or [this document](https://docs.google.com/document/d/1I_58wJGgMdU_0yERq5141vAbwFC3_yDaGVx7Xn2e8gQ/edit#) 

### Screenshots
<img width="1440" alt="Screen Shot 2023-03-15 at 2 33 26 PM" src="https://user-images.githubusercontent.com/46769629/225408712-8fc38ab3-5285-4da3-8953-c680700a886d.png">

### Closes Tickets
[CFDP-2493](https://christfellowshipchurch.atlassian.net/jira/software/projects/CFDP/boards/2?selectedIssue=CFDP-2493)

### Related Tickets
N/A


[CFDP-2493]: https://christfellowshipchurch.atlassian.net/browse/CFDP-2493?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ