### PR TITLE
ASL Changed from Gardens to Trinity

### DIFF
--- a/components/LocationSingle/locationData.js
+++ b/components/LocationSingle/locationData.js
@@ -59,7 +59,7 @@ const additionalInfoCampusData = [
     name: 'Trinity',
     info: [
       'Kids programming up to grade 5 during service',
-      'ASL interpretation offered at 10am',
+      'ASL interpretation available',
     ],
   },
   {

--- a/components/LocationSingle/locationData.js
+++ b/components/LocationSingle/locationData.js
@@ -8,7 +8,6 @@ const additionalInfoCampusData = [
     info: [
       'Kids services take place at each service',
       'Traducciones al español ofrecidas a las 11:45am',
-      'ASL interpretation offered at 10am',
     ],
   },
   {
@@ -58,7 +57,10 @@ const additionalInfoCampusData = [
   },
   {
     name: 'Trinity',
-    info: ['Kids programming up to grade 5 during service'],
+    info: [
+      'Kids programming up to grade 5 during service',
+      'ASL interpretation offered at 10am',
+    ],
   },
   {
     name: 'Cf Everywhere',


### PR DESCRIPTION
### About
Changed ASL Translation from Gardens to Trinity

### Test Instructions
Open Gardens Location Page it should NOT say that ASL Translation is available in the orange box.
Open Trinity Location Page it should say that ASL Translation is available in the orange box.

### Screenshots
![Screenshot 2023-09-20 at 11 51 45 AM](https://github.com/christfellowshipchurch/web-app-v2/assets/94265294/c8620eb7-2ddb-408d-bb6e-19079da1617b)

### Closes Tickets
Pam Requested
