### PR TITLE
Location Pages Map Bug

### DIFF
--- a/components/InfoCardList/InfoCardList.js
+++ b/components/InfoCardList/InfoCardList.js
@@ -30,7 +30,7 @@ function InfoCardList(props) {
             display="flex"
             flexDirection="column"
             alignItems="center"
-            jsutifyContent="center"
+            justifyContent="center"
             textAlign="center"
             color="white"
             p="l"

--- a/components/LocationSingle/CampusInfo/PastorCard.js
+++ b/components/LocationSingle/CampusInfo/PastorCard.js
@@ -66,20 +66,25 @@ const PastorCard = ({
           width="100%"
           display="flex"
           flexDirection="column"
-          alignItems="flex-start"
+          alignItems={{ _: 'center', md: 'flex-start' }}
+          textAlign={{ _: 'center', md: 'left' }}
           px="l"
         >
-          <Image
-            maxWidth={250}
-            aspectRatio="16by9"
-            source={`/location-pages/maps/${kebabCase(campusName)}.jpg`}
-          />
+          {!currentBreakpoints.isSmall && (
+            <Box as="a" target="_blank" href={mapLink}>
+              <Image
+                maxWidth={250}
+                aspectRatio="16by9"
+                source={`/location-pages/maps/${kebabCase(campusName)}.jpg`}
+              />
+            </Box>
+          )}
           <Box as="h4" mt="base" mb="xs">
             {campusName === CFEPBG || campusName === CFERPB
               ? 'Dirección'
               : 'Address'}
           </Box>
-          <Box as="a" textAlign="left" href={mapLink}>
+          <Box as="a" target="_blank" href={mapLink}>
             {addressFirst}
             <br />
             {addressLast}

--- a/components/LocationSingle/CampusInfo/PastorCard.js
+++ b/components/LocationSingle/CampusInfo/PastorCard.js
@@ -66,8 +66,7 @@ const PastorCard = ({
           width="100%"
           display="flex"
           flexDirection="column"
-          alignItems={{ _: 'center', md: 'flex-start' }}
-          textAlign={{ _: 'center', md: 'left' }}
+          alignItems="center"
           px="l"
         >
           {!currentBreakpoints.isSmall && (

--- a/components/LocationSingle/CampusInfo/customComponents.js
+++ b/components/LocationSingle/CampusInfo/customComponents.js
@@ -279,7 +279,6 @@ const CFEMobileButtons = name => {
   const campusName = name.campus;
 
   return [
-    <StyledDivider display="flex" width="100%" />,
     <Box
       ml="base"
       display={{ _: 'flex', md: 'none' }}

--- a/components/LocationSingle/CampusInfo/index.js
+++ b/components/LocationSingle/CampusInfo/index.js
@@ -252,13 +252,14 @@ const CampusInfo = ({
       )}
 
       {(name === CFEPBG || name === CFERPB) && (
-        <Box>
+        <Box display={{ _: 'inline', md: 'none' }}>
           <Divider my="l" width="80%" />
           <WeekdayScheduleDisplay
             isMobile
             weekdaySchedules={weekdaySchedules}
             campus={name}
           />
+          <Divider width="80%" />
           <CFEMobileButtons campus={name} />
         </Box>
       )}


### PR DESCRIPTION
### About
This PR re-implements being able to click on the map to be redirected to the location of the campus on google maps. It also removes the map from mobile view and centers the address.

### Test Instructions
1. Ensure all of the features mentioned above work and look as desired on mobile and desktop view. Look at Figma for reference.
2. Make sure that the dividers showing up on web view are no longer there (Lis changes) See screenshots below.

### Screenshots
<img width="371" alt="Screenshot 2024-01-08 at 2 57 05 PM" src="https://github.com/christfellowshipchurch/web-app-v2/assets/94265294/b54687f4-1ae3-4491-b438-f4a9d8e4e3e6">

#### Before
![Screen Shot 2024-01-17 at 3 14 11 PM](https://github.com/christfellowshipchurch/web-app-v2/assets/46769629/f51e5d69-d448-410a-b816-3eb2a3ebd2a2)

#### After
![Screen Shot 2024-01-17 at 3 13 31 PM](https://github.com/christfellowshipchurch/web-app-v2/assets/46769629/686f13d0-70f0-4ca1-97d7-669d39cb8539)

### Closes Tickets
[CFDP-2866](https://christfellowshipchurch.atlassian.net/browse/CFDP-2866)



[CFDP-2866]: https://christfellowshipchurch.atlassian.net/browse/CFDP-2866?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ