### PR TITLE
Easter 2024 Redirect

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -132,11 +132,6 @@ module.exports = {
         destination: '/dwpb',
         permanent: true,
       },
-      {
-        source: '/easter-2024',
-        destination: '/easter',
-        permanent: true,
-      },
       // TODO: Uncomment these lines to hide Group Finder.
       // NOTE: We can't get `config/flags` in this file.
       // {

--- a/next.config.js
+++ b/next.config.js
@@ -132,6 +132,11 @@ module.exports = {
         destination: '/dwpb',
         permanent: true,
       },
+      {
+        source: '/easter',
+        destination: '/easter-2024',
+        permanent: true,
+      },
       // TODO: Uncomment these lines to hide Group Finder.
       // NOTE: We can't get `config/flags` in this file.
       // {

--- a/next.config.js
+++ b/next.config.js
@@ -132,6 +132,11 @@ module.exports = {
         destination: '/dwpb',
         permanent: true,
       },
+      {
+        source: '/easter-2024',
+        destination: '/easter',
+        permanent: true,
+      },
       // TODO: Uncomment these lines to hide Group Finder.
       // NOTE: We can't get `config/flags` in this file.
       // {

--- a/public/_redirects
+++ b/public/_redirects
@@ -22,3 +22,4 @@
 /locations/riviera-beach                 /riviera-beach
 /studies/sisterhood-sogoodsummer         /studies/sisterhood-shownotes-plus
 /locations/downtown-west-palm-beach      /dwpb
+/easter                                  /easter-2024

--- a/public/_redirects
+++ b/public/_redirects
@@ -22,3 +22,4 @@
 /locations/riviera-beach                 /riviera-beach
 /studies/sisterhood-sogoodsummer         /studies/sisterhood-shownotes-plus
 /locations/downtown-west-palm-beach      /dwpb
+/easter-2024                             /easter

--- a/public/_redirects
+++ b/public/_redirects
@@ -22,4 +22,3 @@
 /locations/riviera-beach                 /riviera-beach
 /studies/sisterhood-sogoodsummer         /studies/sisterhood-shownotes-plus
 /locations/downtown-west-palm-beach      /dwpb
-/easter-2024                             /easter


### PR DESCRIPTION
### About
This PR flips the Easter redirect so `/easter` redirects user to `/easter-2024`. This PR also updates the wording of the external home page to 'for over 40 years'.

### Test Instructions
1. Test that when trying to access `/easter` you are redirected to `/easter-2024`.
2. Test that wording on the external home page, in Thrive section, it says 'for over 40 years'.

### Screenshots


### Closes Tickets
[CFDP-2988](https://christfellowshipchurch.atlassian.net/browse/CFDP-2988)
[CFDP-2951](https://christfellowshipchurch.atlassian.net/browse/CFDP-2951)

[CFDP-2988]: https://christfellowshipchurch.atlassian.net/browse/CFDP-2988?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CFDP-2951]: https://christfellowshipchurch.atlassian.net/browse/CFDP-2951?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ