### PR TITLE
Fixed the Other Check Box on Connect Card

### DIFF
--- a/components/Modals/ConnectCardModal/ConnectCardForm.js
+++ b/components/Modals/ConnectCardModal/ConnectCardForm.js
@@ -94,7 +94,7 @@ function ConnectCardForm(props = {}) {
       ? 'I made a decision to follow Christ today.'
       : '';
     // prettier-ignore
-    const allThatApplies = `${values?.findCommunity ? 'f848c630-4a0d-4264-8c20-e6b77825f001,' : ''}${values?.growFaith ? '581dcac5-acad-498c-89dc-09245b3ad4df,' : ''}${values?.placeForKids ? '29e3b03c-4e3b-442b-8acf-2835ab13b262,' : ''}${values?.strongerMarriage ? '3b2af312-e888-4956-bc05-8a7e318fc68e,' : ''}${values?.improveFinances ? 'c0024735-e0e9-45d1-a3d3-6f42cb58b239,' : ''}${values?.useMyGifts ? '00546698-374e-4746-a99e-6d4381b5262d,' : ''}${values?.discoverAtTheJourney ? 'e989c798-cf52-44d8-8ddd-c8831e7601a1,' : ''}`;
+    const allThatApplies = `${values?.findCommunity ? 'f848c630-4a0d-4264-8c20-e6b77825f001,' : ''}${values?.growFaith ? '581dcac5-acad-498c-89dc-09245b3ad4df,' : ''}${values?.placeForKids ? '29e3b03c-4e3b-442b-8acf-2835ab13b262,' : ''}${values?.strongerMarriage ? '3b2af312-e888-4956-bc05-8a7e318fc68e,' : ''}${values?.improveFinances ? 'c0024735-e0e9-45d1-a3d3-6f42cb58b239,' : ''}${values?.useMyGifts ? '00546698-374e-4746-a99e-6d4381b5262d,' : ''}${values?.discoverAtTheJourney ? 'e989c798-cf52-44d8-8ddd-c8831e7601a1,' : ''}${values?.other ? '1d408930-f300-46f8-8200-b465a51049e3,' : ''}}`;
 
     const input = {
       firstName: values.firstName || '',

--- a/components/Modals/ConnectCardModal/StyledForm.js
+++ b/components/Modals/ConnectCardModal/StyledForm.js
@@ -194,7 +194,10 @@ const StyledForm = ({
             />
             <StyledCheckBox
               id="other"
-              onChange={() => setShowOther(!showOther)}
+              onChange={e => {
+                handleChange(e);
+                setShowOther(!showOther);
+              }}
               text="Other."
             />
           </Box>


### PR DESCRIPTION
### About
This PR fixes the Other checkbox on the Connect Card form and makes sure that it get's properly updated in Rock.

### Test Instructions
* test the Other checkbox in the Connect Card form
* check results in Rock [here](https://rock.gocf.org/page/288?WorkflowTypeId=902)

### Screenshots
![image](https://github.com/christfellowshipchurch/web-app-v2/assets/46049974/5bf96dea-4b42-40f9-807a-c2a0c7e578c9)

### Closes Tickets
[CFDP-2535](https://christfellowshipchurch.atlassian.net/browse/CFDP-2535)


[CFDP-2535]: https://christfellowshipchurch.atlassian.net/browse/CFDP-2535?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ