### PR TITLE
Spacing for Events Page

### DIFF
--- a/components/EventSingle/EventGroupings/EventGroupings.js
+++ b/components/EventSingle/EventGroupings/EventGroupings.js
@@ -1,7 +1,7 @@
 import React, { useEffect } from 'react';
 
 import { Box, Button, Card, Select } from 'ui-kit';
-import { useCurrentBreakpoint, useForm } from 'hooks';
+import { useForm } from 'hooks';
 
 import DateTime from './DateTime';
 
@@ -24,8 +24,6 @@ const EventGroupings = (props = {}) => {
   const selectedGroup = eventGroupings?.find(
     i => i.name === values.campusSelect
   );
-
-  const breakpoints = useCurrentBreakpoint;
 
   return (
     <Box as="form" onSubmit={handleSubmit}>

--- a/components/EventSingle/EventGroupings/EventGroupings.js
+++ b/components/EventSingle/EventGroupings/EventGroupings.js
@@ -1,7 +1,7 @@
 import React, { useEffect } from 'react';
 
 import { Box, Button, Card, Select } from 'ui-kit';
-import { useForm } from 'hooks';
+import { useCurrentBreakpoint, useForm } from 'hooks';
 
 import DateTime from './DateTime';
 
@@ -24,6 +24,8 @@ const EventGroupings = (props = {}) => {
   const selectedGroup = eventGroupings?.find(
     i => i.name === values.campusSelect
   );
+
+  const breakpoints = useCurrentBreakpoint;
 
   return (
     <Box as="form" onSubmit={handleSubmit}>
@@ -73,6 +75,7 @@ const EventGroupings = (props = {}) => {
           boxShadow="base"
           display="flex"
           flexDirection="column"
+          mb = {{ _: '', md: '', lg:'xl', xl:'xl'}}
           p={{ _: 's', md: 'base' }}
         >
           {props.data?.callsToAction?.map((n, i) => (

--- a/components/EventSingle/EventSingle.js
+++ b/components/EventSingle/EventSingle.js
@@ -6,6 +6,8 @@ import { ContentLayout, Share } from 'components';
 
 import EventGroupings from './EventGroupings';
 import { useAnalytics } from 'providers/AnalyticsProvider';
+import { useCurrentBreakpoint } from 'hooks';
+const screen = useCurrentBreakpoint
 
 function EventSingle(props = {}) {
   const analytics = useAnalytics();
@@ -71,7 +73,7 @@ function EventSingle(props = {}) {
       renderC={() => (
         <Box justifySelf="flex-end">
           <Share
-            mb={{ _: 's'}}
+            mb={{ _:'base'}}
             title={props.data.title}
             shareTitle="Invite"
             shareMessages={eventShareMessages}

--- a/components/EventSingle/EventSingle.js
+++ b/components/EventSingle/EventSingle.js
@@ -71,6 +71,7 @@ function EventSingle(props = {}) {
       renderC={() => (
         <Box justifySelf="flex-end">
           <Share
+            mb={{ _: 's'}}
             title={props.data.title}
             shareTitle="Invite"
             shareMessages={eventShareMessages}


### PR DESCRIPTION
### About
This PR adjusts the spacing for the share button on mobile and adds spacing between content and the footer for `/events` 

### Test Instructions
1. Go to https://www.christfellowship.church/events/hear-from-coach-tom
2. Visit `/events/hear-from-coach-tom` on the deployment link and note the space between the card and the footer
3. Use the inspect tool to view both sites on mobile and note the additional space under the Share button on mobile

### Screenshots
<img width="1176" alt="Screenshot 2023-07-25 at 3 02 09 PM" src="https://github.com/christfellowshipchurch/web-app-v2/assets/93110503/9b565f8c-14c9-483a-a87b-550367418fe4">

<img width="339" alt="Screenshot 2023-07-25 at 2 56 29 PM" src="https://github.com/christfellowshipchurch/web-app-v2/assets/93110503/f7676bf7-8787-4546-ab99-a51ad45ed4dd">

### Related Tickets
[CFDP-2578](https://christfellowshipchurch.atlassian.net/browse/CFDP-2578)
