### PR TITLE
Christmas Redirect

### DIFF
--- a/components/LocationSingle/CampusInfo/AdditionalComponents/WeekdaySchedules.js
+++ b/components/LocationSingle/CampusInfo/AdditionalComponents/WeekdaySchedules.js
@@ -84,10 +84,10 @@ const WeekdayScheduleDisplay = ({ weekdaySchedules, isMobile, campus }) => {
           : 'During the Week'}
       </Box>
       <Box>
-        {validDaysOfWeek(weekdaySchedules)?.map(day => {
+        {validDaysOfWeek(weekdaySchedules)?.map((day, index) => {
           const formattedDay = capitalize(Object?.keys(day));
           return (
-            <Box mt="base" textAlign="center">
+            <Box mt="base" key={index} textAlign="center">
               <Box as="h3" mb="xs">
                 {campus === CFEPBG || campus === CFERPB
                   ? weekdaySpanishTranslation(formattedDay)

--- a/components/LocationSingle/CampusInfo/CampusInfo.js
+++ b/components/LocationSingle/CampusInfo/CampusInfo.js
@@ -6,7 +6,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { camelCase, find } from 'lodash';
 
-import { Box, Cell, Divider, Icon, utils } from 'ui-kit';
+import { Box, Cell, Divider, Icon } from 'ui-kit';
 
 import { campusLinks } from '../../../lib/locationData';
 import Styled from '../LocationSingle.styles';

--- a/next.config.js
+++ b/next.config.js
@@ -147,6 +147,11 @@ module.exports = {
         destination: '/next-steps',
         permanent: true,
       },
+      {
+        source: '/christmas',
+        destination: '/christmas-2024',
+        permanent: true,
+      },
       // TODO: Uncomment these lines to hide Group Finder.
       // NOTE: We can't get `config/flags` in this file.
       // {

--- a/public/_redirects
+++ b/public/_redirects
@@ -25,3 +25,4 @@
 /easter                                  /easter-2024
 /easter-espanol                          /easter-espanol-2024
 /it-all-starts-here                      /next-steps
+/christmas                               /christmas-2024


### PR DESCRIPTION
### About
This PR redirect users to the Christmas page builder where they can find out more about this year's Christmas.

### Test Instructions
1. Ensure that when going to `/christmas` you are redirected to `/christmas-2024`, test on different browsers and devices ideally.

### Screenshots


### Closes Tickets
[CFDP-3298](https://christfellowshipchurch.atlassian.net/browse/CFDP-3298)


[CFDP-3298]: https://christfellowshipchurch.atlassian.net/browse/CFDP-3298?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ