### PR TITLE
Added Videos and Logic to Set a Reminder Section on Location Pages

### DIFF
--- a/components/LocationSingle/LocationSingle.js
+++ b/components/LocationSingle/LocationSingle.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { find, includes, replace, startCase } from 'lodash';
+import { find, includes, replace, startCase, camelCase } from 'lodash';
 
 import {
   CollectionPreview,
@@ -11,6 +11,7 @@ import {
   InfoCardList,
   Testimonials,
   HeroListFeature,
+  Video,
 } from 'components';
 
 import { Box, Button, Divider, Loader } from 'ui-kit';
@@ -20,6 +21,7 @@ import defaultBlockData from '../LocationBlockFeature/defaultBlockData';
 import {
   additionalInfoCampusData,
   headerData,
+  setReminderVideos,
   setReminderData,
   thisWeekFeatureId,
 } from './locationData';
@@ -92,6 +94,9 @@ function LocationSingle(props = {}) {
     }
   }
 
+  // note : import hard coded wistia ids
+  const setAReminderVideo = setReminderVideos[camelCase(campus)];
+
   return (
     <Layout
       contentMaxWidth={'100vw'}
@@ -144,6 +149,16 @@ function LocationSingle(props = {}) {
       {/* Set a Reminder */}
       {campus !== 'Cf Everywhere' && (
         <>
+          <Box
+            maxWidth={{ _: 350, md: 600, lg: 800 }}
+            boxShadow="l"
+            mt="xxl"
+            borderRadius="xl"
+            overflow="hidden"
+            mx="auto"
+          >
+            <Video wistiaId={setAReminderVideo} />
+          </Box>
           <Box width="100%" px={{ _: 'base', md: 'xl' }} pt="base">
             <InfoCardList
               {...setReminderData}

--- a/components/LocationSingle/locationData.js
+++ b/components/LocationSingle/locationData.js
@@ -496,6 +496,22 @@ const headerData = [
   },
 ];
 
+const setReminderVideos = {
+  palmBeachGardens: 'hokgxn0k8r',
+  portStLucie: 'vjon73vjg8',
+  royalPalmBeach: 'kq2yuo3glr',
+  boyntonBeach: '69oo6qhvvg',
+  downtownWestPalmBeach: '6fy7j3t3n5',
+  jupiter: 'upnyuxh8x6',
+  stuart: 'do6e26lx36',
+  okeechobee: '2id77bfxem',
+  belleGlade: 't4so17kwrf',
+  veroBeach: 'jo1p0qsz3s',
+  bocaRaton: 'de1dcyyel6',
+  westlake: '7tadieucep',
+  trinity: 'dd5cju1pn6',
+};
+
 const setReminderData = {
   title: 'Set a Reminder for an Upcoming Service',
   subtitle:
@@ -530,6 +546,7 @@ export {
   campusMetaData,
   campusLinks,
   headerData,
+  setReminderVideos,
   setReminderData,
   thisWeekFeatureId,
 };

--- a/ui-kit/Icon/Icon.js
+++ b/ui-kit/Icon/Icon.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { withTheme } from 'styled-components';
 import { themeGet } from '@styled-system/theme-get';
 import camelCase from 'lodash/camelCase';
-//
+
 import { icons, systemPropTypes, theme } from 'ui-kit';
 import Styled from './Icon.styles';
 

--- a/ui-kit/Icon/Icon.js
+++ b/ui-kit/Icon/Icon.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { withTheme } from 'styled-components';
 import { themeGet } from '@styled-system/theme-get';
 import camelCase from 'lodash/camelCase';
-
+//
 import { icons, systemPropTypes, theme } from 'ui-kit';
 import Styled from './Icon.styles';
 


### PR DESCRIPTION
### About
Added Videos and Logic to Set a Reminder Section on Location Pages

### Test Instructions
Open any of the location pages, scroll down to the set a reminder section and you should see the video (please test on all screen sizes)

### Screenshots
![Screen Shot 2023-08-16 at 3 12 45 PM](https://github.com/christfellowshipchurch/web-app-v2/assets/46769629/879505a7-3f12-4029-908b-4652c7474fad)

![Screen Shot 2023-08-16 at 3 13 11 PM](https://github.com/christfellowshipchurch/web-app-v2/assets/46769629/3c3b718c-5bcc-4ae4-a498-e78e2b512b97)

### Closes Tickets
[CFDP-2683](https://christfellowshipchurch.atlassian.net/jira/software/projects/CFDP/boards/2?selectedIssue=CFDP-2683)

### Related Tickets
N/A


[CFDP-2683]: https://christfellowshipchurch.atlassian.net/browse/CFDP-2683?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ