### PR TITLE
Updated Pastor Ryan's Photo on About Page

### DIFF
--- a/lib/aboutData.js
+++ b/lib/aboutData.js
@@ -210,7 +210,7 @@ const teachingTeam = {
       coverImage: {
         sources: [
           {
-            uri: 'https://cloudfront.christfellowship.church/GetImage.ashx?guid=c27702eb-a5f5-44df-a2ea-ff8d7cd4b3d6',
+            uri: '/about/Ryan-McDermott.jpeg',
           },
         ],
       },


### PR DESCRIPTION
### About
Updated Pastor Ryan's photo on About page to new image provided 

### Test Instructions
Open the About page and you should see the new photo under Leadership

### Screenshots
<img width="1350" alt="Screen Shot 2023-04-03 at 2 10 57 PM" src="https://user-images.githubusercontent.com/46769629/229592026-e12bc193-6560-4807-9a6c-55a583145c0c.png">

### Closes Tickets
[CFDP-2508](https://christfellowshipchurch.atlassian.net/jira/software/projects/CFDP/boards/2?selectedIssue=CFDP-2508)

### Related Tickets
N/A


[CFDP-2508]: https://christfellowshipchurch.atlassian.net/browse/CFDP-2508?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ