### PR TITLE
Removed Spanish translations

### DIFF
--- a/components/LocationSingle/locationData.js
+++ b/components/LocationSingle/locationData.js
@@ -5,10 +5,7 @@
 const additionalInfoCampusData = [
   {
     name: 'Palm Beach Gardens',
-    info: [
-      'Kids services take place at each service',
-      'Traducciones al español ofrecidas a las 11:45am',
-    ],
+    info: ['Kids services take place at each service'],
   },
   {
     name: 'Port St. Lucie',


### PR DESCRIPTION
### About
Removed Spanish translations from Gardens campus 

### Test Instructions
Open the Gardens campus location page and you won't see the Spanish translations offered in the orange tab

### Screenshots
<img width="1288" alt="Screen Shot 2023-10-18 at 10 13 26 AM" src="https://github.com/christfellowshipchurch/web-app-v2/assets/46769629/556c1f7b-bf27-440c-afd6-4b787388a1d4">

### Closes Tickets
[CFDP-2777](https://christfellowshipchurch.atlassian.net/jira/software/projects/CFDP/boards/2?selectedIssue=CFDP-2777)

### Related Tickets
N/A


[CFDP-2777]: https://christfellowshipchurch.atlassian.net/browse/CFDP-2777?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ