### PR TITLE
Added Wistia Id to Content Items

### DIFF
--- a/components/ContentSingle/ContentSingle.js
+++ b/components/ContentSingle/ContentSingle.js
@@ -67,17 +67,20 @@ function ContentSingle(props = {}) {
     );
   }
 
-  const author = props?.data?.author;
-  const coverImage = props?.data?.coverImage;
-  const featureFeed = props?.data?.featureFeed;
-  const htmlContent = props?.data?.htmlContent;
-  const mode = props?.data?.mode;
-  const publishDate = props?.data?.publishDate;
-  const schedule = props?.data?.schedule;
-  const summary = props?.data?.summary;
-  const title = props?.data?.title;
-  const videos = props?.data?.videos;
-  const segmentData = props?.data?.segmentData;
+  const {
+    author,
+    coverImage,
+    featureFeed,
+    htmlContent,
+    mode,
+    publishDate,
+    schedule,
+    summary,
+    title,
+    videos,
+    segmentData,
+    wistiaId,
+  } = props?.data;
 
   const coverImageUri = coverImage?.sources[0]?.uri;
   const authorName = author
@@ -117,6 +120,7 @@ function ContentSingle(props = {}) {
           title={title}
           video={currentVideo}
           poster={coverImageUri}
+          wistiaId={wistiaId}
         />
       )}
       renderContentB={() =>

--- a/components/ContentSingle/ContentVideo.js
+++ b/components/ContentSingle/ContentVideo.js
@@ -23,6 +23,7 @@ export default function ContentVideo(props = {}) {
     <Styled.VideoContainer>
       <Video
         segmentData={props.segmentData}
+        wistiaId={props?.wistiaId}
         title={props.title}
         src={props.video.sources[0].uri}
         poster={props.poster}

--- a/hooks/useContentItem.js
+++ b/hooks/useContentItem.js
@@ -173,6 +173,7 @@ export const GET_CONTENT_ITEM = gql`
       }
 
       ... on MediaContentItem {
+        wistiaId
         metadata {
           name
           content


### PR DESCRIPTION
### About
This PR adds WistiaId to Content Items

### Test Instructions
* go to `/messages/discovering-your-priorities`
* you'll see that any content item with a `wistiaId` will now use the WistiaPlayer

### Screenshots
<img width="1391" alt="image" src="https://user-images.githubusercontent.com/46049974/234096539-76f6260d-6076-4bfa-a851-6d0d6b0fd1e8.png">

### Closes Tickets
[CFDP-2511](https://christfellowshipchurch.atlassian.net/browse/CFDP-2511)


[CFDP-2511]: https://christfellowshipchurch.atlassian.net/browse/CFDP-2511?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ