### PR TITLE
Fixed Mobile Nav for Webflow Pages

### DIFF
--- a/pages/next-steps/index.js
+++ b/pages/next-steps/index.js
@@ -1,6 +1,6 @@
 import Head from 'next/head';
 import parseHtml from 'html-react-parser';
-import { Footer, Header } from 'components';
+import { Layout } from 'components';
 import { useAnalytics } from 'providers/AnalyticsProvider';
 import { useEffect } from 'react';
 import { useRouter } from 'next/router';
@@ -29,9 +29,9 @@ export default function NextStepsPage(props) {
   return (
     <>
       <Head>{parseHtml(props?.headContent)}</Head>
-      <Header />
-      <div dangerouslySetInnerHTML={{ __html: props?.bodyContent }} />
-      <Footer />
+      <Layout>
+        <div dangerouslySetInnerHTML={{ __html: props?.bodyContent }} />
+      </Layout>
     </>
   );
 }

--- a/pages/one-life/index.js
+++ b/pages/one-life/index.js
@@ -1,6 +1,6 @@
 import Head from 'next/head';
 import parseHtml from 'html-react-parser';
-import { Footer, Header } from 'components';
+import { Layout } from 'components';
 import { useAnalytics } from 'providers/AnalyticsProvider';
 import { useEffect } from 'react';
 import { useRouter } from 'next/router';
@@ -29,9 +29,9 @@ export default function OneLifePage(props) {
   return (
     <>
       <Head>{parseHtml(props?.headContent)}</Head>
-      <Header />
-      <div dangerouslySetInnerHTML={{ __html: props?.bodyContent }} />
-      <Footer />
+      <Layout>
+        <div dangerouslySetInnerHTML={{ __html: props?.bodyContent }} />
+      </Layout>
     </>
   );
 }

--- a/pages/years-of-impact/index.js
+++ b/pages/years-of-impact/index.js
@@ -1,6 +1,6 @@
 import Head from 'next/head';
 import parseHtml from 'html-react-parser';
-import { Footer, Header } from 'components';
+import { Layout } from 'components';
 import { Box } from 'ui-kit';
 import { useAnalytics } from 'providers/AnalyticsProvider';
 import { useEffect } from 'react';
@@ -16,10 +16,10 @@ export default function TimelinePage(props) {
   }, []);
   return (
     <Box bg="black" overflow="none">
-      <Head>{parseHtml(props.headContent)}</Head>
-      <Header />
-      <div dangerouslySetInnerHTML={{ __html: props.bodyContent }} />
-      <Footer />
+      <Head>{parseHtml(props?.headContent)}</Head>
+      <Layout>
+        <div dangerouslySetInnerHTML={{ __html: props?.bodyContent }} />
+      </Layout>
     </Box>
   );
 }


### PR DESCRIPTION
### About
The mobile Nav Menu was not showing properly for some of our Webflow embedded pages. We were not not using the Layout component properly that renders it for us

### Test Instructions
* Test mobile Navscreen for `/next-steps`, `/years-of-impact`, `/one-life`

### Screenshots
![image](https://github.com/user-attachments/assets/6676d0bf-e0cf-4ee2-824d-3e22b8c916f4)

### Closes Tickets
[CFDP-3199](https://christfellowshipchurch.atlassian.net/browse/CFDP-3199)


[CFDP-3199]: https://christfellowshipchurch.atlassian.net/browse/CFDP-3199?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ