### PR TITLE
Items are now aligned to the left 

### DIFF
--- a/components/GroupSingle/GroupResources.js
+++ b/components/GroupSingle/GroupResources.js
@@ -19,7 +19,7 @@ export default function GroupResources(props = {}) {
       {props.resources
         .filter(resource => resource.title || resource.relatedNode?.title)
         .map(resource => (
-          <Box key={resource.relatedNode?.id} as="li">
+          <Box key={resource.relatedNode?.id} as="li" display="flex">
             <CustomLink
               key={resource.relatedNode?.id}
               href={getUrlFromRelatedNode(resource.relatedNode)}


### PR DESCRIPTION
### About
Added `display=flex` to start playing with the styling and this seemed to have fixed the issue, see before and after under Screenshots 

### Test Instructions
Open CFDP Testing Group and you should see the Resources are left aligned 

### Screenshots
**Before**
<img width="1348" alt="Screen Shot 2023-06-13 at 10 17 08 AM" src="https://github.com/christfellowshipchurch/web-app-v2/assets/46769629/c11e6841-cf8b-4ffb-ab13-4e6a95f13bfe">

**After**
<img width="1438" alt="Screen Shot 2023-06-13 at 10 17 43 AM" src="https://github.com/christfellowshipchurch/web-app-v2/assets/46769629/56a8b498-15a0-4360-872b-3aebb2711f47">

### Closes Tickets
[CFDP-2599](https://christfellowshipchurch.atlassian.net/jira/software/projects/CFDP/boards/2?selectedIssue=CFDP-2599)

### Related Tickets
N/A


[CFDP-2599]: https://christfellowshipchurch.atlassian.net/browse/CFDP-2599?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ