### PR TITLE
Fixed Sizing for Cards to all be the same

### DIFF
--- a/components/CommunitySingle/CommunitySingle.js
+++ b/components/CommunitySingle/CommunitySingle.js
@@ -114,6 +114,7 @@ function CommunitySingle(props = {}) {
   // }
 
   // Bypassing group filter modal temporarily
+
   const handleSubPreferenceSelect = subPreference => {
     filtersDispatch(update({ subPreferences: [subPreference.title] }));
     router.push({

--- a/ui-kit/GroupCard/GroupCard.js
+++ b/ui-kit/GroupCard/GroupCard.js
@@ -7,19 +7,11 @@ import get from 'lodash/get';
 import { useModalDispatch, showModal } from 'providers/ModalProvider';
 
 import { CustomLink } from 'components';
-import {
-  Avatar,
-  Box,
-  Button,
-  Icon,
-  SquareAvatar,
-  systemPropTypes,
-} from 'ui-kit';
+import { Box, Button, Icon, SquareAvatar, systemPropTypes } from 'ui-kit';
 
 import Styled from './GroupCard.styles';
 import { themeGet } from '@styled-system/theme-get';
 import camelCase from 'lodash.camelcase';
-import { getUrlFromRelatedNode } from 'utils';
 
 const GroupCard = (props = {}) => {
   const modalDispatch = useModalDispatch();
@@ -158,7 +150,6 @@ const GroupCard = (props = {}) => {
                   height="100%"
                   name="Group Member"
                   src={n?.photo?.uri}
-                  name="Group Member"
                 />
                 {avatarsDiff > 0 && props.avatars.length === i + 1 && (
                   <Styled.AvatarCount>{`+${avatarsDiff}`}</Styled.AvatarCount>

--- a/ui-kit/GroupCard/GroupCard.styles.js
+++ b/ui-kit/GroupCard/GroupCard.styles.js
@@ -19,6 +19,7 @@ const labelColor = props => {
 const GroupCard = styled(Card)`
   display: flex;
   flex-direction: column;
+  justify-content: space-between;
 
   ${system}
 `;


### PR DESCRIPTION
### About
This PR fixes the sizing of the Group Cards when searching for groups from looking different. I added the 'justify-content: space-between' property so that the bottom half of the content moves to the end of the container and the top part to the top of the container and the space that used to be left over at the bottom is now in the middle and it looks more consistent now.

### Test Instructions
1. Go to our live website, to the group finder ([here](https://www.christfellowship.church/groups/search?text=)), some cards will have different sizing from each other.
2. Do the same thing in testing link ([here](https://web-app-v2-git-group-cards-inco-bd102a-christ-fellowship-church.vercel.app/groups/search?text=)) instead of the live website and see the differences.

### Screenshots
|How it used to be|With the changes|
|--|--|
|<img width="1408" alt="Screenshot 2023-08-23 at 2 29 06 PM" src="https://github.com/christfellowshipchurch/web-app-v2/assets/94265294/6cef1a8e-6285-41a1-8a48-b4565615e33f">|<img width="1439" alt="Screenshot 2023-08-23 at 2 29 33 PM" src="https://github.com/christfellowshipchurch/web-app-v2/assets/94265294/654f207a-cab1-451a-bf22-1163c74ecc90">|


### Closes Tickets
[CFDP-2711](https://christfellowshipchurch.atlassian.net/browse/CFDP-2711)

[CFDP-2711]: https://christfellowshipchurch.atlassian.net/browse/CFDP-2711?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ