### PR TITLE
Fixes campus names for coming up section

### DIFF
--- a/lib/locationData.js
+++ b/lib/locationData.js
@@ -692,9 +692,9 @@ const testimonials = {
 };
 
 const whatsComingUp = {
-  iglesiaRoyalPalmBeach:
+  christFellowshipEspanolRoyalPalmBeach:
     'UniversalContentItem:44033af6345fa2a690509b6030765874',
-  iglesiaPalmBeachGardens:
+  christFellowshipEspanolPalmBeachGardens:
     'UniversalContentItem:44033af6345fa2a690509b6030765874',
   cfEverywhere: 'UniversalContentItem:04f022613f5beaca2532ef3a8e052cd6',
 };


### PR DESCRIPTION
### About
Fixes campus names for coming up section. The Coming Up Section was broken because the campus name was wrong

### Test Instructions
Go to any of the two CFE campuses and scroll down to the Coming Up section, it should say Proximamente and not Coming Up Soon

### Screenshots
![image](https://github.com/christfellowshipchurch/web-app-v2/assets/46769629/1dccac10-4af5-4572-9a2e-c2ab73d9f83e)


### Closes Tickets
N/A

### Related Tickets
N/A

