### PR TITLE
CF Conference Tickets Purchased

### DIFF
--- a/pages/conference-2025-report/index.js
+++ b/pages/conference-2025-report/index.js
@@ -1,0 +1,25 @@
+import { Layout } from 'components';
+import { Box } from 'ui-kit';
+
+export default function ConferenceReport() {
+  return (
+    <Layout>
+      <Box bg="white">
+        <Box
+          maxWidth={1000}
+          mx="auto"
+          height={{ _: 300, sm: 400, md: 600, lg: 700 }}
+        >
+          <iframe
+            title="Looker Studio Embed"
+            width="100%"
+            height="100%"
+            src="https://lookerstudio.google.com/embed/reporting/9374bb18-85ec-41db-bafe-5895ac7e4259/page/kR8BE"
+            style={{ border: 0 }}
+            allowFullScreen
+          />
+        </Box>
+      </Box>
+    </Layout>
+  );
+}


### PR DESCRIPTION
### About
This PR adds a new page with an embed from Looker Studio to display the number of tickets purchased for CF Conference 2025. See new page at `/conference-2025-report`

### Screenshots
![image](https://github.com/user-attachments/assets/bdaaf6d1-caa9-45ad-a4b6-69017bc446ab)

