### PR TITLE
Changed Horizontal Card List Title to an H2

### DIFF
--- a/components/HorizontalCardListFeature/HorizontalCardListFeature.js
+++ b/components/HorizontalCardListFeature/HorizontalCardListFeature.js
@@ -80,7 +80,7 @@ function HorizontalCardListFeature(props = {}) {
 
   return (
     <Box textAlign="center">
-      {!isEmpty(title) && <Box as="h1">{title}</Box>}
+      {!isEmpty(title) && <Box as="h2">{title}</Box>}
       {!isEmpty(subtitle) && <HtmlRenderer htmlContent={subtitle} />}
       <CardCarousel
         cardsDisplayed={cardsDisplayed}


### PR DESCRIPTION
### About
Changed Horizontal Card List Title to an h2 to match the rest of the titles on our website. 

### Test Instructions
You can look at our Internal Home Page or this page to see that now all of the titles are the same font/consistent: /summer-at-christ-fellowship

### Screenshots
<img width="1366" alt="Screen Shot 2023-05-23 at 10 29 02 AM" src="https://github.com/christfellowshipchurch/web-app-v2/assets/46769629/1054facb-2c6c-4af9-9026-2d6a9dbaf002">

### Closes Tickets
[CFDP-2562](https://christfellowshipchurch.atlassian.net/jira/software/projects/CFDP/boards/2?selectedIssue=CFDP-2562)

### Related Tickets
N/A 
