### PR TITLE
Wistia Videos not Working on Content Single

### DIFF
--- a/components/ContentSingle/ContentSingle.js
+++ b/components/ContentSingle/ContentSingle.js
@@ -113,7 +113,7 @@ function ContentSingle(props = {}) {
   const metadata = keyBy(props?.data?.metadata, 'name');
 
   let contentLayoutVideo = null;
-  if (currentVideo?.wistiaId) contentLayoutVideo = currentVideo?.wistiaId;
+  if (props?.wistiaId) contentLayoutVideo = props?.wistiaId;
 
   return (
     <ContentLayout

--- a/components/ContentSingle/ContentVideo.js
+++ b/components/ContentSingle/ContentVideo.js
@@ -2,8 +2,7 @@ import PropTypes from 'prop-types';
 import { Video } from 'components';
 import Styled from './ContentSingle.styles';
 export default function ContentVideo(props = {}) {
-
-  if (!props.video) {
+  if (!props.video && !props.wistiaId) {
     return null;
   }
 


### PR DESCRIPTION
### About
This PR fixes a bug where articles with a Wistia video were not displaying the video.

### Test Instructions
1. Go to any article that is supposed to display a Wistia video. [example](https://www.christfellowship.church/articles/how-to-keep-jesus-at-the-center-of-christmas).
2. Test that the video is displayed in the same article, on the testing [link](https://web-app-v2-git-wistia-videos-ar-1fb955-christ-fellowship-church.vercel.app/articles/how-to-keep-jesus-at-the-center-of-christmas).

### Screenshots
![Screenshot 2024-02-05 at 1 59 45 PM](https://github.com/christfellowshipchurch/web-app-v2/assets/94265294/c52cc4ef-dfc4-48c3-a885-17f8a1475026)


### Closes Tickets
[CFDP-2902](https://christfellowshipchurch.atlassian.net/browse/CFDP-2902)


[CFDP-2902]: https://christfellowshipchurch.atlassian.net/browse/CFDP-2902?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ