### PR TITLE
Easter 2024 Redirect Fix

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -132,6 +132,11 @@ module.exports = {
         destination: '/dwpb',
         permanent: true,
       },
+      {
+        source: '/easter-2024',
+        destination: '/easter',
+        permanent: true,
+      },
       // TODO: Uncomment these lines to hide Group Finder.
       // NOTE: We can't get `config/flags` in this file.
       // {

--- a/public/_redirects
+++ b/public/_redirects
@@ -22,3 +22,4 @@
 /locations/riviera-beach                 /riviera-beach
 /studies/sisterhood-sogoodsummer         /studies/sisterhood-shownotes-plus
 /locations/downtown-west-palm-beach      /dwpb
+/easter-2024                             /easter


### PR DESCRIPTION
### About
This PR redirect users going to `/easter-2024` to `/easter`, this was necessary since we recently changed the url of the Easter page, however Google still directs users to `/easter-2024`

### Test Instructions
1. Test that going to `/easter-2024` redirects users to `/easter`.

### Screenshots


### Closes Tickets
[CFDP-3002](https://christfellowshipchurch.atlassian.net/browse/CFDP-3002)



[CFDP-3002]: https://christfellowshipchurch.atlassian.net/browse/CFDP-3002?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ