### PR TITLE
Removed unnecessary blank space h4h 

### DIFF
--- a/components/HeartForHouseComponents/YearInReview.js
+++ b/components/HeartForHouseComponents/YearInReview.js
@@ -211,7 +211,7 @@ const HeartForHouseYearInReview = ({ id }) => (
           <Box as="a" color="primary" fontWeight="600">
             Christ Fellowship Everywhere{' '}
           </Box>
-          on- demand messages had over 5 million views and were shared with over
+          on-demand messages had over 5 million views and were shared with over
           100,000 people!
         </Box>
 


### PR DESCRIPTION
### About
Removed unnecessary blank space before "demand"
 
### Before 
<img width="440" alt="Screen Shot 2024-04-25 at 2 34 29 PM" src="https://github.com/christfellowshipchurch/web-app-v2/assets/46769629/914f104d-497f-4acb-9a7d-97b598395b8d">
