### PR TITLE
Content Search - Added Filter for Bad Duplicates

### DIFF
--- a/hooks/useSearchContentItems.js
+++ b/hooks/useSearchContentItems.js
@@ -54,8 +54,6 @@ function useSearchContentItems(options = {}) {
     );
   }
 
-  console.log(query?.data?.search?.edges);
-
   return [
     search,
     {

--- a/hooks/useSearchContentItems.js
+++ b/hooks/useSearchContentItems.js
@@ -46,6 +46,16 @@ function useSearchContentItems(options = {}) {
     fetchPolicy: 'no-cache',
   });
 
+  // Add a check that removes any results that don't have a url
+  // This is a temporary fix to remove duplicate results with no url
+  if (query?.data?.search?.edges) {
+    query.data.search.edges = query.data.search.edges.filter(
+      edge => edge.routing?.pathname
+    );
+  }
+
+  console.log(query?.data?.search?.edges);
+
   return [
     search,
     {


### PR DESCRIPTION
### About
For some reason Algolia is returning duplicate content items, not sure why, but will add a filter here for the time being to remove duplicates that don't have a URL

### Test Instructions
* search for duplicate item(such as "How to Create a Lifestyle of Prayer") in the Discover search
* You should see no bad duplicates.

### Screenshots
![image](https://github.com/christfellowshipchurch/web-app-v2/assets/46049974/e667907d-1362-4962-a8dd-85dfebe69ad3)

### Closes Tickets
[CFDP-2793](https://christfellowshipchurch.atlassian.net/browse/CFDP-2793)

[CFDP-2793]: https://christfellowshipchurch.atlassian.net/browse/CFDP-2793?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ