### PR TITLE
Changed PSL Spanish translation time

### DIFF
--- a/components/LocationSingle/locationData.js
+++ b/components/LocationSingle/locationData.js
@@ -15,7 +15,7 @@ const additionalInfoCampusData = [
     name: 'Port St. Lucie',
     info: [
       'Kids services take place at each service',
-      'Traducciones al español ofrecidas a las 10AM',
+      'Traducciones al español ofrecidas a las 10:15AM',
     ],
   },
   {


### PR DESCRIPTION
### About
Changed PSL Spanish translation time

### Test Instructions
Open PSL campus location page and the time of Spanish translations should be 10:15AM, not 10:00AM


