### PR TITLE
Map Link for Location Pages

### DIFF
--- a/components/LocationSingle/CampusInfo.js
+++ b/components/LocationSingle/CampusInfo.js
@@ -114,6 +114,7 @@ const CampusInfo = ({
   phoneNumber,
   serviceTimes,
   additionalInfo,
+  mapLink,
 }) => {
   const modalDispatch = useModalDispatch();
   const addressFirst = street1 ? `${street1}` : null;
@@ -166,10 +167,11 @@ const CampusInfo = ({
   /** Instagram and Google Map URLs */
   const campusLink = find(campusLinks, { name: name });
 
-  /** Directions to all Campuses except Trinity Campus (has special link) */
-  const allCampusesDirections = campusLink?.googleMap
-    ? campusLink?.googleMap
-    : `https://www.google.com/maps/place/${addressFirst?.replace(' ', '+')}`;
+  /** Directions to campus using the "mapLink" attribute from Rock campuses, if not found we'll generate a link using the campus address */
+  const allCampusesDirections =
+    mapLink && mapLink !== ''
+      ? mapLink
+      : `https://www.google.com/maps/place/${addressFirst?.replace(' ', '+')}`;
 
   /** Trinity Campus Directions Link */
   const trinityCampusDirections =

--- a/components/LocationSingle/locationData.js
+++ b/components/LocationSingle/locationData.js
@@ -209,66 +209,53 @@ const campusLinks = [
   {
     name: 'Palm Beach Gardens',
     instagram: 'https://www.instagram.com/cf.gardens/',
-    googleMap: 'https://goo.gl/maps/oaAmU8d3PiyFKqb56',
   },
   {
     name: 'Port St. Lucie',
     instagram: 'https://www.instagram.com/cf.psl/',
-    googleMap: 'https://goo.gl/maps/ueVZs2zeZsQktb4q6',
   },
   {
     name: 'Boynton Beach',
     instagram: 'https://www.instagram.com/cf.boynton/',
-    googleMap: 'https://goo.gl/maps/V2vem5hz5eMHAjQZA',
   },
   {
     name: 'Belle Glade',
     instagram: 'https://www.instagram.com/cf.belleglade/',
-    googleMap: 'https://goo.gl/maps/NJcvaKo7btse434GA',
   },
   {
     name: 'Downtown West Palm Beach',
     instagram: 'https://www.instagram.com/cf.downtownwpb/',
-    googleMap: 'https://goo.gl/maps/wRHEkPkP6PM6YSvXA',
   },
   {
     name: 'Royal Palm Beach',
     instagram: 'https://www.instagram.com/cf.royalpalm/',
-    googleMap: 'https://goo.gl/maps/RQCSvNAJ8uFo9atR6',
   },
   {
     name: 'Jupiter',
     instagram: 'https://www.instagram.com/cf.jupiter/',
-    googleMap: 'https://goo.gl/maps/nCgqzQUJw2FyZ4WK7',
   },
   {
     name: 'Stuart',
     instagram: 'https://www.instagram.com/cf.stuart/',
-    googleMap: 'https://goo.gl/maps/6pxgRULscdFFefXZ7',
   },
   {
     name: 'Vero Beach',
     instagram: 'https://www.instagram.com/cf.verobeach/',
-    googleMap: 'https://goo.gl/maps/Wny5uvv1BRNnTdDZ9',
   },
   {
     name: 'Riviera Beach',
     instagram: 'https://www.instagram.com/cf.riviera/',
-    googleMap: 'https://goo.gl/maps/zRZmHMwgoNBhD5L29',
   },
   {
     name: 'Boca Raton',
     instagram: 'https://www.instagram.com/cf.boca/',
-    googleMap: 'https://goo.gl/maps/GqXgUzqwZXTPpn9T7',
   },
   {
     name: 'Okeechobee',
     instagram: 'https://www.instagram.com/cf.okeechobee/',
-    googleMap: 'https://goo.gl/maps/EjYCSoh8Zsi4fnfp6',
   },
   {
     name: 'en Español Royal Palm Beach',
-    googleMap: 'https://goo.gl/maps/RQCSvNAJ8uFo9atR6',
     instagram: 'https://www.instagram.com/cf.espanol/',
   },
   {

--- a/hooks/useCampus.js
+++ b/hooks/useCampus.js
@@ -16,6 +16,7 @@ export const GET_CAMPUS = gql`
       street1
       state
       postalCode
+      mapLink
       phoneNumber
       serviceTimes {
         day


### PR DESCRIPTION
### About
This PR updates the "Get Directions" button inside of  Location Pages to use the `mapLink` attribute from Rock instead. In doing so we removed all the hardcoded `googleMap` links, and if no map link is found then we will generate one from address.

_**Note:**
PR will be ready for review once the API has been updated with this PR: https://github.com/christfellowshipchurch/services/pull/57_

### Test Instructions
* Go to any location page and test the "Get Directions" button.

### Screenshots
<img width="1317" alt="image" src="https://github.com/christfellowshipchurch/web-app-v2/assets/46049974/269ecd7a-21c7-4bfe-872c-b1df49bb47e6">

### Closes Tickets
[CFDP-2636](https://christfellowshipchurch.atlassian.net/browse/CFDP-2636)

[CFDP-2636]: https://christfellowshipchurch.atlassian.net/browse/CFDP-2636?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ