### PR TITLE
Fixed the FAQ Scroll

### DIFF
--- a/components/FAQ/FAQ.js
+++ b/components/FAQ/FAQ.js
@@ -87,7 +87,7 @@ FAQ.defaultProps = {
   displayAll: false,
   showDescription: true,
   scrollPosition: {
-    desktop: 2800,
+    desktop: 3470,
     mobile: 4450,
   },
 };

--- a/components/FAQ/FAQ.js
+++ b/components/FAQ/FAQ.js
@@ -88,7 +88,7 @@ FAQ.defaultProps = {
   showDescription: true,
   scrollPosition: {
     desktop: 3470,
-    mobile: 4450,
+    mobile: 5270,
   },
 };
 

--- a/components/FAQ/FAQ.js
+++ b/components/FAQ/FAQ.js
@@ -88,7 +88,7 @@ FAQ.defaultProps = {
   showDescription: true,
   scrollPosition: {
     desktop: 3470,
-    mobile: 5270,
+    mobile: 4450,
   },
 };
 

--- a/components/LocationSingle/LocationSingle.js
+++ b/components/LocationSingle/LocationSingle.js
@@ -79,6 +79,29 @@ function LocationSingle(props = {}) {
   const campusAdditionalInfo = find(additionalInfoCampusData, { name: campus });
   const headerContent = find(headerData, { name: campus });
 
+  function campusScroll(campus) {
+    switch (campus) {
+      case 'Trinity': {
+        return {
+          desktop: 3490,
+          mobile: 5420,
+       }
+      }
+      case 'Downtown West Palm Beach': {
+        return {
+          desktop: 3470,
+          mobile: 4750,
+       }
+       }
+       default: {
+        return {
+          desktop: 3470,
+          mobile: 5270,
+        }
+      }
+    }
+  }
+
   return (
     <Layout
       contentMaxWidth={'100vw'}
@@ -143,7 +166,10 @@ function LocationSingle(props = {}) {
       {/* FAQs Section */}
       <Box bg="white" px="base" py="xl" width="100%">
         <Box mx="auto" maxWidth={1200}>
-          <FAQ data={faqData(campus)} />
+          <FAQ 
+            data={faqData(campus)}
+            scrollPosition={campusScroll(campus)}
+          />
         </Box>
       </Box>
 


### PR DESCRIPTION
### About
When clicking the see more or see less button it would scroll way above the FAQ Section. Now it scrolls to the right section.

### Test Instructions
1. Open any locations page.
2. Scroll down to the FAQ section.
3. Click 'See More'
4. Click 'See Less'
5. See the difference in the Preview Link 

### Screenshots
<img width="1436" alt="Screenshot 2023-05-24 at 2 05 03 PM" src="https://github.com/christfellowshipchurch/web-app-v2/assets/94265294/be6d2216-345a-43b2-a02c-fe8d02ae7d5d">

### Closes Tickets
[CFDP-2565](https://christfellowshipchurch.atlassian.net/jira/software/projects/CFDP/boards/2?selectedIssue=CFDP-2565)

### Related Tickets
N/A


[CFDP-2565]: https://christfellowshipchurch.atlassian.net/browse/CFDP-2565?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ