### PR TITLE
Group resources ordering

### DIFF
--- a/components/GroupManage/ResourcesList.js
+++ b/components/GroupManage/ResourcesList.js
@@ -34,7 +34,23 @@ function ResourceCoverImage(props = {}) {
 
 function ResourcesList(props = {}) {
   const { groupData } = useGroupManageState();
-
+  console.log(groupData.resources);
+  // const myData = groupData.resources
+  //   .sort((a, b) => a.title.localeCompare(b.title))
+  //   .map((item, i) => <List key={i} data={item} />);
+  // console.log(myData);
+  const sortedResources = [groupData.resources];
+  sortedResources.sort(function (a, b) {
+    console.log(a.title, b.title);
+    if (a.title < b.title) {
+      return -1;
+    }
+    if (a.title > b.title) {
+      return 1;
+    }
+    return 0;
+  });
+  console.log(sortedResources);
   return (
     <List>
       {groupData?.resources?.map(

--- a/components/GroupManage/ResourcesList.js
+++ b/components/GroupManage/ResourcesList.js
@@ -34,14 +34,7 @@ function ResourceCoverImage(props = {}) {
 
 function ResourcesList(props = {}) {
   const { groupData } = useGroupManageState();
-  console.log(groupData.resources);
-  // const myData = groupData.resources
-  //   .sort((a, b) => a.title.localeCompare(b.title))
-  //   .map((item, i) => <List key={i} data={item} />);
-  // console.log(myData);
-  const sortedResources = [groupData.resources];
-  sortedResources.sort(function (a, b) {
-    console.log(a.title, b.title);
+  const sortedResources = [...groupData.resources].sort((a, b) => {
     if (a.title < b.title) {
       return -1;
     }
@@ -50,10 +43,10 @@ function ResourcesList(props = {}) {
     }
     return 0;
   });
-  console.log(sortedResources);
+
   return (
     <List>
-      {groupData?.resources?.map(
+      {sortedResources.map(
         (resource, idx) =>
           resource?.title && (
             <Box as="li" key={idx} display="flex" alignItems="center">

--- a/components/GroupSingle/GroupResources.js
+++ b/components/GroupSingle/GroupResources.js
@@ -14,34 +14,48 @@ export default function GroupResources(props = {}) {
   // typically derive a URL from the `relatedNode` regardless of
   // whether it's an `OPEN_URL` or `READ_CONTENT` etc action.
 
+  // Sort resources by title
+  const sortedResources = [...props.resources].sort((a, b) => {
+    const titleA = a.title || a.relatedNode?.title;
+    const titleB = b.title || b.relatedNode?.title;
+
+    if (titleA < titleB) {
+      return -1;
+    }
+
+    if (titleA > titleB) {
+      return 1;
+    }
+
+    return 0;
+  });
+
   return (
     <List>
-      {props.resources
-        .filter(resource => resource.title || resource.relatedNode?.title)
-        .map(resource => (
-          <Box key={resource.relatedNode?.id} as="li" display="flex">
-            <CustomLink
-              key={resource.relatedNode?.id}
-              href={getUrlFromRelatedNode(resource.relatedNode)}
-              textDecoration="none"
-              target="_blank"
-            >
-              <Box display="flex" alignItems="center">
-                <Image
-                  maxWidth="50px"
-                  source={
-                    resource.relatedNode?.coverImage?.sources[0]?.uri ||
-                    '/link.png'
-                  }
-                  mr="base"
-                />
-                <Box as="h4">
-                  {resource.title || resource.relatedNode?.title}
-                </Box>
+      {sortedResources.map(sortedResource => (
+        <Box key={sortedResource.relatedNode?.id} as="li" display="flex">
+          <CustomLink
+            key={sortedResource.relatedNode?.id}
+            href={getUrlFromRelatedNode(sortedResource.relatedNode)}
+            textDecoration="none"
+            target="_blank"
+          >
+            <Box display="flex" alignItems="center">
+              <Image
+                maxWidth="50px"
+                source={
+                  sortedResource.relatedNode?.coverImage?.sources[0]?.uri ||
+                  '/link.png'
+                }
+                mr="base"
+              />
+              <Box as="h4">
+                {sortedResource.title || sortedResource.relatedNode?.title}
               </Box>
-            </CustomLink>
-          </Box>
-        ))}
+            </Box>
+          </CustomLink>
+        </Box>
+      ))}
     </List>
   );
 }


### PR DESCRIPTION
### About
Resources now display in alphabetical order in the groups resources tab.

### Test Instructions
1. Go to the CFDP testing group on the live website and compare how the group resources tab looks vs the testing link.
2. On the testing link resources should be ordered alphabetically.
3. Ensure that clicking on external links AND content items works as expected.

### Screenshots
|How it used to be|With the changes|
|--|--|
|<img width="1077" alt="Screenshot 2023-09-26 at 3 13 10 PM" src="https://github.com/christfellowshipchurch/web-app-v2/assets/94265294/455fd5e9-1391-4e3f-b579-e38350530d68">|<img width="1076" alt="Screenshot 2023-09-26 at 3 13 33 PM" src="https://github.com/christfellowshipchurch/web-app-v2/assets/94265294/28bdbc0d-be78-4c4f-9c10-a9cc60feaf75">|


### Closes Tickets
[CFDP-2760](https://christfellowshipchurch.atlassian.net/browse/CFDP-2760)



[CFDP-2760]: https://christfellowshipchurch.atlassian.net/browse/CFDP-2760?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ