### PR TITLE
Events Header Fix

### DIFF
--- a/components/EventSingle/EventSingle.js
+++ b/components/EventSingle/EventSingle.js
@@ -26,7 +26,7 @@ function EventSingle(props = {}) {
     if (props.data?.videos?.length >= 1 && currentVideo === null) {
       setCurrentVideo(props.data.videos[0]);
     } else if (props.data?.wistiaId?.length >= 1 && currentVideo === null) {
-      setCurrentVideo(props.data.wistiaId);
+      setCurrentVideo(null);
     }
   }, [props.data?.videos, props.data?.wistiaId, currentVideo]);
 
@@ -45,21 +45,21 @@ function EventSingle(props = {}) {
     );
   }
 
-  const author = props?.data?.author;
-  const coverImage = props?.data?.coverImage;
-  const featureFeed = props?.data?.featureFeed;
-  const schedule = props?.data?.schedule;
-  const summary = props?.data?.summary;
-  const title = props?.data?.title;
+  const {
+    author,
+    coverImage,
+    featureFeed,
+    schedule,
+    summary,
+    title,
+    videos,
+    wistiaId,
+  } = props?.data;
+
   const coverImageUri = coverImage?.sources[0]?.uri;
   const authorName = author
     ? `${author.firstName} ${author.lastName}`
     : undefined;
-  const wistiaId = props?.data?.wistiaId;
-
-  if (!currentVideo && wistiaId) {
-    setCurrentVideo(props.data.wistiaId);
-  }
 
   const eventShareMessages = {
     faceBook: `Check out ${title} happening at Christ Fellowship Church!`,
@@ -92,15 +92,19 @@ function EventSingle(props = {}) {
         video: contentLayoutVideo,
       }}
       summary={props.data.summary}
-      coverImage={currentVideo ? null : coverImageUri}
-      renderA={() => (
-        <ContentVideo
-          title={title}
-          video={wistiaId ? wistiaId : props?.data?.videos[0]}
-          poster={coverImageUri}
-          wistiaId={wistiaId}
-        />
-      )}
+      coverImage={coverImageUri}
+      renderA={
+        videos[0] || wistiaId
+          ? () => (
+              <ContentVideo
+                title={title}
+                video={videos[0]}
+                poster={coverImageUri}
+                wistiaId={wistiaId}
+              />
+            )
+          : null
+      }
       renderC={() => (
         <Box justifySelf="flex-end" mb={{ _: 'base', md: '0px' }}>
           <Share


### PR DESCRIPTION
### About
This PR implements a fix to the bug that stoped header images from showing up in event pages.

### Test Instructions
Go to any event page in the testing link. Here are two examples:
1. [/infuse](https://web-app-v2-git-events-header-fix-christ-fellowship-church.vercel.app/events/infuse)
2. [/vive-night](https://web-app-v2-git-events-header-fix-christ-fellowship-church.vercel.app/events/vive-night)

### Screenshots
<img width="1440" alt="Screenshot 2024-01-26 at 9 52 38 AM" src="https://github.com/christfellowshipchurch/web-app-v2/assets/94265294/d6d1fb46-65e1-475e-8cd9-022f736762a3">


### Closes Tickets
[CFDP-2890](https://christfellowshipchurch.atlassian.net/browse/CFDP-2890)



[CFDP-2890]: https://christfellowshipchurch.atlassian.net/browse/CFDP-2890?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ