### PR TITLE
Redirected items and content to home

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -107,6 +107,18 @@ module.exports = {
         destination: '/messages/god-lives-in-you-joyce-meyer',
         permanent: true,
       },
+      {
+        source:
+          '/items/:title',
+        destination: '/',
+        permanent: true,
+      },
+      {
+        source:
+          '/content/:title',
+        destination: '/',
+        permanent: true,
+      },
       // TODO: Uncomment these lines to hide Group Finder.
       // NOTE: We can't get `config/flags` in this file.
       // {

--- a/pages/content/[title].js
+++ b/pages/content/[title].js
@@ -1,3 +1,7 @@
+/**
+ * ! This file is now deprecated, all `/content` routes are redirected to home
+ */
+
 import { LegacyNodeRouter } from 'components';
 
 /**

--- a/pages/items/[title].js
+++ b/pages/items/[title].js
@@ -1,3 +1,7 @@
+/**
+ * ! This file is now deprecated, all `/items` routes are redirected to home
+ */
+
 import { isEmpty } from 'lodash';
 import { useRouter } from 'next/router';
 

--- a/pages/locations/[title].js
+++ b/pages/locations/[title].js
@@ -125,7 +125,6 @@ export async function getStaticPaths() {
     'okeechobee',
     'palm-beach-gardens',
     'port-st-lucie',
-    'riviera-beach',
     'royal-palm-beach',
     'stuart',
     'vero-beach',

--- a/public/_redirects
+++ b/public/_redirects
@@ -17,3 +17,5 @@
 /nexus-platform                          https://www.nexusplatform.com
 /events/amazing-a-sisterhood-event       /events/amazing
 /items/god-lives-in-you-joyce-meyer-9638eed9752c44acffee9861ef2db161 /messages/god-lives-in-you-joyce-meyer
+/items/:title                            /
+/content/:title                          /


### PR DESCRIPTION
### About
This PR adds a redirect for `/items` and `/content` to the CF homepage.

### Test Instructions
1. Go to `/items` and it should redirect to the homepage
2. Go to `/content` and it should redirect to the homepage

### Screenshots
<img width="1333" alt="Screenshot 2023-06-09 at 4 39 11 PM" src="https://github.com/christfellowshipchurch/web-app-v2/assets/93110503/deafabdb-64b9-4e36-b851-13710d0fb49a">

### Closes Tickets
https://christfellowshipchurch.atlassian.net/browse/CFDP-2237?atlOrigin=eyJpIjoiY2UyOWJmNmRkMWZkNDNhODkxMzRiMzYwNjE4OGNlZWEiLCJwIjoiaiJ9