### PR TITLE
Adjusting My Prayers title on the Connect page 

### DIFF
--- a/components/HorizontalCardListFeature/HorizontalCardListFeature.js
+++ b/components/HorizontalCardListFeature/HorizontalCardListFeature.js
@@ -59,7 +59,7 @@ function HorizontalCardListFeature(props = {}) {
         {!isEmpty(subtitle) && <Box as="p">{subtitle}</Box>}
         <Box>
           {' '}
-          <Box as="a" href="https://rock.gocf.org/RequestPrayer">
+          <Box as="a" target="blank" href="https://rock.gocf.org/RequestPrayer">
             Click here
           </Box>{' '}
           to let us know how we can pray for you.

--- a/components/HorizontalCardListFeature/HorizontalCardListFeature.js
+++ b/components/HorizontalCardListFeature/HorizontalCardListFeature.js
@@ -59,7 +59,7 @@ function HorizontalCardListFeature(props = {}) {
         {!isEmpty(subtitle) && <Box as="p">{subtitle}</Box>}
         <Box>
           {' '}
-          <Box as="a" href="/connect">
+          <Box as="a" href="https://rock.gocf.org/RequestPrayer">
             Click here
           </Box>{' '}
           to let us know how we can pray for you.

--- a/components/HorizontalCardListFeature/HorizontalCardListFeature.js
+++ b/components/HorizontalCardListFeature/HorizontalCardListFeature.js
@@ -53,7 +53,19 @@ function HorizontalCardListFeature(props = {}) {
 
   console.log(cards.length);
   if (cards.length === 0) {
-    return <Box>You don't have any prayers right now</Box>;
+    return (
+      <Box>
+        {!isEmpty(title) && <Box as="h2">{title}</Box>}
+        {!isEmpty(subtitle) && <Box as="p">{subtitle}</Box>}
+        <Box>
+          {' '}
+          <Box as="a" href="/connect">
+            Click here
+          </Box>{' '}
+          to let us know how we can pray for you.
+        </Box>
+      </Box>
+    );
   }
   if (cards && cards[0]?.action === 'READ_PRAYER') {
     return props.loading ? (

--- a/components/HorizontalCardListFeature/HorizontalCardListFeature.js
+++ b/components/HorizontalCardListFeature/HorizontalCardListFeature.js
@@ -51,7 +51,6 @@ function HorizontalCardListFeature(props = {}) {
     );
   }
 
-  console.log(cards.length);
   if (cards.length === 0) {
     return (
       <Box>

--- a/components/HorizontalCardListFeature/HorizontalCardListFeature.js
+++ b/components/HorizontalCardListFeature/HorizontalCardListFeature.js
@@ -50,12 +50,17 @@ function HorizontalCardListFeature(props = {}) {
       </Box>
     );
   }
+
+  console.log(cards.length);
+  if (cards.length === 0) {
+    return <Box>You don't have any prayers right now</Box>;
+  }
   if (cards && cards[0]?.action === 'READ_PRAYER') {
     return props.loading ? (
       <Loader text="Loading your prayers" />
     ) : (
       <Box>
-        {!isEmpty(title) && <Box as="h1">{title}</Box>}
+        {!isEmpty(title) && <Box as="h2">{title}</Box>}
         {!isEmpty(subtitle) && <Box as="p">{subtitle}</Box>}
         <CardCarousel
           cardsDisplayed={4}

--- a/ui-kit/GroupCard/GroupCard.styles.js
+++ b/ui-kit/GroupCard/GroupCard.styles.js
@@ -77,7 +77,6 @@ const GroupCardContent = styled.div`
   display: flex;
   flex-direction: column;
   padding: ${themeGet('space.base')};
-  height: 100%;
 
   ${system}
 `;


### PR DESCRIPTION
### About
Adjusted the `My Prayers` title on the Connect page to be left aligned like the rest of the titles on that page, and to show a message when the user does not have any prayers. 

### Test Instructions
1. If you have prayer requests you need to delete them to test this ticket, go to your `Rock profile` and under `Prayers`, click on `Filter Options` and select `Show Expired Requests?`, then go ahead and select `No` under `Approved?` for all of your prayers. You can move them back to Approved after you're done testing. 
2. Open /connect 
3. You should see the `My Prayers` title left aligned 
4. You should see the "Click here to let us know how we can pray for you" message and `Click here` should take you to the Rock Prayer Request form on a new tab 

### Screenshots
<img width="1385" alt="Screen Shot 2023-06-07 at 1 26 04 PM" src="https://github.com/christfellowshipchurch/web-app-v2/assets/46769629/0072368f-ec82-40cf-b5b7-0b54477850fa">

<img width="317" alt="Screen Shot 2023-06-07 at 1 26 28 PM" src="https://github.com/christfellowshipchurch/web-app-v2/assets/46769629/57bea74e-9fad-4c72-a497-21232de4eb47">

### Closes Tickets
[CFDP-2598](https://christfellowshipchurch.atlassian.net/jira/software/projects/CFDP/boards/2?selectedIssue=CFDP-2598)

### Related Tickets
N/A


[CFDP-2598]: https://christfellowshipchurch.atlassian.net/browse/CFDP-2598?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ