### PR TITLE
Added Spanish Translations Back

### DIFF
--- a/components/LocationSingle/locationData.js
+++ b/components/LocationSingle/locationData.js
@@ -5,7 +5,10 @@
 const additionalInfoCampusData = [
   {
     name: 'Palm Beach Gardens',
-    info: ['Kids services take place at each service'],
+    info: [
+      'Kids services take place at each service',
+      'Traducciones al español ofrecidas a las 11:45am',
+    ],
   },
   {
     name: 'Port St. Lucie',


### PR DESCRIPTION
### About
Added Spanish Translations Back to Gardens Location Page 

### Test Instructions
Open Gardens Location Page and you should see the Spanish translations offered in the orange box.

### Screen
![Screen Shot 2023-11-03 at 12 02 18 PM](https://github.com/christfellowshipchurch/web-app-v2/assets/46769629/38d77557-58dc-460a-8760-7f19e650be71)
shots


### Closes Tickets
[CFDP-2778](https://christfellowshipchurch.atlassian.net/jira/software/projects/CFDP/boards/2?selectedIssue=CFDP-2778)

### Related Tickets
N/A


[CFDP-2778]: https://christfellowshipchurch.atlassian.net/browse/CFDP-2778?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ