### PR TITLE
Events Header Video Fix

### DIFF
--- a/components/ContentLayout/ContentLayout.js
+++ b/components/ContentLayout/ContentLayout.js
@@ -18,7 +18,9 @@ const DEFAULT_CONTENT_WIDTH = utils.rem('1100px');
 
 function ContentLayout(props = {}) {
   function renderA() {
-    if (props.coverImage) {
+    if (props.renderA) {
+      return props.renderA();
+    } else if (props.coverImage) {
       return (
         <DefaultCard
           coverImage={props.coverImage}
@@ -27,7 +29,6 @@ function ContentLayout(props = {}) {
         />
       );
     }
-    if (props.renderA) return props.renderA();
     return null;
   }
 

--- a/components/ContentSingle/ContentSingle.js
+++ b/components/ContentSingle/ContentSingle.js
@@ -52,7 +52,7 @@ function ContentSingle(props = {}) {
     } else if (!currentBreakpoint.isSmall) {
       setShowShare(true);
     }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [currentBreakpoint]);
 
   useEffect(() => {
@@ -81,7 +81,7 @@ function ContentSingle(props = {}) {
         mediaType: getMediaType({ url: asPath, ...props?.data }),
       });
     }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [router]);
 
   if (props.loading) {
@@ -98,8 +98,6 @@ function ContentSingle(props = {}) {
       </Box>
     );
   }
-
-  
 
   if (!currentVideo && wistiaId) {
     setCurrentVideo(props.data.wistiaId);

--- a/components/EventSingle/EventSingle.js
+++ b/components/EventSingle/EventSingle.js
@@ -22,8 +22,6 @@ function EventSingle(props = {}) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  const videos = props?.data?.videos;
-
   useEffect(() => {
     if (props.data?.videos?.length >= 1 && currentVideo === null) {
       setCurrentVideo(props.data.videos[0]);
@@ -98,7 +96,7 @@ function EventSingle(props = {}) {
       renderA={() => (
         <ContentVideo
           title={title}
-          video={wistiaId ? wistiaId : videos[0]}
+          video={wistiaId ? wistiaId : props?.data?.videos[0]}
           poster={coverImageUri}
           wistiaId={wistiaId}
         />

--- a/components/Video/Video.js
+++ b/components/Video/Video.js
@@ -31,6 +31,9 @@ export default function Video(props = {}) {
   };
   const notPlaying = () => setIsPlaying(false);
 
+  //generate a random Id for Wistia Wrapper so we can show the same video multiple times on a single page
+  const randomId = Math.floor(Math.random() * 10000);
+
   return (
     <Box
       position="relative"
@@ -42,7 +45,7 @@ export default function Video(props = {}) {
       {props?.wistiaId ? (
         <WistiaPlayer
           videoId={props?.wistiaId}
-          wrapper={`wistia-player-container-${props?.wistiaId}`}
+          wrapper={`wistia-player-container-${props?.wistiaId}-${randomId}`}
         />
       ) : (
         <>

--- a/components/WistiaPlayer/WistiaPlayer.js
+++ b/components/WistiaPlayer/WistiaPlayer.js
@@ -20,7 +20,7 @@ function WistiaPlayer({ videoId, wrapper }) {
       // Cleanup code
       container.innerHTML = '';
     };
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   return <div id={`${wrapper}`}></div>;


### PR DESCRIPTION
### About
This PR fixes a bug where if an event has both video and image it will show the image instead of the video, now it shows the video and not image, but when this event is referenced elsewhere the image is there to display.

### Test Instructions
1. Go to the live website and go to `/events/promotional-video`. The image attached should be displayed instead of the wistia video.
2. But if you go to the testing link and do the same the video should be displayed instead of the image.

 _**This affects other components, such as content single and group single that are using the ContentLayout component, the pages where this is being used will also display videos over images now.**_.


### Screenshots
|How it used to be|With the changes|
|--|--|
|<img width="1440" alt="Screenshot 2023-09-27 at 9 12 34 AM" src="https://github.com/christfellowshipchurch/web-app-v2/assets/94265294/5324d493-002e-4cc5-be24-bc2acb47a142">|<img width="1440" alt="Screenshot 2023-09-27 at 9 12 59 AM" src="https://github.com/christfellowshipchurch/web-app-v2/assets/94265294/37f82d80-ed7f-45c7-a2bd-e71c32696243">|

### Closes Tickets
[CFDP-2748](https://christfellowshipchurch.atlassian.net/browse/CFDP-2748)


[CFDP-2748]: https://christfellowshipchurch.atlassian.net/browse/CFDP-2748?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ