### PR TITLE
So Good Sisterhood Update

### DIFF
--- a/hooks/useSisterhoodPodcast.js
+++ b/hooks/useSisterhoodPodcast.js
@@ -1,8 +1,8 @@
 import { gql, useQuery } from '@apollo/client';
 
 export const GET_SISTERHOOD_SEASON = gql`
-  query SisterhoodPodcastSeason($seasonNumber: Int!) {
-    sisterhoodPodcastSeason(seasonNumber: $seasonNumber) {
+  query SisterhoodPodcastSeason($seasonName: String!) {
+    sisterhoodPodcastSeason(seasonName: $seasonName) {
       title
       summary
       id

--- a/pages/so-good-sisterhood/season/[title].js
+++ b/pages/so-good-sisterhood/season/[title].js
@@ -15,6 +15,7 @@ import {
 } from 'ui-kit';
 import { Layout, CustomLink } from 'components';
 import { useAnalytics } from 'providers/AnalyticsProvider';
+import { startCase } from 'lodash';
 
 const CARDS_LOADING = 6;
 
@@ -22,24 +23,30 @@ export default function SisterhoodPodcastSeason() {
   const { push } = useRouter();
   const analytics = useAnalytics();
   const router = useRouter();
-  const seasonNumber = parseInt(router.query.title);
-
+  const routerTitle = router.query.title;
+  let seasonName;
+  // Check if the season name is the season number or a whole sentence like 'Summer With Friends'
+  if (!isNaN(routerTitle)) {
+    seasonName = `Season ${routerTitle}`;
+  } else {
+    seasonName = startCase(routerTitle);
+  }
   const { contentItems, loading } = useSisterhoodPodcast({
-    variables: { seasonNumber: seasonNumber },
+    variables: { seasonName: seasonName },
     fetchPolicy: 'cache-and-network',
   });
 
   //Segment Page Tracking
   useEffect(() => {
     analytics.page({
-      title: `View All Season "${seasonNumber}" Category`,
+      title: `View All "${seasonName}" Category`,
       mediaType: 'Information',
     });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   return (
-    <Layout title={`Season ${seasonNumber}`}>
+    <Layout title={seasonName}>
       <Cell
         as="main"
         maxWidth={utils.rem('1100px')}
@@ -53,7 +60,7 @@ export default function SisterhoodPodcastSeason() {
           mb="l"
         >
           <Box as="h1" mb="0">
-            Season {seasonNumber}
+            {seasonName}
           </Box>
           <Box>
             <Button


### PR DESCRIPTION
### About
This PR updates the variable passed to the query that fetches the episodes for individual seasons of the So Good Sisterhood podcast. This was because before the Seasons were just numbers, but now they are full sentences.

### Test Instructions
1. Test locally with the API, with the branch: christfellowshipchurch/services#79

### Screenshots
Visually nothing changed, but the query was changed in the API, but if these changed had not worked, the episodes in the individual season pages would not be visible.

### Closes Tickets
[CFDP-3079](https://christfellowshipchurch.atlassian.net/browse/CFDP-3079)


[CFDP-3079]: https://christfellowshipchurch.atlassian.net/browse/CFDP-3079?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ