### PR TITLE
Added margin bottom for share button

### DIFF
--- a/components/EventSingle/EventSingle.js
+++ b/components/EventSingle/EventSingle.js
@@ -102,9 +102,9 @@ function EventSingle(props = {}) {
         />
       )}
       renderC={() => (
-        <Box justifySelf="flex-end">
+        <Box justifySelf="flex-end" mb={{ _: 'base', md: '0px' }}>
           <Share
-            mb={{ _: 'base' }}
+            mb="base"
             title={props.data.title}
             shareTitle="Invite"
             shareMessages={eventShareMessages}


### PR DESCRIPTION
### About
This PR adds margin to the bottom of the share button on mobile view.

### Test Instructions
1. Go to [the Christmas Wishlist event page](https://web-app-v2-git-events-share-margin-christ-fellowship-church.vercel.app/events/christmas-wishlist) through the testing link and compare the mobile view with the live version.

### Screenshots
|Without the changes|With the changes|
|--|--|
|<img width="327" alt="Screenshot 2023-12-05 at 2 29 25 PM" src="https://github.com/christfellowshipchurch/web-app-v2/assets/94265294/e9e099c2-15cf-4e56-b6e8-118a8db2130e">|<img width="326" alt="Screenshot 2023-12-05 at 2 28 37 PM" src="https://github.com/christfellowshipchurch/web-app-v2/assets/94265294/1bc282cc-cad9-4352-bfc9-26d60b1735ac">|

### Closes Tickets
[CFDP-2826](https://christfellowshipchurch.atlassian.net/jira/software/projects/CFDP/boards/2?selectedIssue=CFDP-2826)


[CFDP-2826]: https://christfellowshipchurch.atlassian.net/browse/CFDP-2826?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ