### PR TITLE
Changed the formatting of 20's + 30's

### DIFF
--- a/lib/externalHomeData.js
+++ b/lib/externalHomeData.js
@@ -36,7 +36,7 @@ export const churchForEveryGeneration = [
   {
     __typename: 'MediaContentItem',
     title: 'YOUNG ADULTS',
-    summary: 'College Students / 20s & 30s',
+    summary: "College Students / 20's + 30's",
     coverImage: {
       sources: [
         {


### PR DESCRIPTION
### About
Changed the formatting of 20's + 30's

### Test Instructions
Open external home page 
Under "A church for every generation section", under "Young Adults", you will see that now it says `20's + 30's` instead of `20s & 30s`

### Screenshots
<img width="1188" alt="Screen Shot 2023-09-18 at 9 13 26 AM" src="https://github.com/christfellowshipchurch/web-app-v2/assets/46769629/c1093e8c-17b4-4174-b44e-eeefc0480d4d">


### Closes Tickets
[CFDP-2743](https://christfellowshipchurch.atlassian.net/jira/software/projects/CFDP/boards/2?selectedIssue=CFDP-2743)

### Related Tickets



[CFDP-2743]: https://christfellowshipchurch.atlassian.net/browse/CFDP-2743?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ