### PR TITLE
Wistia Videos Not Showing on Articles

### DIFF
--- a/components/ContentSingle/ContentSingle.js
+++ b/components/ContentSingle/ContentSingle.js
@@ -15,8 +15,9 @@ import Styled from './ContentSingle.styles';
 import { useRouter } from 'next/router';
 function ContentSingle(props = {}) {
   const [currentVideo, setCurrentVideo] = useState(
-    Array.isArray(props.data?.wistiaId) ? props.data.wistiaId[0] : null
+    Array.isArray(props.data?.videos) ? props.data.videos[0] : null
   );
+
   const [showShare, setShowShare] = useState(true);
   const router = useRouter();
   const analytics = useAnalytics();
@@ -41,10 +42,12 @@ function ContentSingle(props = {}) {
   useEffect(() => {
     // Do we have videos now, when we didn't before?
     // ( Loading just finished, so we can properly select the first video if present )
-    if (props.data?.wistiaId?.length >= 1 && currentVideo === null) {
-      setCurrentVideo(props.data.wistiaId[0]);
+    if (props.data?.videos?.length >= 1 && currentVideo === null) {
+      setCurrentVideo(props.data.videos[0]);
+    } else if (props.data?.wistiaId?.length >= 1 && currentVideo === null) {
+      setCurrentVideo(props.data.wistiaId);
     }
-  }, [props.data?.wistiaId, currentVideo]);
+  }, [props.data?.videos, props.data?.wistiaId, currentVideo]);
 
   /**
    * note : Page view tracking for Segment Analytics
@@ -94,18 +97,29 @@ function ContentSingle(props = {}) {
     wistiaId,
   } = props?.data;
 
+  if (!currentVideo && wistiaId) {
+    setCurrentVideo(props.data.wistiaId);
+  }
+
   const coverImageUri = coverImage?.sources[0]?.uri;
   const authorName = author
     ? `${author.firstName} ${author.lastName}`
     : undefined;
 
-  const handleSelectVideo = wistiaId => {
-    if (wistiaId !== currentVideo) {
-      setCurrentVideo(wistiaId);
+  const handleSelectVideo = video => {
+    if (video !== currentVideo) {
+      setCurrentVideo(video);
     }
   };
 
   const metadata = keyBy(props?.data?.metadata, 'name');
+
+  var contentLayoutVideo;
+  if (wistiaId) {
+    contentLayoutVideo = currentVideo?.wistiaId;
+  } else {
+    contentLayoutVideo = currentVideo?.sources[0]?.uri;
+  }
 
   return (
     <ContentLayout
@@ -120,7 +134,7 @@ function ContentSingle(props = {}) {
         image: coverImageUri,
         author: authorName,
         url: typeof window !== 'undefined' ? window.location.href : undefined,
-        video: currentVideo?.wistiaId,
+        video: contentLayoutVideo,
         keywords: metadata?.keywords?.content,
         title: metadata?.title?.content || title,
       }}
@@ -201,7 +215,7 @@ function ContentSingle(props = {}) {
           <ContentVideosList
             key={`videos-${props?.data?.id}`}
             thumbnail={coverImageUri}
-            videos={wistiaId}
+            videos={wistiaId ? wistiaId : videos}
             onSelectVideo={handleSelectVideo}
           />
         </>

--- a/components/ContentSingle/ContentSingle.js
+++ b/components/ContentSingle/ContentSingle.js
@@ -42,7 +42,6 @@ function ContentSingle(props = {}) {
     // Do we have videos now, when we didn't before?
     // ( Loading just finished, so we can properly select the first video if present )
     if (props.data?.wistiaId?.length >= 1 && currentVideo === null) {
-      console.log('TRUE');
       setCurrentVideo(props.data.wistiaId[0]);
     }
   }, [props.data?.wistiaId, currentVideo]);
@@ -94,8 +93,6 @@ function ContentSingle(props = {}) {
     segmentData,
     wistiaId,
   } = props?.data;
-  console.log(wistiaId);
-  console.log(videos);
 
   const coverImageUri = coverImage?.sources[0]?.uri;
   const authorName = author

--- a/components/ContentSingle/ContentSingle.js
+++ b/components/ContentSingle/ContentSingle.js
@@ -179,7 +179,7 @@ function ContentSingle(props = {}) {
           </Box>
         )
       }
-      contentTitleE={wistiaId?.length >= 2 ? 'Videos' : null}
+      contentTitleE={videos?.length >= 2 ? 'Videos' : null}
       renderContentE={() => (
         <>
           {actions?.length > 0 && (

--- a/components/ContentSingle/ContentSingle.js
+++ b/components/ContentSingle/ContentSingle.js
@@ -15,7 +15,7 @@ import Styled from './ContentSingle.styles';
 import { useRouter } from 'next/router';
 function ContentSingle(props = {}) {
   const [currentVideo, setCurrentVideo] = useState(
-    Array.isArray(props.data?.videos) ? props.data.videos[0] : null
+    Array.isArray(props.data?.wistiaId) ? props.data.wistiaId[0] : null
   );
   const [showShare, setShowShare] = useState(true);
   const router = useRouter();
@@ -41,10 +41,11 @@ function ContentSingle(props = {}) {
   useEffect(() => {
     // Do we have videos now, when we didn't before?
     // ( Loading just finished, so we can properly select the first video if present )
-    if (props.data?.videos?.length >= 1 && currentVideo === null) {
-      setCurrentVideo(props.data.videos[0]);
+    if (props.data?.wistiaId?.length >= 1 && currentVideo === null) {
+      console.log('TRUE');
+      setCurrentVideo(props.data.wistiaId[0]);
     }
-  }, [props.data?.videos, currentVideo]);
+  }, [props.data?.wistiaId, currentVideo]);
 
   /**
    * note : Page view tracking for Segment Analytics
@@ -93,15 +94,17 @@ function ContentSingle(props = {}) {
     segmentData,
     wistiaId,
   } = props?.data;
+  console.log(wistiaId);
+  console.log(videos);
 
   const coverImageUri = coverImage?.sources[0]?.uri;
   const authorName = author
     ? `${author.firstName} ${author.lastName}`
     : undefined;
 
-  const handleSelectVideo = video => {
-    if (video !== currentVideo) {
-      setCurrentVideo(video);
+  const handleSelectVideo = wistiaId => {
+    if (wistiaId !== currentVideo) {
+      setCurrentVideo(wistiaId);
     }
   };
 
@@ -120,7 +123,7 @@ function ContentSingle(props = {}) {
         image: coverImageUri,
         author: authorName,
         url: typeof window !== 'undefined' ? window.location.href : undefined,
-        video: currentVideo?.sources[0]?.uri,
+        video: currentVideo?.wistiaId,
         keywords: metadata?.keywords?.content,
         title: metadata?.title?.content || title,
       }}
@@ -179,7 +182,7 @@ function ContentSingle(props = {}) {
           </Box>
         )
       }
-      contentTitleE={videos?.length >= 2 ? 'Videos' : null}
+      contentTitleE={wistiaId?.length >= 2 ? 'Videos' : null}
       renderContentE={() => (
         <>
           {actions?.length > 0 && (
@@ -201,7 +204,7 @@ function ContentSingle(props = {}) {
           <ContentVideosList
             key={`videos-${props?.data?.id}`}
             thumbnail={coverImageUri}
-            videos={videos}
+            videos={wistiaId}
             onSelectVideo={handleSelectVideo}
           />
         </>

--- a/components/ContentSingle/ContentVideo.js
+++ b/components/ContentSingle/ContentVideo.js
@@ -25,7 +25,7 @@ export default function ContentVideo(props = {}) {
         segmentData={props.segmentData}
         wistiaId={props?.wistiaId}
         title={props.title}
-        src={props.video.sources[0].uri}
+        //src={props.video.sources[0].uri}
         poster={props.poster}
         autoPlay={true}
         playsInline={true}
@@ -36,6 +36,7 @@ export default function ContentVideo(props = {}) {
 
 ContentVideo.propTypes = {
   poster: PropTypes.string,
+  wistiaID: PropTypes.string,
   video: PropTypes.shape({
     sources: PropTypes.arrayOf(
       PropTypes.shape({

--- a/components/ContentSingle/ContentVideo.js
+++ b/components/ContentSingle/ContentVideo.js
@@ -25,6 +25,7 @@ export default function ContentVideo(props = {}) {
         segmentData={props.segmentData}
         wistiaId={props?.wistiaId}
         title={props.title}
+        src={props?.wistiaId ? undefined : props.video.sources[0].uri}
         poster={props.poster}
         autoPlay={true}
         playsInline={true}
@@ -35,7 +36,7 @@ export default function ContentVideo(props = {}) {
 
 ContentVideo.propTypes = {
   poster: PropTypes.string,
-  wistiaID: PropTypes.string,
+  wistiaId: PropTypes.string,
   video: PropTypes.shape({
     sources: PropTypes.arrayOf(
       PropTypes.shape({

--- a/components/ContentSingle/ContentVideo.js
+++ b/components/ContentSingle/ContentVideo.js
@@ -25,7 +25,6 @@ export default function ContentVideo(props = {}) {
         segmentData={props.segmentData}
         wistiaId={props?.wistiaId}
         title={props.title}
-        //src={props.video.sources[0].uri}
         poster={props.poster}
         autoPlay={true}
         playsInline={true}


### PR DESCRIPTION
### About
This PR fixes a bug that prevents Wistia videos not showing on articles unless a Video Link is provided as well as adding a Wistia Project media item to the Rock Content Item. 

### Test Instructions
The Testing Wistia Video Content Item on Rock ( [here](https://rock.christfellowship.church/page/2798?ContentItemId=14422) ) has no video linked, however it does have a Wistia Project media item added to it.

1. Go to [/testing-wistia-video](https://www.christfellowship.church/articles/testing-wistia-video) on the website and see how it used to be.
2. Go to [/testing-wistia-video](https://web-app-v2-git-wistia-videos-no-ef3b37-christ-fellowship-church.vercel.app//articles/testing-wistia-video) on the testing link to see how it is with the changes.
3. Remove the Wisitia Project from the Content Item and add just a video link to ensure that it still works with just a link.
4. Test other type of pages that use Content Single like messages or devotionals to make sure nothing else broke.

### Screenshots
|How it used to be|With the changes|
|--|--|
|<img width="1194" alt="Screenshot 2023-06-30 at 4 07 33 PM" src="https://github.com/christfellowshipchurch/web-app-v2/assets/94265294/087e26d0-2067-4a02-aae3-0b53ae132387">|<img width="1194" alt="Screenshot 2023-06-30 at 4 07 33 PM" src="https://github.com/christfellowshipchurch/web-app-v2/assets/94265294/b6586d55-040e-4a1a-ba6f-9c35cdb4ac6a">|
|--|--|

### Closes Tickets
[CFDP-2635](https://christfellowshipchurch.atlassian.net/browse/CFDP-2635)


[CFDP-2635]: https://christfellowshipchurch.atlassian.net/browse/CFDP-2635?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ