### PR TITLE
Added logic to change title and copy for CF Everywhere

### DIFF
--- a/components/LocationSingle/locationData.js
+++ b/components/LocationSingle/locationData.js
@@ -554,11 +554,17 @@ const setReminderData = {
 };
 
 const whatToExpectData = name => {
-  return {
-    name,
-    title: `What to Expect at ${name}`,
-    htmlContent: `Here at Christ Fellowship Church in ${name}, you can expect to experience church services with uplifting worship music, encouraging messages from our pastors, special programming for your family, and opportunities for you to find people to do life with all throughout the week—it all starts here!`,
-  };
+  return name === 'Cf Everywhere'
+    ? {
+        name,
+        title: `What to Expect at Christ Fellowship Everywhere`,
+        htmlContent: `Here at Christ Fellowship Everywhere, you can expect to experience church services with uplifting worship music, encouraging messages from our pastors, special programming for your family, and opportunities for you to find people to do life with all throughout the week—it all starts here!`,
+      }
+    : {
+        name,
+        title: `What to Expect at ${name}`,
+        htmlContent: `Here at Christ Fellowship Church in ${name}, you can expect to experience church services with uplifting worship music, encouraging messages from our pastors, special programming for your family, and opportunities for you to find people to do life with all throughout the week—it all starts here!`,
+      };
 };
 
 const thisWeekFeatureId =

--- a/components/LocationSingle/locationData.js
+++ b/components/LocationSingle/locationData.js
@@ -554,17 +554,17 @@ const setReminderData = {
 };
 
 const whatToExpectData = name => {
-  return name === 'Cf Everywhere'
-    ? {
-        name,
-        title: `What to Expect at Christ Fellowship Everywhere`,
-        htmlContent: `Here at Christ Fellowship Everywhere, you can expect to experience church services with uplifting worship music, encouraging messages from our pastors, special programming for your family, and opportunities for you to find people to do life with all throughout the week—it all starts here!`,
-      }
-    : {
-        name,
-        title: `What to Expect at ${name}`,
-        htmlContent: `Here at Christ Fellowship Church in ${name}, you can expect to experience church services with uplifting worship music, encouraging messages from our pastors, special programming for your family, and opportunities for you to find people to do life with all throughout the week—it all starts here!`,
-      };
+  return {
+    name,
+    title: `What to Expect at ${
+      name === 'Cf Everywhere' ? 'Christ Fellowship Everywhere' : name
+    }`,
+    htmlContent: `${
+      name === 'Cf Everywhere'
+        ? 'Here at Christ Fellowship Everywhere'
+        : 'Here at Christ Fellowship Church in ' + name
+    }, you can expect to experience church services with uplifting worship music, encouraging messages from our pastors, special programming for your family, and opportunities for you to find people to do life with all throughout the week—it all starts here!`,
+  };
 };
 
 const thisWeekFeatureId =


### PR DESCRIPTION
### About
Added logic to change title and copy for CF Everywhere

### Test Instructions
Test link -> /locations/cf-everywhere: you should see the changes on the What to Expect section  
These changes only apply to CF Everywhere, not any other campuses. 

### Screenshots
**Before**
<img width="1440" alt="Screenshot 2023-10-16 at 2 47 20 PM" src="https://github.com/christfellowshipchurch/web-app-v2/assets/46769629/fcb7511f-e396-4abd-8dc8-26604e28bc64">

**After**
<img width="1436" alt="Screen Shot 2023-10-16 at 3 59 05 PM" src="https://github.com/christfellowshipchurch/web-app-v2/assets/46769629/b9c9c026-0351-4670-95a5-a56818b652c4">

### Closes Tickets
[CFDP-2773](https://christfellowshipchurch.atlassian.net/jira/software/projects/CFDP/boards/2?selectedIssue=CFDP-2773)

### Related Tickets
N/A

[CFDP-2773]: https://christfellowshipchurch.atlassian.net/browse/CFDP-2773?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ