### PR TITLE
Added Wistia Id to Content Block Feature

### DIFF
--- a/components/ContentBlockFeature/ContentBlockFeature.js
+++ b/components/ContentBlockFeature/ContentBlockFeature.js
@@ -25,6 +25,7 @@ const ContentBlockFeature = props => {
         image={content?.coverImage?.sources[0]?.uri}
         imageRatio={content?.imageRatio}
         videos={content?.videos}
+        wistiaId={content?.wistiaId}
         {...props}
       />
     </Box>

--- a/fragments/features.js
+++ b/fragments/features.js
@@ -159,6 +159,7 @@ const CONTENT_BLOCK_FEATURE_FRAGMENT = gql`
         uri
       }
     }
+    wistiaId
   }
 `;
 

--- a/ui-kit/ContentBlock/ContentBlock.js
+++ b/ui-kit/ContentBlock/ContentBlock.js
@@ -43,7 +43,8 @@ function ContentBlock(props = {}) {
   const hasHtmlContent = !isEmpty(htmlContent);
   const hasActions = actions?.length > 0;
   const hasImage = !isEmpty(props?.image);
-  const hasVideo = !isEmpty(props?.videos[0]?.sources[0]?.uri);
+  const hasVideo =
+    !isEmpty(props?.videos[0]?.sources[0]?.uri) || !isEmpty(props?.wistiaId);
   const hasMedia = hasImage || hasVideo;
 
   const idRegex = /\D/g;
@@ -85,6 +86,7 @@ function ContentBlock(props = {}) {
               poster={props?.image}
               // all videos will defatult to 16:9 aspect ratio keeping sizing consistent
               aspectRatio="16/9"
+              wistiaId={props?.wistiaId}
             />
           </Conditional>
         </Box>


### PR DESCRIPTION
### About
This PR allows us to use the Wistia player for a Content Block Feature

### Test Instructions
* run this locally with the this API branch: https://github.com/christfellowshipchurch/services/pull/63
* go to `/dream-team-updates` to see Wistia Player being used instead for Content Block.

### Screenshots
![image](https://github.com/christfellowshipchurch/web-app-v2/assets/46049974/4c3c54e8-49a7-48bd-9243-72be579038c9)


### Closes Tickets
[CFDP-2685](https://christfellowshipchurch.atlassian.net/browse/CFDP-2685)

[CFDP-2685]: https://christfellowshipchurch.atlassian.net/browse/CFDP-2685?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ