### PR TITLE
Removed Lottie Logo Animation

### DIFF
--- a/components/Logo/Logo.js
+++ b/components/Logo/Logo.js
@@ -2,19 +2,11 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import { Box } from 'ui-kit';
-import { LottieViewer } from 'components';
 
 function Logo(props = {}) {
   const filename = `/logo${props.dark ? '-dark' : ''}.png`;
 
-  /**
-   * Adding temporary Lottie animation for dark mode for Christ Fellowship 40th Anniversary
-   */
-  return props?.dark ? (
-    <Box maxWidth={200}>
-      <LottieViewer fileName="cf40-logo" />
-    </Box>
-  ) : (
+  return (
     <Box
       as="img"
       src={filename}


### PR DESCRIPTION
### About
This PR removes the 40th anniversary Lottie animation and adds the static logo back.

### Test Instructions
1. Ensure that Nav and Footer logos are not the anniversary animations.

### Screenshots


### Closes Tickets
[CFDP-3277](https://christfellowshipchurch.atlassian.net/browse/CFDP-3277)


[CFDP-3277]: https://christfellowshipchurch.atlassian.net/browse/CFDP-3277?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ