### PR TITLE
Adding Heart for the House to Give page

### DIFF
--- a/components/GiveWithPushpay/GiveWithPushpay.js
+++ b/components/GiveWithPushpay/GiveWithPushpay.js
@@ -13,6 +13,7 @@ function GiveWithPushpay(props = {}) {
     : [
         'Tithes & Offerings',
         'Kingdom Builders',
+        'Heart for the House',
         'Christ Birthday Offering',
         'Missions',
       ];
@@ -55,6 +56,25 @@ function GiveWithPushpay(props = {}) {
         [event.target.name]: '',
       }));
   };
+
+  const givingTypeURL =
+    values.givingType === 'Heart for the House'
+      ? 'https://pushpay.com/g/cfh4th?fnd=jt-LCSg3OxQQuMJmf0SzbQ&lang=en' +
+        '?f[0]=' +
+        values.campus +
+        '&a=' +
+        values.amount +
+        '&' +
+        (active === 'giveRecurring' && 'r=weekly')
+      : props?.buttonLink +
+        '?f[0]=' +
+        values.campus +
+        '&a=' +
+        values.amount +
+        '&f[1]=' +
+        values.givingType +
+        '&' +
+        (active === 'giveRecurring' && 'r=weekly');
 
   return (
     <Styled id="give" backgroundImage={props?.backgroundImage}>
@@ -186,17 +206,7 @@ function GiveWithPushpay(props = {}) {
             target="blank"
             mt="xl"
             mb="l"
-            href={
-              props?.buttonLink +
-              '?f[0]=' +
-              values.campus +
-              '&a=' +
-              values.amount +
-              '&f[1]=' +
-              values.givingType +
-              '&' +
-              (active === 'giveRecurring' && 'r=weekly')
-            }
+            href={givingTypeURL}
             bg={props?.buttonColor}
             px="l"
           >


### PR DESCRIPTION
### About
This PR adds 'Heart for the House' giving type with custom Pushpay URL.

### Test Instructions
1. Test that selecting Heart for the House option directs users to a different Pushpay link, and that the selected elements go over to that page correctly, as well as confirm that the selected elements go over to the regular Pushpay link propertly.

### Screenshots
![Screenshot 2025-02-27 at 11 27 26 AM](https://github.com/user-attachments/assets/b915b928-d4ed-4270-bb2d-42fc82973c03)


### Closes Tickets
[CFDP-3376](https://christfellowshipchurch.atlassian.net/browse/CFDP-3376)


[CFDP-3376]: https://christfellowshipchurch.atlassian.net/browse/CFDP-3376?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ