### PR TITLE
Re-added set a remainder only for cf-everywhere page

### DIFF
--- a/components/LocationSingle/LocationSingle.js
+++ b/components/LocationSingle/LocationSingle.js
@@ -142,6 +142,24 @@ function LocationSingle(props = {}) {
         </Box>
       )}
 
+      {campus !== 'Cf Everywhere' && (
+        <>
+          {/* Set a Reminder */}
+          <Box width="100%" px={{ _: 'base', md: 'xl' }} pt="base">
+            <InfoCardList
+              {...setReminderData}
+              button={{
+                title: 'Set a Reminder',
+                onClick: () =>
+                  modalDispatch(
+                    showModal('SetReminder', { defaultCampus: campus })
+                  ),
+              }}
+            />
+          </Box>
+        </>
+      )}
+
       {/* At this Location Section */}
       <Box bg="white" width="100%" px={{ _: 'base', md: 'xl' }} pt="base">
         <LocationBlockFeature


### PR DESCRIPTION
### About
The 'Set a Remainder' Section was accidentally deleted from all the pages instead of just the Cf Everywhere page, this adds it back to all pages except Cf Everywhere.

### Test Instructions
1. Go to any location page, like [/locations/palm-beach-gardens](https://web-app-v2-git-faq-scroll-fix-2-christ-fellowship-church.vercel.app/locations/palm-beach-gardens).
2. Check if the section appears there.
3. Do the same in the [/locations/palm-beach-gardens](https://web-app-v2-git-faq-scroll-fix-2-christ-fellowship-church.vercel.app/locations/palm-beach-gardens) page.

### Screenshots
|Cf Everywhere|Palm Beach Gardens|
|--|--|
|<img width="1213" alt="Screenshot 2023-06-27 at 9 50 54 AM" src="https://github.com/christfellowshipchurch/web-app-v2/assets/94265294/bf70442c-4405-4c31-b77a-e0e20a0da360">|<img width="1196" alt="Screenshot 2023-06-27 at 9 53 22 AM" src="https://github.com/christfellowshipchurch/web-app-v2/assets/94265294/fd67a56c-d832-4beb-9b92-b5a5a1e8956e">|



### Closes Tickets
[CFDP-2633](https://christfellowshipchurch.atlassian.net/browse/CFDP-2633)
[CFDP-2632](https://christfellowshipchurch.atlassian.net/browse/CFDP-2632)