### PR TITLE
Color changes with transparent header

### DIFF
--- a/components/Nav/Nav.js
+++ b/components/Nav/Nav.js
@@ -125,7 +125,7 @@ function Nav(props = {}) {
               fontSize="12px"
               cursor="pointer"
               onClick={handleLogoutClick}
-              color="fg"
+              color={props?.transparentMode ? 'white' : 'fg'}
             >
               Sign Out
             </Box>

--- a/components/Nav/Nav.js
+++ b/components/Nav/Nav.js
@@ -1,48 +1,20 @@
 import React from 'react';
-import { useRouter } from 'next/router';
 import PropTypes from 'prop-types';
 
-import { CurrentUserProvider } from 'providers';
-import { logout, useAuth } from 'providers/AuthProvider';
-import {
-  hideModal,
-  useModalDispatch,
-  showModal,
-} from 'providers/ModalProvider';
+import { useModalDispatch, showModal } from 'providers/ModalProvider';
 
 import { Box, Button, Icon, systemPropTypes } from 'ui-kit';
-import { ClientSideComponent, UserAvatar } from 'components';
 import Styled from './Nav.styles';
 import { useCurrentBreakpoint } from 'hooks';
 
+import SignIn from './SignIn';
 function Nav(props = {}) {
-  const [{ authenticated }, authDispatch] = useAuth();
-  const currentBreakpoint = useCurrentBreakpoint();
   const modalDispatch = useModalDispatch();
-  const router = useRouter();
+  const currentBreakpoint = useCurrentBreakpoint();
 
   /**
    * todo : Update the handleRouterReload to take a list a specific pages that need to be reloaded after logging as user out. To skip the rest of the pages and continue to reduce the amount of unnecessary reloads.
    */
-
-  function handleAuthClick(event) {
-    event.preventDefault();
-    modalDispatch(showModal('Auth'));
-  }
-
-  function handleRouterReload(pathname) {
-    if (pathname === '/') {
-      return null;
-    }
-    return router.reload();
-  }
-
-  function handleLogoutClick(event) {
-    event.preventDefault();
-    authDispatch(logout());
-    handleRouterReload(router.pathname);
-    modalDispatch(hideModal());
-  }
 
   return (
     <Styled>
@@ -87,51 +59,8 @@ function Nav(props = {}) {
         </Box>
       </Box>
 
-      {/* SignIn Icon External Home Page*/}
-      {!currentBreakpoint.isSmall && !authenticated && (
-        <Box cursor="pointer" textDecoration="none" onClick={handleAuthClick}>
-          <Box
-            display="flex"
-            border="2px solid white"
-            justifyContent="center"
-            borderRadius="50%"
-            size="36px"
-          >
-            <Icon
-              name="user"
-              size={20}
-              color={props?.transparentMode ? 'white' : 'fg'}
-            />
-          </Box>
-        </Box>
-      )}
-
-      <ClientSideComponent>
-        {authenticated && (
-          <Box
-            textAlign="center"
-            display="flex"
-            alignItems="center"
-            flexDirection="column"
-          >
-            <CurrentUserProvider
-              Component={UserAvatar}
-              handleAuthClick={handleAuthClick}
-              size={'40'}
-            />
-            <Box
-              as="span"
-              mt="xs"
-              fontSize="12px"
-              cursor="pointer"
-              onClick={handleLogoutClick}
-              color={props?.transparentMode ? 'white' : 'fg'}
-            >
-              Sign Out
-            </Box>
-          </Box>
-        )}
-      </ClientSideComponent>
+      {/* SignIn/SignOut Icon External Home Page*/}
+      <SignIn transparentMode={props.transparentMode}></SignIn>
     </Styled>
   );
 }

--- a/components/Nav/Nav.js
+++ b/components/Nav/Nav.js
@@ -120,7 +120,7 @@ function Nav(props = {}) {
               size={'40'}
             />
             <Box
-              as="a"
+              as="span"
               mt="xs"
               fontSize="12px"
               cursor="pointer"

--- a/components/Nav/Nav.js
+++ b/components/Nav/Nav.js
@@ -8,6 +8,7 @@ import Styled from './Nav.styles';
 import { useCurrentBreakpoint } from 'hooks';
 
 import SignIn from './SignIn';
+import ClientSideComponent from 'components/ClientSideComponent';
 function Nav(props = {}) {
   const modalDispatch = useModalDispatch();
   const currentBreakpoint = useCurrentBreakpoint();
@@ -60,7 +61,9 @@ function Nav(props = {}) {
       </Box>
 
       {/* SignIn/SignOut Icon External Home Page*/}
-      <SignIn transparentMode={props.transparentMode}></SignIn>
+      <ClientSideComponent>
+        <SignIn transparentMode={props.transparentMode}></SignIn>
+      </ClientSideComponent>
     </Styled>
   );
 }

--- a/components/Nav/SignIn.js
+++ b/components/Nav/SignIn.js
@@ -13,9 +13,8 @@ import {
 } from 'providers/ModalProvider';
 
 function SignIn(props = {}) {
-  const authenticated = useAuth();
+  const [{ authenticated }, authDispatch] = useAuth();
   const currentBreakpoint = useCurrentBreakpoint();
-  const authDispatch = useAuth();
   const modalDispatch = useModalDispatch();
   const router = useRouter();
 

--- a/components/Nav/SignIn.js
+++ b/components/Nav/SignIn.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import { Box, Icon, systemPropTypes } from 'ui-kit';
 import { CurrentUserProvider } from 'providers';
 import { logout, useAuth } from 'providers/AuthProvider';
-import { UserAvatar, ClientSideComponent } from 'components';
+import { UserAvatar } from 'components';
 import { useCurrentBreakpoint } from 'hooks';
 import {
   hideModal,
@@ -19,13 +19,6 @@ function SignIn(props = {}) {
   const router = useRouter();
 
   const [isHover, setIsHover] = useState(false);
-  const [isHoverImg, setIsHoverImg] = useState(false);
-  const handleMouse = () => {
-    setIsHover(!isHover);
-  };
-  const handleMouseImg = () => {
-    setIsHoverImg(!isHoverImg);
-  };
 
   function handleAuthClick(event) {
     event.preventDefault();
@@ -46,59 +39,52 @@ function SignIn(props = {}) {
     modalDispatch(hideModal());
   }
 
-  return (
-    <>
-      {!currentBreakpoint.isSmall && !authenticated && (
-        <Box cursor="pointer" textDecoration="none" onClick={handleAuthClick}>
-          <Box
-            display="flex"
-            border="2px solid white"
-            justifyContent="center"
-            borderRadius="50%"
-            size="36px"
-          >
-            <Icon
-              name="user"
-              size={20}
-              color={props?.transparentMode ? 'white' : 'fg'}
-            />
-          </Box>
+  return authenticated ? (
+    <Box
+      textAlign="center"
+      display="flex"
+      alignItems="center"
+      flexDirection="column"
+    >
+      <CurrentUserProvider
+        Component={UserAvatar}
+        handleAuthClick={handleAuthClick}
+        size={'40'}
+        //Opacity is set to 0.7 when the user hovers over the avatar
+        opacity={0.7}
+      />
+      <Box
+        as="span"
+        mt="xs"
+        fontSize="12px"
+        cursor="pointer"
+        onClick={handleLogoutClick}
+        color={props?.transparentMode ? 'white' : 'fg'}
+        onMouseEnter={() => setIsHover(!isHover)}
+        onMouseLeave={() => setIsHover(!isHover)}
+        textDecoration={isHover && 'underline'}
+      >
+        Sign Out
+      </Box>
+    </Box>
+  ) : (
+    !currentBreakpoint.isSmall && (
+      <Box cursor="pointer" textDecoration="none" onClick={handleAuthClick}>
+        <Box
+          display="flex"
+          border="2px solid white"
+          justifyContent="center"
+          borderRadius="50%"
+          size="36px"
+        >
+          <Icon
+            name="user"
+            size={20}
+            color={props?.transparentMode ? 'white' : 'fg'}
+          />
         </Box>
-      )}
-
-      <ClientSideComponent>
-        {authenticated && (
-          <Box
-            textAlign="center"
-            display="flex"
-            alignItems="center"
-            flexDirection="column"
-          >
-            <CurrentUserProvider
-              Component={UserAvatar}
-              handleAuthClick={handleAuthClick}
-              size={'40'}
-              onMouseEnter={handleMouseImg}
-              onMouseLeave={handleMouseImg}
-              opacity={isHoverImg && '0.5'}
-            />
-            <Box
-              as="span"
-              mt="xs"
-              fontSize="12px"
-              cursor="pointer"
-              onClick={handleLogoutClick}
-              color={props?.transparentMode ? 'white' : 'fg'}
-              onMouseEnter={handleMouse}
-              onMouseLeave={handleMouse}
-              textDecoration={isHover && 'underline'}
-            >
-              Sign Out
-            </Box>
-          </Box>
-        )}
-      </ClientSideComponent>
-    </>
+      </Box>
+    )
   );
 }
 

--- a/components/Nav/SignIn.js
+++ b/components/Nav/SignIn.js
@@ -1,0 +1,116 @@
+import { React, useState } from 'react';
+import { useRouter } from 'next/router';
+import PropTypes from 'prop-types';
+import { Box, Icon, systemPropTypes } from 'ui-kit';
+import { CurrentUserProvider } from 'providers';
+import { logout, useAuth } from 'providers/AuthProvider';
+import { UserAvatar, ClientSideComponent } from 'components';
+import { useCurrentBreakpoint } from 'hooks';
+import {
+  hideModal,
+  useModalDispatch,
+  showModal,
+} from 'providers/ModalProvider';
+
+function SignIn(props = {}) {
+  const authenticated = useAuth();
+  const currentBreakpoint = useCurrentBreakpoint();
+  const authDispatch = useAuth();
+  const modalDispatch = useModalDispatch();
+  const router = useRouter();
+
+  const [isHover, setIsHover] = useState(false);
+  const [isHoverImg, setIsHoverImg] = useState(false);
+  const handleMouse = () => {
+    setIsHover(!isHover);
+  };
+  const handleMouseImg = () => {
+    setIsHoverImg(!isHoverImg);
+  };
+
+  function handleAuthClick(event) {
+    event.preventDefault();
+    modalDispatch(showModal('Auth'));
+  }
+
+  function handleRouterReload(pathname) {
+    if (pathname === '/') {
+      return null;
+    }
+    return router.reload();
+  }
+
+  function handleLogoutClick(event) {
+    event.preventDefault();
+    authDispatch(logout());
+    handleRouterReload(router.pathname);
+    modalDispatch(hideModal());
+  }
+
+  return (
+    <>
+      {!currentBreakpoint.isSmall && !authenticated && (
+        <Box cursor="pointer" textDecoration="none" onClick={handleAuthClick}>
+          <Box
+            display="flex"
+            border="2px solid white"
+            justifyContent="center"
+            borderRadius="50%"
+            size="36px"
+          >
+            <Icon
+              name="user"
+              size={20}
+              color={props?.transparentMode ? 'white' : 'fg'}
+            />
+          </Box>
+        </Box>
+      )}
+
+      <ClientSideComponent>
+        {authenticated && (
+          <Box
+            textAlign="center"
+            display="flex"
+            alignItems="center"
+            flexDirection="column"
+          >
+            <CurrentUserProvider
+              Component={UserAvatar}
+              handleAuthClick={handleAuthClick}
+              size={'40'}
+              onMouseEnter={handleMouseImg}
+              onMouseLeave={handleMouseImg}
+              opacity={isHoverImg && '0.5'}
+            />
+            <Box
+              as="span"
+              mt="xs"
+              fontSize="12px"
+              cursor="pointer"
+              onClick={handleLogoutClick}
+              color={props?.transparentMode ? 'white' : 'fg'}
+              onMouseEnter={handleMouse}
+              onMouseLeave={handleMouse}
+              textDecoration={isHover && 'underline'}
+            >
+              Sign Out
+            </Box>
+          </Box>
+        )}
+      </ClientSideComponent>
+    </>
+  );
+}
+
+SignIn.propTypes = {
+  ...systemPropTypes,
+  data: PropTypes.object,
+  transparentMode: PropTypes.bool,
+};
+
+SignIn.defaultProps = {
+  transparentMode: false,
+};
+
+export default SignIn;

--- a/components/UserAvatar/UserAvatar.js
+++ b/components/UserAvatar/UserAvatar.js
@@ -18,6 +18,7 @@ function UserAvatar(props = {}) {
       height={props?.size}
       width={props?.size}
       cursor="pointer"
+      {...props}
     />
   );
 }

--- a/ui-kit/Avatar/Avatar.styles.js
+++ b/ui-kit/Avatar/Avatar.styles.js
@@ -5,6 +5,16 @@ import { system } from 'ui-kit';
 const Avatar = styled.img`
   border-radius: 50%;
   object-fit: cover;
+  opacity: 1 !important;
+
+  &:hover {
+    opacity: ${props => props.opacity}!important;
+  }
+  // for when adding a transition to the opacity with hover
+  transition: opacity 0.3s ease-out;
+  -moz-transition: opacity 0.3s ease-out;
+  -webkit-transition: opacity 0.3s ease-out;
+  -o-transition: opacity 0.3s ease-out;
 
   ${system}
 `;


### PR DESCRIPTION
### About
This PR makes it so color of "Sign Out" changes with transparent header.

### Test Instructions
1. Go to our live page, sign in and go to any location page, for example Palm Beach Gardens [here](https://www.christfellowship.church/locations/palm-beach-gardens), to see how the sign out text looks.
2. Do the same thing on the testing link [here](https://web-app-v2-git-nav-sign-out-color-christ-fellowship-church.vercel.app/locations/palm-beach-gardens).
3. Color on the testing link should be white, matching the other text and icons on the nav bar.


### Screenshots
|How it used to be|With the changes|
|--|--|
|<img width="1440" alt="Screenshot 2023-09-08 at 11 53 11 AM" src="https://github.com/christfellowshipchurch/web-app-v2/assets/94265294/3b4ee5f5-322e-4487-ab44-e17963c5d146">|<img width="1440" alt="Screenshot 2023-09-08 at 11 55 15 AM" src="https://github.com/christfellowshipchurch/web-app-v2/assets/94265294/b77020a5-25ce-4b66-82c7-83140b71afcd">|




### Closes Tickets

