### PR TITLE
Promotional Video for Events

### DIFF
--- a/components/EventSingle/EventSingle.js
+++ b/components/EventSingle/EventSingle.js
@@ -4,7 +4,6 @@ import PropTypes from 'prop-types';
 import { Box, Loader } from 'ui-kit';
 import { ContentLayout, Share } from 'components';
 import ContentVideo from 'components/ContentSingle/ContentVideo';
-import ContentVideosList from 'components/ContentSingle/ContentVideosList';
 import EventGroupings from './EventGroupings';
 import { useAnalytics } from 'providers/AnalyticsProvider';
 
@@ -22,14 +21,8 @@ function EventSingle(props = {}) {
     });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
-
-  const videos = props?.data?.videos;
-  const wistiaId = props?.data?.wistiaId
-  console.log(videos);
   
   useEffect(() => {
-    // Do we have videos now, when we didn't before?
-    // ( Loading just finished, so we can properly select the first video if present)
     if (props.data?.videos?.length >= 1 && currentVideo === null) {
       setCurrentVideo(props.data.videos[0]);
     } else if (props.data?.wistiaId?.length >= 1 && currentVideo === null) {
@@ -63,16 +56,11 @@ function EventSingle(props = {}) {
   const authorName = author
     ? `${author.firstName} ${author.lastName}`
     : undefined;
+  const wistiaId = props?.data?.wistiaId;
 
   if (!currentVideo && wistiaId) {
       setCurrentVideo(props.data.wistiaId);
   }
-
-  const handleSelectVideo = video => {
-    if (video !== currentVideo) {
-      setCurrentVideo(video);
-    }
-  };
 
   const eventShareMessages = {
     faceBook: `Check out ${title} happening at Christ Fellowship Church!`,

--- a/components/EventSingle/EventSingle.js
+++ b/components/EventSingle/EventSingle.js
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 
 import { Box, Loader } from 'ui-kit';
@@ -10,6 +10,10 @@ import { useAnalytics } from 'providers/AnalyticsProvider';
 function EventSingle(props = {}) {
   const analytics = useAnalytics();
 
+  const [currentVideo, setCurrentVideo] = useState(
+    Array.isArray(props.data?.videos) ? props.data.videos[0] : null
+  );
+
   useEffect(() => {
     analytics.page({
       contentCategory: 'Information',
@@ -17,6 +21,18 @@ function EventSingle(props = {}) {
     });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+
+  const videos = props?.data?.videos;
+  const wistiaId = props?.data?.wistiaId
+
+  useEffect(() => {
+    if (videos.length >= 1 && currentVideo === null) {
+      setCurrentVideo(props.data.videos[0]);
+    } else if (props.data?.wistiaId?.length >= 1 && currentVideo === null) {
+      setCurrentVideo(props.data.wistiaId);
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [videos, wistiaId, currentVideo]);  
 
   if (props.loading) {
     return (
@@ -43,6 +59,8 @@ function EventSingle(props = {}) {
   const authorName = author
     ? `${author.firstName} ${author.lastName}`
     : undefined;
+
+    
 
   const eventShareMessages = {
     faceBook: `Check out ${title} happening at Christ Fellowship Church!`,

--- a/components/EventSingle/EventSingle.js
+++ b/components/EventSingle/EventSingle.js
@@ -106,7 +106,14 @@ function EventSingle(props = {}) {
       }}
       summary={props.data.summary}
       coverImage={props.data?.coverImage?.sources[0]?.uri}
-      
+      renderA={() => (
+        <ContentVideo
+          title={title}
+          video={currentVideo}
+          poster={coverImageUri}
+          wistiaId={wistiaId}
+        />
+      )}
       renderC={() => (
         <Box justifySelf="flex-end">
           <Share

--- a/components/EventSingle/EventSingle.js
+++ b/components/EventSingle/EventSingle.js
@@ -3,7 +3,8 @@ import PropTypes from 'prop-types';
 
 import { Box, Loader } from 'ui-kit';
 import { ContentLayout, Share } from 'components';
-
+import ContentVideo from 'components/ContentSingle/ContentVideo';
+import ContentVideosList from 'components/ContentSingle/ContentVideosList';
 import EventGroupings from './EventGroupings';
 import { useAnalytics } from 'providers/AnalyticsProvider';
 
@@ -24,15 +25,18 @@ function EventSingle(props = {}) {
 
   const videos = props?.data?.videos;
   const wistiaId = props?.data?.wistiaId
-
+  console.log(videos);
+  
   useEffect(() => {
-    if (videos.length >= 1 && currentVideo === null) {
+    // Do we have videos now, when we didn't before?
+    // ( Loading just finished, so we can properly select the first video if present)
+    if (props.data?.videos?.length >= 1 && currentVideo === null) {
       setCurrentVideo(props.data.videos[0]);
     } else if (props.data?.wistiaId?.length >= 1 && currentVideo === null) {
       setCurrentVideo(props.data.wistiaId);
     }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [videos, wistiaId, currentVideo]);  
+  }, [props.data?.videos, props.data?.wistiaId, currentVideo]);
+
 
   if (props.loading) {
     return (
@@ -60,7 +64,15 @@ function EventSingle(props = {}) {
     ? `${author.firstName} ${author.lastName}`
     : undefined;
 
-    
+  if (!currentVideo && wistiaId) {
+      setCurrentVideo(props.data.wistiaId);
+  }
+
+  const handleSelectVideo = video => {
+    if (video !== currentVideo) {
+      setCurrentVideo(video);
+    }
+  };
 
   const eventShareMessages = {
     faceBook: `Check out ${title} happening at Christ Fellowship Church!`,
@@ -71,6 +83,13 @@ function EventSingle(props = {}) {
     },
     sms: `Join me for ${title} at Christ Fellowship! ${document?.URL}`,
   };
+
+  var contentLayoutVideo;
+  if (wistiaId) {
+    contentLayoutVideo = currentVideo?.wistiaId;
+  } else {
+    contentLayoutVideo = currentVideo?.sources[0]?.uri;
+  }
 
   return (
     <ContentLayout
@@ -83,9 +102,11 @@ function EventSingle(props = {}) {
         image: coverImageUri,
         author: authorName,
         url: typeof window !== 'undefined' ? window.location.href : undefined,
+        video: contentLayoutVideo,
       }}
       summary={props.data.summary}
       coverImage={props.data?.coverImage?.sources[0]?.uri}
+      
       renderC={() => (
         <Box justifySelf="flex-end">
           <Share
@@ -94,7 +115,7 @@ function EventSingle(props = {}) {
             shareTitle="Invite"
             shareMessages={eventShareMessages}
           />
-        </Box>
+        </Box>   
       )}
       htmlContent={props.data.htmlContent}
       features={featureFeed?.features}


### PR DESCRIPTION
### About
This PR makes use of the Promotional Video field for `/events` in Rock so that event pages can display video.

### Test Instructions
1. Go to https://www.christfellowship.church/events/promotional-video
2. Visit `/events/promotional-video` locally or on Vercel
3. Note that the video playing is the video inputted to the promotional video field in [Rock](https://rock.gocf.org/page/2798?ContentItemId=14811)

### Screenshots
|Before|After|
|--|--|
|<img width="1440" alt="Screenshot 2023-08-04 at 4 49 27 PM" src="https://github.com/christfellowshipchurch/web-app-v2/assets/93110503/395800a9-c802-4485-ad2c-658280300333">|<img width="1434" alt="Screenshot 2023-08-04 at 4 49 47 PM" src="https://github.com/christfellowshipchurch/web-app-v2/assets/93110503/34e9ed4a-d8be-4630-bbad-4bdeda9254e4">|


### Closes Tickets
[CFDP-2650](https://christfellowshipchurch.atlassian.net/browse/CFDP-2650)


[CFDP-2650]: https://christfellowshipchurch.atlassian.net/browse/CFDP-2650?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ