### PR TITLE
Removed address for all group members

### DIFF
--- a/components/GroupMemberDetails/GroupMemberDetails.js
+++ b/components/GroupMemberDetails/GroupMemberDetails.js
@@ -157,12 +157,6 @@ const GroupMemberDetails = ({
         </Row>
       )}
 
-      {!isEmpty(person?.address) && (
-        <Row label="Address">
-          <Styled.Label as="h4">{renderAddress(person?.address)}</Styled.Label>
-        </Row>
-      )}
-
       <Row label="Notes">
         <TextArea
           id="group-leader-notes"


### PR DESCRIPTION
### About
Removed addresses for all group members

### Test Instructions
Open a group and find members, you should not see anybody's physical address

### Screenshots
<img width="1392" alt="Screen Shot 2023-03-28 at 7 25 49 PM" src="https://user-images.githubusercontent.com/46769629/228388915-88e5c8d6-c772-4dcd-8b18-8e7d83ff5e01.png">

### Closes Tickets
[CFDP-2250](https://christfellowshipchurch.atlassian.net/jira/software/projects/CFDP/boards/2?selectedIssue=CFDP-2250)

### Related Tickets

