### PR TITLE
Young Adults Copy Fix

### DIFF
--- a/lib/externalHomeData.js
+++ b/lib/externalHomeData.js
@@ -36,7 +36,7 @@ export const churchForEveryGeneration = [
   {
     __typename: 'MediaContentItem',
     title: 'YOUNG ADULTS',
-    summary: "College Students / 20's + 30's",
+    summary: 'College Students / 20s + 30s',
     coverImage: {
       sources: [
         {


### PR DESCRIPTION
### About
This PR updates the copy for the young adults card in the Get There First section of the home page, the apostrophes were removed, 20s + 30s reads without them.

### Test Instructions
1. Test that the copy for this section is updated correctly.

### Screenshots
|Before|After|
|--|--|
|<img width="400" alt="Screenshot 2024-08-06 at 11 58 23 AM" src="https://github.com/user-attachments/assets/c5da867e-74d8-465d-8313-808e93ae8b30">|<img width="400" alt="Screenshot 2024-08-06 at 11 58 23 AM" src="https://github.com/user-attachments/assets/65be7ded-8eec-498a-8a83-40d684c18da1">|

### Closes Tickets
[CFDP-3136](https://christfellowshipchurch.atlassian.net/browse/CFDP-3136)


[CFDP-3136]: https://christfellowshipchurch.atlassian.net/browse/CFDP-3136?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ