### PR TITLE
Fixed Sisterhood Podcast Season Bug

### DIFF
--- a/pages/so-good-sisterhood/season/[title].js
+++ b/pages/so-good-sisterhood/season/[title].js
@@ -10,12 +10,13 @@ import {
   Cell,
   Button,
   utils,
-  Loader,
   HorizontalHighlightCard,
   Icon,
 } from 'ui-kit';
 import { Layout, CustomLink } from 'components';
 import { useAnalytics } from 'providers/AnalyticsProvider';
+
+const CARDS_LOADING = 6;
 
 export default function SisterhoodPodcastSeason() {
   const { push } = useRouter();
@@ -68,26 +69,25 @@ export default function SisterhoodPodcastSeason() {
         </Box>
 
         <CardGrid columns="3" mb="xl">
-          {loading ? (
-            <Loader />
-          ) : (
-            contentItems.map(n => (
-              <CustomLink
-                Component={n?.title ? DefaultCard : HorizontalHighlightCard}
-                as="a"
-                boxShadow="none"
-                coverImage={n?.coverImage?.sources[0]?.uri}
-                description={n?.summary}
-                href={getUrlFromRelatedNode(n)}
-                key={n?.id}
-                scaleCard={false}
-                scaleCoverImage={true}
-                title={n?.title}
-                loading
-                type="HIGHLIGHT_SMALL"
-              />
-            ))
-          )}
+          {loading
+            ? [...Array(CARDS_LOADING)].map(n => (
+                <DefaultCard key={n} height={250} loading={true} />
+              ))
+            : contentItems.map(n => (
+                <CustomLink
+                  Component={n?.title ? DefaultCard : HorizontalHighlightCard}
+                  as="a"
+                  boxShadow="none"
+                  coverImage={n?.coverImage?.sources[0]?.uri}
+                  description={n?.summary}
+                  href={getUrlFromRelatedNode(n)}
+                  key={n?.id}
+                  scaleCard={false}
+                  scaleCoverImage={true}
+                  title={n?.title}
+                  type="HIGHLIGHT_SMALL"
+                />
+              ))}
         </CardGrid>
       </Cell>
     </Layout>


### PR DESCRIPTION
### About
The So Good Sisterhood Podcast season pages we're not loading properly. This PR fixes that and adds a new loading state.

### Test Instructions
* go to `/so-good-sisterhood` and navigate to any of the season pages.

### Screenshots
![image](https://github.com/christfellowshipchurch/web-app-v2/assets/46049974/b9771dfc-f70f-4520-a454-66ed45a61c1b)


### Closes Tickets
[CFDP-2879](https://christfellowshipchurch.atlassian.net/browse/CFDP-2879)



[CFDP-2879]: https://christfellowshipchurch.atlassian.net/browse/CFDP-2879?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ