### PR TITLE
Modals Bug

### DIFF
--- a/components/Header/Header.styles.js
+++ b/components/Header/Header.styles.js
@@ -11,7 +11,7 @@ const Header = styled.header`
   padding: ${themeGet('space.base')};
   position: ${props => props.position};
   width: 100%;
-  z-index: 9;
+  z-index: 1001;
   transition: background-color ease-in 0.2s, opacity ease-in 0.2s;
 
   > *:last-child {

--- a/components/Header/TransparentHeader.js
+++ b/components/Header/TransparentHeader.js
@@ -30,7 +30,7 @@ function TransparentHeader(props = {}) {
   });
 
   return (
-    <Box position="fixed" zIndex={9} width="100%">
+    <Box position="fixed" zIndex={1001} width="100%">
       <ActionBannerProvider Component={ActionBanner} />
       <Styled
         boxShadow="none"

--- a/components/Header/TransparentHeader.js
+++ b/components/Header/TransparentHeader.js
@@ -30,7 +30,7 @@ function TransparentHeader(props = {}) {
   });
 
   return (
-    <Box position="fixed" zIndex={2000} width="100%">
+    <Box position="fixed" zIndex={9} width="100%">
       <ActionBannerProvider Component={ActionBanner} />
       <Styled
         boxShadow="none"

--- a/components/LocationSingle/OldLocationSingle/OldLocationSingle.js
+++ b/components/LocationSingle/OldLocationSingle/OldLocationSingle.js
@@ -66,7 +66,7 @@ function LocationSingle(props = {}) {
           color="white"
           position="absolute"
           mb="base"
-          zIndex={1000}
+          zIndex={8}
           mx="base"
           bottom="0"
         >

--- a/ui-kit/Menu/Menu.styles.js
+++ b/ui-kit/Menu/Menu.styles.js
@@ -9,40 +9,42 @@ const Menu = styled.div`
   ${system}
 `;
 
-const side = ({ side }) => props => {
-  if (typeof side === 'string') {
-    if (side === 'right') {
-      return css`
-        right: 0;
-      `;
+const side =
+  ({ side }) =>
+  props => {
+    if (typeof side === 'string') {
+      if (side === 'right') {
+        return css`
+          right: 0;
+        `;
+      }
     }
-  }
 
-  if (typeof side === 'object') {
-    let styles = '';
+    if (typeof side === 'object') {
+      let styles = '';
 
-    for (const [key, value] of Object.entries(side)) {
-      const breakpoint = theme.breakpoints[key];
-      styles += `
+      for (const [key, value] of Object.entries(side)) {
+        const breakpoint = theme.breakpoints[key];
+        styles += `
         @media screen and (min-width: ${breakpoint}) {
           ${value}: 0;
         }
       `;
+      }
+      return css`
+        ${styles}
+      `;
     }
-    return css`
-      ${styles}
-    `;
-  }
 
-  return css`
-    left: 0;
-  `;
-};
+    return css`
+      left: 0;
+    `;
+  };
 
 const Content = styled.div`
   position: absolute;
   top: 100%;
-  z-index: 20;
+  z-index: 10;
 
   ${side}
   ${system}

--- a/ui-kit/Modal/Modal.styles.js
+++ b/ui-kit/Modal/Modal.styles.js
@@ -49,7 +49,7 @@ const Content = styled.div`
   top: 50%;
   transform: translate(-50%, -50%);
   width: ${props => props.width};
-  z-index: 10;
+  z-index: 1002;
 
   /* Small Only */
   @media screen and (max-width: ${themeGet('breakpoints.md')}) {
@@ -72,7 +72,7 @@ const Overlay = styled.div`
   right: 0;
   top: 0;
   width: 100%;
-  z-index: 9;
+  z-index: 1001;
 `;
 
 Modal.Close = Close;

--- a/ui-kit/Modal/Modal.styles.js
+++ b/ui-kit/Modal/Modal.styles.js
@@ -53,12 +53,11 @@ const Content = styled.div`
 
   /* Small Only */
   @media screen and (max-width: ${themeGet('breakpoints.md')}) {
-    margin-top: -${themeGet('space.l')};
     padding: ${themeGet('space.base')};
     padding-top: ${themeGet('space.xl')};
     width: max-content;
     max-width: calc(100vw - ${themeGet('space.base')});
-    max-height: 85vh;
+    max-height: 75vh;
   }
 `;
 

--- a/ui-kit/Modal/Modal.styles.js
+++ b/ui-kit/Modal/Modal.styles.js
@@ -53,11 +53,12 @@ const Content = styled.div`
 
   /* Small Only */
   @media screen and (max-width: ${themeGet('breakpoints.md')}) {
+    margin-top: ${themeGet('space.base')};
     padding: ${themeGet('space.base')};
     padding-top: ${themeGet('space.xl')};
     width: max-content;
     max-width: calc(100vw - ${themeGet('space.base')});
-    max-height: 75vh;
+    max-height: 80vh;
   }
 `;
 


### PR DESCRIPTION
### About
This PR fixes a bug where when opening big modals the header of the page covers the top of the modal by limiting the max height of the modal more and adding padding top to move it down the page.

### Test Instructions
1. Go to the live website and open the modal on mobile, preferably on an actual mobile device and not simulator, and the top of the modal should be covered by the header of the page.
2. Go to the testing link and do the same, but this time the top of the modal should be visible.
3. Make sure to test both Safari and Google Chrome.

### Screenshots
|How it used to be|With the changes|
|--|--|
|<img width="1077" alt="Screenshot 2023-09-26 at 3 13 10 PM" src="https://github.com/christfellowshipchurch/web-app-v2/assets/94265294/aeff384b-c36b-48d4-9210-018124c3b896">|<img width="1076" alt="Screenshot 2023-09-26 at 3 13 33 PM" src="https://github.com/christfellowshipchurch/web-app-v2/assets/94265294/39dfd7c0-cac7-4ded-8db1-d3df8d019d74">|

### Closes Tickets
[CFDP-2698](https://christfellowshipchurch.atlassian.net/browse/CFDP-2698)


[CFDP-2698]: https://christfellowshipchurch.atlassian.net/browse/CFDP-2698?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ