### PR TITLE
Removed Trinity SetAReminder Video 

### DIFF
--- a/lib/locationData.js
+++ b/lib/locationData.js
@@ -629,7 +629,7 @@ const setReminderVideos = {
   veroBeach: 'jo1p0qsz3s',
   bocaRaton: 'de1dcyyel6',
   westlake: '7tadieucep',
-  trinity: '6fy7j3t3n5',
+  // trinity: '6fy7j3t3n5',
   christFellowshipEspanolPalmBeachGardens: 'c0flio8p3x',
 };
 


### PR DESCRIPTION
### About
Removed Trinity Set a Reminder video until video of new pastor is ready

### Test Instructions
Open the trinity locations page and you won't see the set a reminder video

### Closes Tickets
[CFDP-3017](https://christfellowshipchurch.atlassian.net/jira/software/projects/CFDP/boards/2?selectedIssue=CFDP-3017)


[CFDP-3017]: https://christfellowshipchurch.atlassian.net/browse/CFDP-3017?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ