### PR TITLE
Search Bug

### DIFF
--- a/pages/discover/index.js
+++ b/pages/discover/index.js
@@ -57,7 +57,7 @@ const Discover = () => {
   //   }
   // };
 
-  const handleClick = event => {
+  const handleClick = () => {
     setSearchVisible(true);
     if (values.text) {
       router.push({
@@ -93,6 +93,13 @@ const Discover = () => {
   function handleClearAllClick(event) {
     event.preventDefault();
     setSearchVisible(false);
+    router.push({
+      pathname: '/discover',
+      query: {
+        c: kebabCase(filterValues.title),
+        s: kebabCase(''),
+      },
+    });
     reset();
   }
 


### PR DESCRIPTION
### About
This PR fixes a search bug where, when something is searched, and then cleared with the x icon, then select a filter, it will search what you previously searched again. This was due to the search still being saved in the url.

### Test Instructions
1. In the [live](https://www.christfellowship.church/discover?c=on-demand-messages&s=) discover page do what's described above.
2. Try the same thing in the [testing](https://web-app-v2-git-search-bug-fix-christ-fellowship-church.vercel.app/discover?c=on-demand-messages&s=) link.

### Screenshots


### Closes Tickets
[CFDP-3045](https://christfellowshipchurch.atlassian.net/browse/CFDP-3045)



[CFDP-3045]: https://christfellowshipchurch.atlassian.net/browse/CFDP-3045?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ