### PR TITLE
Removed Okeechobee Easter Spanish Translation

### DIFF
--- a/components/PhotoCarousel/PhotoCarousel.js
+++ b/components/PhotoCarousel/PhotoCarousel.js
@@ -9,7 +9,7 @@ import Styled from './PhotoCarousel.styles';
 
 function PhotoCarousel({ photo }) {
   return (
-    <Box overflow="hidden" borderTop="3px solid black">
+    <Box overflow="hidden">
       <Styled.CarouselTrack
         height={400}
         position="relative"

--- a/lib/easterServiceData.js
+++ b/lib/easterServiceData.js
@@ -227,7 +227,7 @@ const easterServices = [
     easterServices: [
       {
         day: 'Sunday, March 31',
-        timeDescription: '8AM, 9:30AM*, 11:30AM',
+        timeDescription: '8AM, 9:30AM, 11:30AM',
       },
     ],
     goodFridayServices: [
@@ -244,10 +244,7 @@ const easterServices = [
         date: 'March 31',
       },
     ],
-    extraInfo: [
-      '<span style="color: #818181; font-style: italic;">*Spanish Translation</span>',
-      'Special programming for babies - 6th grade.',
-    ],
+    extraInfo: ['Special programming for babies - 6th grade.'],
   },
   {
     name: 'Belle Glade',


### PR DESCRIPTION
### About
This PR removes the Spanish translation from the Okeechobee card in the Easter page. 

### Test Instructions
Test that the translation is removed.

### Screenshots


### Closes Tickets

