### PR TITLE
Group Chat now shows on mobile

### DIFF
--- a/components/GroupSingle/GroupChat.js
+++ b/components/GroupSingle/GroupChat.js
@@ -1,21 +1,10 @@
 import PropTypes from 'prop-types';
-
 import { Chat } from 'components';
-import { useCurrentBreakpoint } from 'hooks';
-
-import GroupChatMobile from './GroupChatMobile';
-
 import Styled from './GroupSingle.styles';
 
 export default function GroupChat(props = {}) {
-  const currentBreakpoint = useCurrentBreakpoint();
-
   if (!props.streamChatChannel) {
     return null;
-  }
-
-  if (currentBreakpoint.isSmall) {
-    return <GroupChatMobile />;
   }
 
   return (


### PR DESCRIPTION
### About
This PR removes the logic that makes it so that when a mobile users goes to a group on Web they cannot see chat and need to download the app, they now see chat.

### Test Instructions
1. Go to our live website ([here](https://www.christfellowship.church/)) and after logging in go to one of your groups.
2. Inspect and toggle device toolbar.
3. In the dimensions at the top select any of the mobile devices.
4. You should not be able to see the chat.
5. Repeat the first three steps in the testing link ([here](https://web-app-v2-git-allowing-chat-fo-2c6911-christ-fellowship-church.vercel.app/)) instead of the live website.

### Screenshots
|How it used to be|With the changes|
|--|--|
|<img width="1268" alt="Screenshot 2023-06-30 at 4 06 57 PM" src="https://github.com/christfellowshipchurch/web-app-v2/assets/94265294/521c7c2d-a5ce-49a2-863b-01910140f20f">|<img width="1194" alt="Screenshot 2023-06-30 at 4 07 33 PM" src="https://github.com/christfellowshipchurch/web-app-v2/assets/94265294/06d447ed-5e0a-433c-b6df-cba5a0c017bc">|

### Closes Tickets
[CFDP-2646](https://christfellowshipchurch.atlassian.net/browse/CFDP-2646)

[CFDP-2646]: https://christfellowshipchurch.atlassian.net/browse/CFDP-2646?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ