### PR TITLE
Fixed scrolling issue and cleaned up the code 

### DIFF
--- a/pages/login/reset-password/index.js
+++ b/pages/login/reset-password/index.js
@@ -72,31 +72,14 @@ export default function ResetPassword(props) {
     }
   }, [queryEmail, setValues]);
 
-  if (status === 'SUCCESS') {
-    return (
-      <Layout title="Password Reset">
-        <Cell
-          as="main"
-          maxWidth={utils.rem('1100px')}
-          px="base"
-          py={{ _: 'l', lg: 'xl' }}
-          mb="xxl"
-        >
-          <Card maxWidth="62%" margin="auto" p="base" pb="l">
-            <Box my="l" textAlign="center">
-              <Icon name="checkCircle" color="success" size="64" mb="base" />
-              <Box as="h1" color="success">
-                Password Reset
-              </Box>
-              <Box as="p">Your password has been successfully reset!</Box>
-            </Box>
-          </Card>
-        </Cell>
-      </Layout>
-    );
-  }
+  //On status change / submission forces scroll to the top to see the success message
+  useEffect(() => {
+    if (window) {
+      window.scrollTo({ top: 0, behavior: 'instant' });
+    }
+  }, [status]);
 
-  return (
+  return status === 'SUCCESS' ? (
     <Layout title="Password Reset">
       <Cell
         as="main"
@@ -105,14 +88,40 @@ export default function ResetPassword(props) {
         py={{ _: 'l', lg: 'xl' }}
         mb="xxl"
       >
-        <Card width='620px' maxWidth="100%" margin="auto" p="base" pb="l">
+        <Card maxWidth="62%" margin="auto" p="base" pb="l">
+          <Box my="l" textAlign="center">
+            <Icon name="checkCircle" color="success" size="64" mb="base" />
+            <Box as="h1" color="success">
+              Password Reset
+            </Box>
+            <Box as="p">Your password has been successfully reset!</Box>
+          </Box>
+        </Card>
+      </Cell>
+    </Layout>
+  ) : (
+    <Layout title="Password Reset">
+      <Cell
+        as="main"
+        maxWidth={utils.rem('1100px')}
+        px="base"
+        py={{ _: 'l', lg: 'xl' }}
+        mb="xxl"
+      >
+        <Card width="620px" maxWidth="100%" margin="auto" p="base" pb="l">
           {/* Form Header */}
           <Box my="l" textAlign="center">
             <Box as="h1">Password Reset</Box>
             <Box as="p">Forgot your password? We’ve got you covered!</Box>
           </Box>
 
-          <Box as="form" action="" onSubmit={handleSubmit} my="l" textAlign="center">
+          <Box
+            as="form"
+            action=""
+            onSubmit={handleSubmit}
+            my="l"
+            textAlign="center"
+          >
             {/* Email & Confirmation Code*/}
             <Box as="section" mb="l">
               <Box


### PR DESCRIPTION
### About
Before this PR on submission of password reset the confirmation screen would scroll all the way down to the footer, this PR fixes that issue and cleans up the code a bit as well. 

### Test Instructions
Change your password 
On submission, the screen will scroll up and after loading you will see the confirmation screen 

### Screenshots
<img width="435" alt="Screen Shot 2023-08-09 at 6 51 47 PM" src="https://github.com/christfellowshipchurch/web-app-v2/assets/46769629/b895c97c-1d79-4738-8bc5-baebb830422f">

### Closes Tickets
[CFDP-2276](https://christfellowshipchurch.atlassian.net/jira/software/projects/CFDP/boards/2?selectedIssue=CFDP-2276)

### Related Tickets
N/A


[CFDP-2276]: https://christfellowshipchurch.atlassian.net/browse/CFDP-2276?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ