### PR TITLE
Made modals scrollable

### DIFF
--- a/ui-kit/Modal/Modal.styles.js
+++ b/ui-kit/Modal/Modal.styles.js
@@ -41,7 +41,7 @@ const Content = styled.div`
   left: 50%;
   /* margin-top: -${themeGet('space.xxl')}; */
   max-width: 100vw;
-  max-width: 100vw;
+  max-height: 54vw;
   overflow: scroll;
   padding: ${themeGet('space.l')};
   padding-top: ${themeGet('space.xl')};

--- a/ui-kit/Modal/Modal.styles.js
+++ b/ui-kit/Modal/Modal.styles.js
@@ -41,7 +41,7 @@ const Content = styled.div`
   left: 50%;
   /* margin-top: -${themeGet('space.xxl')}; */
   max-width: 100vw;
-  max-height: 54vw;
+  max-height: 780px;
   overflow: scroll;
   padding: ${themeGet('space.l')};
   padding-top: ${themeGet('space.xl')};
@@ -56,7 +56,7 @@ const Content = styled.div`
     margin-top: -${themeGet('space.l')};
     padding: ${themeGet('space.base')};
     padding-top: ${themeGet('space.xl')};
-    width: calc(100vw - ${themeGet('space.base')});
+    width: calc(88vw - ${themeGet('space.base')});
     max-height: 85vh;
   }
 `;

--- a/ui-kit/Modal/Modal.styles.js
+++ b/ui-kit/Modal/Modal.styles.js
@@ -39,9 +39,9 @@ const Content = styled.div`
   border-radius: ${themeGet('radii.base')};
   box-shadow: ${themeGet('shadows.xl')};
   left: 50%;
-  /* margin-top: -${themeGet('space.xxl')}; */
   max-width: 100vw;
-  max-height: 780px;
+  max-height: 80vh;
+  width: max-content;
   overflow: scroll;
   padding: ${themeGet('space.l')};
   padding-top: ${themeGet('space.xl')};
@@ -56,7 +56,8 @@ const Content = styled.div`
     margin-top: -${themeGet('space.l')};
     padding: ${themeGet('space.base')};
     padding-top: ${themeGet('space.xl')};
-    width: calc(88vw - ${themeGet('space.base')});
+    width: max-content;
+    max-width: calc(100vw - ${themeGet('space.base')});
     max-height: 85vh;
   }
 `;


### PR DESCRIPTION
### About
All modal are now scrollable instead of the text overflowing and not being able to click the submit or save button at the bottom.

### Test Instructions
1.  Go on any page on testing page ( [Home Page](https://rock.christfellowship.church/page/4212?ContentItemId=14407) ),  on a device with a big screen, scroll to the footer at the bottom of the page and click on `Connect Card` you should see that now everything loads.
2. Go to the [Home Page](https://www.christfellowship.church/) on the website and see how it used to be.
4. Go to a different modal on the live website, for example, when you sign in and go to `My Groups` and click on a group, then click on `Manage Group` then click on `View` on any of the members and you will see that it also does not fit in the screen.
5. Try the same thing in the testing link and see the difference.

### Screenshots
|How it used to be|With the changes|
|--|--|
|<img width="1268" alt="Screenshot 2023-06-30 at 4 06 57 PM" src="https://github.com/christfellowshipchurch/web-app-v2/assets/94265294/14a71cfa-7070-460f-9c84-8627d5135a52">|<img width="1194" alt="Screenshot 2023-06-30 at 4 07 33 PM" src="https://github.com/christfellowshipchurch/web-app-v2/assets/94265294/ca662860-085e-4f00-a1ca-e8ccb95ad843">|

How it used to be|With the changes|
|--|--|
|<img width="1268" alt="Screenshot 2023-06-30 at 4 06 57 PM" src="https://github.com/christfellowshipchurch/web-app-v2/assets/94265294/2eb8e73d-ecd7-446f-a9a4-d99821462faa">|<img width="1194" alt="Screenshot 2023-06-30 at 4 07 33 PM" src="https://github.com/christfellowshipchurch/web-app-v2/assets/94265294/ad9913d1-44aa-403f-8c94-bf65c949ab20">|



### Closes Tickets
[CFDP-2654](https://christfellowshipchurch.atlassian.net/browse/CFDP-2654)
[CFDP-2495](https://christfellowshipchurch.atlassian.net/browse/CFDP-2495)


[CFDP-2654]: https://christfellowshipchurch.atlassian.net/browse/CFDP-2654?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ