### PR TITLE
Made the border of the sign-in icon color dynamic 

### DIFF
--- a/components/Nav/SignIn.js
+++ b/components/Nav/SignIn.js
@@ -72,9 +72,10 @@ function SignIn(props = {}) {
       <Box cursor="pointer" textDecoration="none" onClick={handleAuthClick}>
         <Box
           display="flex"
-          border="2px solid white"
+          border="2px solid"
           justifyContent="center"
           borderRadius="50%"
+          borderColor={props?.transparentMode ? 'white' : 'fg'}
           size="36px"
         >
           <Icon


### PR DESCRIPTION
### About
Made the border of the sign-in icon color dynamic so that it changes depending on the color of the background, rather than always being white.

### Test Instructions
Open a page with a white nav bar background, like the Discover page, and the sign-in icon should now have a visible black border 

### Screenshots
<img width="430" alt="Screen Shot 2023-09-18 at 8 06 57 PM" src="https://github.com/christfellowshipchurch/web-app-v2/assets/46769629/5761c27a-54f5-4be0-9ded-0e9a04e9cb84">

### Closes Tickets
[CFDP-2744](https://christfellowshipchurch.atlassian.net/jira/software/projects/CFDP/boards/2?selectedIssue=CFDP-2744)

### Related Tickets
N/A


[CFDP-2744]: https://christfellowshipchurch.atlassian.net/browse/CFDP-2744?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ