### PR TITLE
Discover Bug Fix

### DIFF
--- a/pages/discover/[title].js
+++ b/pages/discover/[title].js
@@ -11,7 +11,6 @@ import {
   Cell,
   Button,
   utils,
-  Loader,
   HorizontalHighlightCard,
   Icon,
 } from 'ui-kit';

--- a/pages/discover/[title].js
+++ b/pages/discover/[title].js
@@ -61,7 +61,9 @@ export default function DiscoverFilterCategoriesPreview() {
               display="flex"
               py="none"
               variant="link"
-              onClick={() => push(`/discover?c=${query?.c}&s=${query?.s}`)}
+              onClick={() =>
+                push(`/discover?c=${query?.c}&s=${query?.s || ''}`)
+              }
             >
               <Icon name="angle-left" color="primary" />
               Back

--- a/pages/discover/[title].js
+++ b/pages/discover/[title].js
@@ -87,7 +87,6 @@ export default function DiscoverFilterCategoriesPreview() {
                 scaleCard={false}
                 scaleCoverImage={true}
                 title={n?.title}
-                loading
                 type="HIGHLIGHT_SMALL"
               />
             ))

--- a/pages/discover/[title].js
+++ b/pages/discover/[title].js
@@ -72,25 +72,36 @@ export default function DiscoverFilterCategoriesPreview() {
         </Box>
 
         <CardGrid columns="3" mb="xl">
-          {loading ? (
-            <Loader />
-          ) : (
-            contentItems.map(n => (
-              <CustomLink
-                Component={n?.title ? DefaultCard : HorizontalHighlightCard}
-                as="a"
-                boxShadow="none"
-                coverImage={n?.coverImage?.sources[0]?.uri}
-                description={n?.summary}
-                href={getUrlFromRelatedNode(n)}
-                key={n?.id}
-                scaleCard={false}
-                scaleCoverImage={true}
-                title={n?.title}
-                type="HIGHLIGHT_SMALL"
-              />
-            ))
-          )}
+          {loading
+            ? contentItems.map(n => (
+                <CustomLink
+                  as="a"
+                  boxShadow="none"
+                  href=""
+                  Component={HorizontalHighlightCard}
+                  label={'true'}
+                  coverImageLabelBgColor="black"
+                  coverImageOverlay={true}
+                  type="HIGHLIGHT_SMALL"
+                  mobileHeight="150px"
+                  loading={true}
+                />
+              ))
+            : contentItems.map(n => (
+                <CustomLink
+                  Component={n?.title ? DefaultCard : HorizontalHighlightCard}
+                  as="a"
+                  boxShadow="none"
+                  coverImage={n?.coverImage?.sources[0]?.uri}
+                  description={n?.summary}
+                  href={getUrlFromRelatedNode(n)}
+                  key={n?.id}
+                  scaleCard={false}
+                  scaleCoverImage={true}
+                  title={n?.title}
+                  type="HIGHLIGHT_SMALL"
+                />
+              ))}
         </CardGrid>
       </Cell>
     </Layout>


### PR DESCRIPTION
### About
This PR fixes a bug where when nothing is searched and the user clicks the back button after opening a resource "undefined "is searched.

### Test Instructions
1. Go to the live [discover](https://www.christfellowship.church/discover?c=devotionals-articles&s=) page and click on view all, then click back and undefined should appear in the search bar.
2. Go to the [discover](https://web-app-v2-git-discover-bug-christ-fellowship-church.vercel.app/discover?c=devotionals-articles&s=) testing link and do the same, the bug should be fixed. 
3. When clicking on `view all` in the testing link it should also work now.

### Screenshots


### Closes Tickets

