### PR TITLE
Fix Card Bug on External Home

### DIFF
--- a/components/ExternalHome/StartHere.js
+++ b/components/ExternalHome/StartHere.js
@@ -2,50 +2,56 @@ import React from 'react';
 import styled from 'styled-components';
 import { themeGet } from '@styled-system/theme-get';
 
-import { gtag } from 'lib/analytics';
-import { Box, Image, Button } from 'ui-kit';
-import { htmlToReactParser } from 'utils';
+import { Box, Image } from 'ui-kit';
 
-const StyledCard = styled.div`
+const buttonData = [
+  {
+    title: 'Find a Location',
+    subtitle:
+      'Attend a Sunday service, in person or online. We would love to meet you!',
+    image: 'find-a-location.jpg',
+    url: '/locations',
+  },
+  {
+    title: 'Discover What’s Here',
+    subtitle:
+      'We’ve designed a path for you and your family to grow in your faith, find friends, and serve others.',
+    image: 'discover-whats-here.jpeg',
+    url: '/it-all-starts-here',
+  },
+  {
+    title: 'Ask a Question',
+    subtitle:
+      'Have a question or need prayer? Let us know and our team will reach out to you!',
+    image: 'ask-a-question.jpeg',
+    url: 'https://rock.gocf.org/contactus',
+    target: '_blank',
+  },
+];
+
+const StyledCard = styled.a`
   background: white;
   border-radius: ${themeGet('radii.base')};
-  overflow: hidden;
   display: flex;
   flex-direction: column;
+  align-items: center;
   padding: ${themeGet('space.base')};
   padding-bottom: ${themeGet('space.l')};
-  height: 100%;
-
   box-shadow: ${themeGet('shadows.base')};
+  margin: ${themeGet('space.s')};
+  text-align: center;
   transition: box-shadow ease 0.3s, transform ease 0.3s;
+  text-decoration: none;
+  flex: 1;
+
+  &:hover {
+    box-shadow: ${themeGet('shadows.xl')};
+    cursor: pointer;
+    transform: scale(1.03);
+  }
 `;
 
 const StartHere = ({ maxWidth }) => {
-  const data = [
-    {
-      title: 'Find a Location',
-      subtitle:
-        'Attend a Sunday service, in person or online. We would love to meet you!',
-      image: 'find-a-location.jpg',
-      url: '/locations',
-    },
-    {
-      title: 'Discover What’s Here',
-      subtitle:
-        'We’ve designed a path for you and your family to grow in your faith, find friends, and serve others.',
-      image: 'discover-whats-here.jpeg',
-      url: '/it-all-starts-here',
-    },
-    {
-      title: 'Ask a Question',
-      subtitle:
-        'Have a question or need prayer? Let us know and our team will reach out to you!',
-      image: 'ask-a-question.jpeg',
-      url: 'https://rock.gocf.org/contactus',
-      target: '_blank',
-    },
-  ];
-
   return (
     <Box my="xl">
       <Box textAlign="center" my="l">
@@ -53,70 +59,33 @@ const StartHere = ({ maxWidth }) => {
           It all starts here.
         </Box>
       </Box>
-
       <Box
-        display={{ _: 'block', md: 'grid' }}
-        gridTemplateColumns="1fr 1fr 1fr"
-        gridTemplateRows="1fr"
-        gridGap="1rem 1rem"
-        gridTemplateAreas={`". . ."`}
-        textAlign="center"
-        maxWidth={maxWidth}
-        margin="auto"
+        display="flex"
+        flexGrow="1 1 0"
+        flexDirection={{ _: 'column', lg: 'row' }}
+        mx="auto"
+        maxWidth={1200}
       >
-        {data.map(({ title, subtitle, image, url, target }, i) => (
-          <Box
-            key={i}
-            mb={{ _: i === data.length - 1 ? '0' : 'base', md: '0' }}
-            display="flex"
-          >
+        {buttonData.map(({ title, subtitle, image, url, target }, i) => (
+          <StyledCard href={url} target={target}>
+            <Image aspectRatio="16by9" source={image} />
             <Box
-              as="a"
-              textDecoration="none"
-              color="black"
-              href={url}
-              target={target}
+              as="h3"
+              bg="secondary"
+              borderRadius="base"
+              p="s"
+              my="base"
+              color="white"
+              fontWeight="bold"
+              width="fit-content"
+              px="l"
             >
-              <StyledCard
-                boxShadow={i === 0 ? 'l' : 'base'}
-                onClick={() => [
-                  gtag.trackEvent({
-                    category: 'External Landing Page - It All Starts Here',
-                    label: `${title} - Button`,
-                    action: url,
-                  }),
-                ]}
-              >
-                <Image mb="2rem" source={image} aspectRatio="16by9" />
-
-                <Box px="s">
-                  <Box
-                    display="flex"
-                    justifyContent="center"
-                    alignItems="center"
-                  >
-                    <Button
-                      bg="secondary"
-                      as="h2"
-                      m="0"
-                      mb="0.25rem"
-                      fontSize={{ _: '1.1rem', lg: '1.25rem' }}
-                    >
-                      {title}
-                    </Button>
-                  </Box>
-                </Box>
-                <Box
-                  as="p"
-                  fontSize={{ _: '1rem', lg: '1.1rem' }}
-                  lineHeight="1.65rem"
-                  mt="s"
-                >
-                  {htmlToReactParser.parse(subtitle)}
-                </Box>
-              </StyledCard>
+              {title}
             </Box>
-          </Box>
+            <Box as="p" color="black">
+              {subtitle}
+            </Box>
+          </StyledCard>
         ))}
       </Box>
     </Box>

--- a/components/ExternalHome/StartHere.js
+++ b/components/ExternalHome/StartHere.js
@@ -18,12 +18,6 @@ const StyledCard = styled.div`
 
   box-shadow: ${themeGet('shadows.base')};
   transition: box-shadow ease 0.3s, transform ease 0.3s;
-
-  :hover {
-    box-shadow: ${themeGet('shadows.xl')};
-    cursor: pointer;
-    transform: scale(1.03);
-  }
 `;
 
 const StartHere = ({ maxWidth }) => {


### PR DESCRIPTION
### About
This PR removes the hover functionality on the three cards under the "It All Starts Here" section on the external homepage. 

### Test Instructions
1. Go to the "It all starts here" section on the external homepage.
2. Move your cursor over the three boxes. They should be clickable but there should not be any hover functionality.

### Screenshots
<img width="1433" alt="Screenshot 2023-06-19 at 12 55 40 PM" src="https://github.com/christfellowshipchurch/web-app-v2/assets/93110503/d11ef45a-601b-4b5b-a34b-e55d5df07368">

### Closes Tickets
[CFDP-2617](https://christfellowshipchurch.atlassian.net/browse/CFDP-2617)

[CFDP-2617]: https://christfellowshipchurch.atlassian.net/browse/CFDP-2617?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ