### PR TITLE
Update Manage Group Content

### DIFF
--- a/components/GroupManage/AddResourceContent.js
+++ b/components/GroupManage/AddResourceContent.js
@@ -5,29 +5,33 @@ import { useGroupManage, update } from 'providers/GroupManageProvider';
 import { useUpdateGroupResourceContentItem } from 'hooks';
 import { Box, Button, Loader, Select } from 'ui-kit';
 
-function AddResourceContent(props = {}) {
-  const [
-    { resourceStatus: status, groupData, message },
-    dispatch,
-  ] = useGroupManage();
+function AddResourceContent({ data, loading, currentResources }) {
+  const [{ resourceStatus: status, groupData, message }, dispatch] =
+    useGroupManage();
   const setStatus = s => dispatch(update({ resourceStatus: s }));
-  const [selection, setSelection] = useState('');
+  const [selectedCategory, setSelectedCategory] = useState('');
+  const [selectedItem, setSelectedItem] = useState('');
 
   const [updateGroupResourceContentItem] = useUpdateGroupResourceContentItem();
 
-  function handleChange(event) {
-    setSelection(event.target.value);
-  }
+  const categories = categorizeItemsByTitle(data);
 
-  async function handleSave(event) {
+  const handleCategoryChange = event => {
+    setSelectedCategory(event.target.value);
+    setSelectedItem('');
+  };
+
+  const handleItemChange = event => {
+    setSelectedItem(event.target.value);
+  };
+
+  const handleSave = async event => {
     event.preventDefault();
 
-    const noSelection = selection === '';
+    const noSelection = selectedCategory === '' || selectedItem === '';
     if (noSelection) {
       dispatch(
-        update({
-          message: `You need to select an item in the menu.`,
-        })
+        update({ message: 'You need to select both a category and an item.' })
       );
       return;
     }
@@ -36,19 +40,19 @@ function AddResourceContent(props = {}) {
 
     await updateGroupResourceContentItem({
       variables: {
-        contentItemId: selection,
+        contentItemId: selectedItem,
         groupId: groupData.id,
       },
       refetchQueries: ['getGroup'],
     });
 
     setStatus('IDLE');
-  }
+  };
 
-  function handleBackClick(event) {
+  const handleBackClick = event => {
     event.preventDefault();
     setStatus('IDLE');
-  }
+  };
 
   return (
     <>
@@ -57,33 +61,51 @@ function AddResourceContent(props = {}) {
           {message}
         </Box>
       )}
-      {props.loading ? (
+      {loading ? (
         <Loader pt="s" pb="base" />
       ) : (
-        <Select
-          defaultValue=""
-          id="contentOption"
-          name="contentOption"
-          onChange={handleChange}
-          mb="base"
-        >
-          <Select.Option value="" disabled={true}>
-            Select...
-          </Select.Option>
-          {props.data?.map(item => {
-            return (
-              <Select.Option
-                key={item.node.id}
-                value={item.node.id}
-                disabled={props.currentResources?.find(
-                  resourceId => item.node.id === resourceId
-                )}
-              >
-                {item.node.title}
+        <>
+          <Select
+            defaultValue=""
+            id="categoryOption"
+            name="categoryOption"
+            value={selectedCategory}
+            onChange={handleCategoryChange}
+            mb="base"
+          >
+            <Select.Option value="" disabled>
+              Select a Category...
+            </Select.Option>
+            {Object.keys(categories).map(category => (
+              <Select.Option key={category} value={category}>
+                {category}
               </Select.Option>
-            );
-          })}
-        </Select>
+            ))}
+          </Select>
+          <Select
+            defaultValue=""
+            id="itemOption"
+            name="itemOption"
+            value={selectedItem}
+            onChange={handleItemChange}
+            mb="base"
+            disabled={!selectedCategory}
+          >
+            <Select.Option value="" disabled={!selectedCategory}>
+              Select an Item...
+            </Select.Option>
+            {selectedCategory &&
+              categories[selectedCategory].map(item => (
+                <Select.Option
+                  key={item.node.id}
+                  value={item.node.id}
+                  disabled={currentResources?.includes(item.node.id)}
+                >
+                  {item.node.title}
+                </Select.Option>
+              ))}
+          </Select>
+        </>
       )}
       <Box alignItems="center" display="flex">
         <Button
@@ -110,6 +132,26 @@ AddResourceContent.propTypes = {
       }),
     })
   ),
+  loading: PropTypes.bool,
+  currentResources: PropTypes.arrayOf(PropTypes.string),
 };
 
 export default AddResourceContent;
+
+// Helper function to categorize items based on words before the "|" symbol in the "title" attribute
+function categorizeItemsByTitle(data) {
+  const categories = {};
+
+  data.forEach(({ node }) => {
+    const titleParts = node.title.split('|');
+    const categoryName = titleParts.length > 1 ? titleParts[0].trim() : 'Other';
+
+    if (!categories[categoryName]) {
+      categories[categoryName] = [];
+    }
+
+    categories[categoryName].push({ node });
+  });
+
+  return categories;
+}

--- a/components/GroupManage/AddResourceContent.js
+++ b/components/GroupManage/AddResourceContent.js
@@ -18,7 +18,7 @@ function AddResourceContent({ data, loading, currentResources }) {
 
   useEffect(() => {
     if (!loading) {
-      // Simulating a delay of 500 milliseconds before setting isDataLoaded to true
+      // Adding a delay to the loading to make sure all the data is loaded for the categories to be created
       const delay = setTimeout(() => {
         const categorizedItems = categorizeItemsByTitle(data);
         setCategories(categorizedItems);

--- a/components/GroupManage/AddResourceContent.js
+++ b/components/GroupManage/AddResourceContent.js
@@ -5,7 +5,7 @@ import { useGroupManage, update } from 'providers/GroupManageProvider';
 import { useUpdateGroupResourceContentItem } from 'hooks';
 import { Box, Button, Loader, Select } from 'ui-kit';
 
-function AddResourceContent({ data, loading, currentResources }) {
+function AddResourceContent({ data, loading, totalCount, currentResources }) {
   const [{ resourceStatus: status, groupData, message }, dispatch] =
     useGroupManage();
   const setStatus = s => dispatch(update({ resourceStatus: s }));
@@ -16,18 +16,14 @@ function AddResourceContent({ data, loading, currentResources }) {
 
   const [updateGroupResourceContentItem] = useUpdateGroupResourceContentItem();
 
+  // ** We evetually want to update the way we load all the content items for Group resources in the backround and not have to wait for them to load all at once.
   useEffect(() => {
-    if (!loading) {
-      // Adding a delay to the loading to make sure all the data is loaded for the categories to be created
-      const delay = setTimeout(() => {
-        const categorizedItems = categorizeItemsByTitle(data);
-        setCategories(categorizedItems);
-        setIsDataLoaded(true);
-      }, 1500);
-
-      return () => clearTimeout(delay);
+    if (!loading && data && data.length === totalCount) {
+      const categorizedItems = categorizeItemsByTitle(data);
+      setCategories(categorizedItems);
+      setIsDataLoaded(true);
     }
-  }, [data, loading]);
+  }, [data, loading, totalCount]);
 
   const handleCategoryChange = event => {
     setSelectedCategory(event.target.value);
@@ -146,6 +142,7 @@ AddResourceContent.propTypes = {
     })
   ),
   loading: PropTypes.bool,
+  totalCount: PropTypes.number,
   currentResources: PropTypes.arrayOf(PropTypes.string),
 };
 

--- a/components/GroupManage/AddResourceContent.js
+++ b/components/GroupManage/AddResourceContent.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 
 import { useGroupManage, update } from 'providers/GroupManageProvider';
@@ -11,10 +11,23 @@ function AddResourceContent({ data, loading, currentResources }) {
   const setStatus = s => dispatch(update({ resourceStatus: s }));
   const [selectedCategory, setSelectedCategory] = useState('');
   const [selectedItem, setSelectedItem] = useState('');
+  const [categories, setCategories] = useState({});
+  const [isDataLoaded, setIsDataLoaded] = useState(false);
 
   const [updateGroupResourceContentItem] = useUpdateGroupResourceContentItem();
 
-  const categories = categorizeItemsByTitle(data);
+  useEffect(() => {
+    if (!loading) {
+      // Simulating a delay of 500 milliseconds before setting isDataLoaded to true
+      const delay = setTimeout(() => {
+        const categorizedItems = categorizeItemsByTitle(data);
+        setCategories(categorizedItems);
+        setIsDataLoaded(true);
+      }, 1500);
+
+      return () => clearTimeout(delay);
+    }
+  }, [data, loading]);
 
   const handleCategoryChange = event => {
     setSelectedCategory(event.target.value);
@@ -61,9 +74,7 @@ function AddResourceContent({ data, loading, currentResources }) {
           {message}
         </Box>
       )}
-      {loading ? (
-        <Loader pt="s" pb="base" />
-      ) : (
+      {isDataLoaded ? (
         <>
           <Select
             defaultValue=""
@@ -106,6 +117,8 @@ function AddResourceContent({ data, loading, currentResources }) {
               ))}
           </Select>
         </>
+      ) : (
+        <Loader pt="s" pb="base" />
       )}
       <Box alignItems="center" display="flex">
         <Button

--- a/providers/GroupResourceOptionsProvider.js
+++ b/providers/GroupResourceOptionsProvider.js
@@ -2,14 +2,11 @@ import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 
 import { useGroupResourceOptions } from 'hooks';
+import { Attachment } from 'stream-chat-react';
 
 function GroupResourceOptionsProvider({ Component, options, ...props }) {
-  const {
-    loading,
-    error,
-    groupResourceOptions,
-    fetchMore,
-  } = useGroupResourceOptions(options);
+  const { loading, error, groupResourceOptions, fetchMore } =
+    useGroupResourceOptions(options);
   const endCursor = groupResourceOptions?.pageInfo?.endCursor;
   const totalCount = groupResourceOptions?.totalCount;
   const data = groupResourceOptions?.edges;
@@ -46,7 +43,15 @@ function GroupResourceOptionsProvider({ Component, options, ...props }) {
     }
   }, [loading, error, data, endCursor, fetchMore, totalCount]);
 
-  return <Component data={data} loading={loading} error={error} {...props} />;
+  return (
+    <Component
+      data={data}
+      totalCount={totalCount}
+      loading={loading}
+      error={error}
+      {...props}
+    />
+  );
 }
 
 GroupResourceOptionsProvider.propTypes = {

--- a/ui-kit/Select/Select.styles.js
+++ b/ui-kit/Select/Select.styles.js
@@ -19,6 +19,8 @@ const Select = styled.select`
   max-width: 100%;
   padding: ${themeGet('space.s')};
   width: 100%;
+  word-wrap: break-word;
+  padding-right: 30px;
 
   :focus {
     border-color: ${themeGet('colors.primary')};


### PR DESCRIPTION
### About
This PR updates the Manage Group section specifically when updating content. We wanted to organize the content more so a user doesn't have to go through one giant list of items.

Now when selecting content from Rock you'll see that the content is organized by category. We added a function that creates categories based of the naming of content items by using the words that come before the `|` symbol in the title. You'll find that there are now two drop down menus. One for selecting the initial category and a second for the items in that category.

#### Caveats
Organizing by the content title means that we can't load incrementally when showing the items but must wait for ALL content times from that content channel to load before we display the categories. While this does solve the problem without touching the backend, we lengthening the wait time for the items to load. _We will most likely want to revisit using Rock tags and find a different way to pull in Group Resources._

### Test Instructions
* sign in and go to My Groups and Manage Content. Go to Resources and Add Content. You should now see two drop downs.

### Screenshots
![image](https://github.com/christfellowshipchurch/web-app-v2/assets/46049974/c78ae484-8f4e-46b7-aeb3-769e11f13871)

### Closes Tickets
[CFDP-2600](https://christfellowshipchurch.atlassian.net/browse/CFDP-2600)


[CFDP-2600]: https://christfellowshipchurch.atlassian.net/browse/CFDP-2600?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ