### PR TITLE
Adding Note to Banner

### DIFF
--- a/components/LocationSingle/CampusInfo/index.js
+++ b/components/LocationSingle/CampusInfo/index.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { camelCase, find } from 'lodash';
 import { useCurrentBreakpoint } from 'hooks';
 
-import { Box, Cell, Divider, Icon, Image, utils } from 'ui-kit';
+import { Box, Cell, Divider, Icon, utils } from 'ui-kit';
 
 import { campusLinks } from '../../../lib/locationData';
 import Styled from '../LocationSingle.styles';
@@ -71,28 +71,8 @@ const CampusInfo = ({
         {/* Christmas Banner For Mobile */}
         {currentBreakpoints.isSmall && (
           <Styled.MobileChristmasBanner>
-            <Image
-              width={40}
-              height={40}
-              source="/location-pages/christmas-banner.jpeg"
-              mr="10px"
-            />
-            <Box>
-              <Box as="h3" mb="0">
-                Looking for Christmas Service?
-              </Box>
-              <Box fontStyle="italic">
-                Christmas service times differ.{' '}
-                <Box
-                  as="a"
-                  color="white"
-                  href="https://www.christmasatcf.com/"
-                  target="_blank"
-                  textDecoration="underline"
-                >
-                  Find a Christmas service here.
-                </Box>
-              </Box>
+            <Box fontStyle="italic">
+              *Note: There will be no 5PM service on New Year's Eve
             </Box>
           </Styled.MobileChristmasBanner>
         )}
@@ -140,30 +120,8 @@ const CampusInfo = ({
             {/* Christmas Banner */}
             {!currentBreakpoints.isSmall && (
               <Styled.ChristmasBanner>
-                <Image
-                  width="42px"
-                  height="42px"
-                  source="/location-pages/christmas-banner.jpeg"
-                  mr="10px"
-                />
-
-                <Box>
-                  Looking for a Christmas Service?
-                  <Styled.ChristmasSubtitle>
-                    Times may vary.{' '}
-                    <Box
-                      as="a"
-                      color="white"
-                      href="https://www.christmasatcf.com/"
-                      target="_blank"
-                      textDecoration="underline"
-                    >
-                      Find a Christmas service{' '}
-                      {currentBreakpoints.isMedium
-                        ? 'here'
-                        : "that's right for you."}
-                    </Box>
-                  </Styled.ChristmasSubtitle>
+                <Box fontStyle="italic">
+                  *Note: There will be no 5PM service on New Year's Eve
                 </Box>
               </Styled.ChristmasBanner>
             )}

--- a/components/LocationSingle/CampusInfo/index.js
+++ b/components/LocationSingle/CampusInfo/index.js
@@ -69,7 +69,7 @@ const CampusInfo = ({
         width="100%"
       >
         {/* Christmas Banner For Mobile */}
-        {currentBreakpoints.isSmall && (
+        {currentBreakpoints.isSmall && name === 'Palm Beach Gardens' && (
           <Styled.MobileChristmasBanner>
             <Box fontStyle="italic">
               *Note: There will be no 5PM service on New Year's Eve
@@ -118,7 +118,7 @@ const CampusInfo = ({
             )}
 
             {/* Christmas Banner */}
-            {!currentBreakpoints.isSmall && (
+            {!currentBreakpoints.isSmall && name === 'Palm Beach Gardens' && (
               <Styled.ChristmasBanner>
                 <Box fontStyle="italic">
                   *Note: There will be no 5PM service on New Year's Eve

--- a/components/LocationSingle/LocationSingle.styles.js
+++ b/components/LocationSingle/LocationSingle.styles.js
@@ -21,13 +21,15 @@ const ChristmasBanner = styled.div`
   padding-top: ${themeGet('space.s')};
   box-shadow: -7px -5px 19px rgba(0, 0, 0, 0.12);
   position: absolute;
-  top: -42px;
+  top: -21px;
   right: 370px;
 
   @media screen and (min-width: ${themeGet(
       'breakpoints.md'
     )}) and (max-width: ${themeGet('breakpoints.lg')}) {
-    right: 322px;
+    right: 306px;
+    top: -37px;
+    font-size: 14px;
   }
 
   ${system}

--- a/components/LocationSingle/LocationSingle.styles.js
+++ b/components/LocationSingle/LocationSingle.styles.js
@@ -12,7 +12,6 @@ const ChristmasBanner = styled.div`
   border-top-left-radius: ${themeGet('radii.base')};
   color: white;
   font-size: 17px;
-  font-weight: bold;
   display: flex;
 
   padding-bottom: ${themeGet('space.s')};
@@ -39,7 +38,6 @@ const MobileChristmasBanner = styled.div`
   background: ${themeGet('colors.hues.red')};
   color: white;
   font-size: 14px;
-  font-weight: bold;
   padding-bottom: ${themeGet('space.s')};
   padding-top: ${themeGet('space.s')};
   box-shadow: -7px -5px 19px rgba(0, 0, 0, 0.12);


### PR DESCRIPTION
### About
This PR removes the Christmas Info telling users about Christmas Services and adds a note, to the Garden's Campus, saying that there will not be a 5pm service on Christmas Eve.

### Test Instructions
Test that the banner looks good on mobile and desktop, and that is only visible in the Garden's location.

### Screenshots
<img width="1440" alt="Screenshot 2023-12-27 at 12 36 51 PM" src="https://github.com/christfellowshipchurch/web-app-v2/assets/94265294/08488784-a9ce-4ed6-8f32-b1dc40eba72e">


### Closes Tickets

[CFDP-2848](https://christfellowshipchurch.atlassian.net/browse/CFDP-2848)

[CFDP-2848]: https://christfellowshipchurch.atlassian.net/browse/CFDP-2848?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ