### PR TITLE
Remove Easter 2025 from Location Pages

### DIFF
--- a/components/LocationSingle/CampusInfo/CampusInfo.js
+++ b/components/LocationSingle/CampusInfo/CampusInfo.js
@@ -6,7 +6,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { camelCase, find } from 'lodash';
 
-import { Box, Button, Cell, Divider, Icon, Image } from 'ui-kit';
+import { Box, Cell, Divider, Icon } from 'ui-kit';
 
 import { campusLinks } from '../../../lib/locationData';
 import Styled from '../LocationSingle.styles';
@@ -53,20 +53,20 @@ const CampusInfo = ({
   const mdHeight = name === 'Online (CF Everywhere)' ? 500 : 'auto';
 
   /** ---- Event Banner Props ----  */
-  const bannerUrl = '/easter';
+  // const bannerUrl = '/easter';
 
-  /** Spanish Campuses */
+  // /** Spanish Campuses */
 
-  let subtitle, title, cta;
-  if (cfe) {
-    title = '¿Buscas un servicio de Pascua?';
-    subtitle = 'Mira los horarios de los servicios de Pascua y Viernes Santo ';
-    cta = 'aquí';
-  } else {
-    title = 'Looking for an Easter service?';
-    subtitle = 'See all Easter and Good Friday service times ';
-    cta = 'here';
-  }
+  // let subtitle, title, cta;
+  // if (cfe) {
+  //   title = '¿Buscas un servicio de Pascua?';
+  //   subtitle = 'Mira los horarios de los servicios de Pascua y Viernes Santo ';
+  //   cta = 'aquí';
+  // } else {
+  //   title = 'Looking for an Easter service?';
+  //   subtitle = 'See all Easter and Good Friday service times ';
+  //   cta = 'here';
+  // }
   /** ---- Event Banner Props ----  */
 
   return (
@@ -87,7 +87,7 @@ const CampusInfo = ({
         width="100%"
       >
         {/* Event Banner For Mobile --- For Easter/Christmas */}
-        <Styled.MobileEventBanner
+        {/* <Styled.MobileEventBanner
           display={{ _: 'flex', md: 'none' }}
           backgroundColor="#F1EB9C"
           textColor="black"
@@ -95,7 +95,7 @@ const CampusInfo = ({
           alignItems="center"
           px="base"
         >
-          {/* <Image
+          <Image
             width={50}
             height={50}
             objectFit="contain"
@@ -118,33 +118,13 @@ const CampusInfo = ({
               </Box>
               .
             </Styled.EventSubtitle>
-          </Box> */}
-
-          {/* Holy Week Banner */}
-          <Box as="h3" mt="0.5rem" color="#2A5989">
-            Easter Week Services
           </Box>
-          <Box as="p" textAlign="center" fontWeight="normal">
-            Join us for special services this week as we celebrate the
-            resurrection of Jesus Christ. Our schedule has been modified for
-            Easter.
-          </Box>
-          <Button
-            maxWidth="400px"
-            mx="auto"
-            width="100%"
-            borderRadius="l"
-            my="base"
-            bg="#2A5989"
-          >
-            View Easter Service Times
-          </Button>
-        </Styled.MobileEventBanner>
+        </Styled.MobileEventBanner> */}
 
         {/* Service Times */}
         <Box width="100%" mt="-0.3rem">
           <Styled.ServiceTimeContainer>
-            {/* <Styled.ServiceTimeTitle>
+            <Styled.ServiceTimeTitle>
               {name === 'Online (CF Everywhere)'
                 ? 'Live Every Sunday'
                 : cfe
@@ -171,38 +151,11 @@ const CampusInfo = ({
                       )}
                     </React.Fragment>
                   )
-              )} */}
-
-            {/* Holy Week Service Times */}
-            <Box
-              display="flex"
-              flexDirection="column"
-              alignItems="center"
-              pl="base"
-            >
-              <Box as="h3" fontSize="20px" color="#2A5989">
-                Easter Week Services
-              </Box>
-              <Button size="s" width="100%" borderRadius="l" bg="#2A5989">
-                Service Times
-              </Button>
-            </Box>
-            <Box
-              as="p"
-              px="base"
-              fontWeight="normal"
-              flex="3"
-              lineHeight="1.6"
-              href="/easter"
-            >
-              Join us for special services this week as we celebrate the
-              resurrection of Jesus Christ. Our schedule has been modified for
-              Easter.
-            </Box>
+              )}
           </Styled.ServiceTimeContainer>
 
           {/* Addtional Information - Orange Box */}
-          {/* <Box mr={{ _: 0, lg: 'base' }}>
+          <Box mr={{ _: 0, lg: 'base' }}>
             {additionalInfo && additionalInfo?.length > 0 && (
               <Styled.InfoBox>
                 {additionalInfo.map(n => (
@@ -212,9 +165,8 @@ const CampusInfo = ({
                 ))}
               </Styled.InfoBox>
             )}
-          </Box> */}
-          {/* Desktop Easter Banner --- For Easter/Christmas */}
-
+          </Box>
+          {/* Event Banner for Desktop --- For Easter/Christmas */}
           {/* <Styled.EventBanner
             display={{ _: 'none', md: 'flex' }}
             position="relative"

--- a/components/LocationSingle/LocationHeader.js
+++ b/components/LocationSingle/LocationHeader.js
@@ -95,8 +95,7 @@ const LocationHeader = (props = {}) => {
               display="flex"
               justifyContent={{ _: 'space-between', sm: 'flex-start' }}
             >
-              {/* Set a Reminder -- HIDING FOR EASTER 2025 */}
-              {/* <Button
+              <Button
                 as="a"
                 id={props?.primaryButton?.id}
                 href={props?.primaryButton?.action}
@@ -115,7 +114,7 @@ const LocationHeader = (props = {}) => {
                 px={{ _: '6px', sm: '1.25rem' }}
               >
                 {props?.primaryButton?.call}
-              </Button> */}
+              </Button>
               <Button
                 as="a"
                 onClick={() =>

--- a/components/LocationSingle/LocationSingle.js
+++ b/components/LocationSingle/LocationSingle.js
@@ -175,22 +175,16 @@ function LocationSingle(props = {}) {
                 {...(campus === CFEPBG || campus === CFERPB
                   ? setReminderEspanolData
                   : setReminderData)}
-                // HIDING FOR EASTER 2025
-                // button={{
-                //   id: 'set-reminder',
-                //   title:
-                //     campus === CFEPBG || campus === CFERPB
-                //       ? 'Recuérdame'
-                //       : 'Set a Reminder',
-                //   onClick: () =>
-                //     modalDispatch(
-                //       showModal('SetReminder', { defaultCampus: campus })
-                //     ),
-                // }}
                 button={{
-                  id: 'connect-card-button',
-                  title: 'Connect',
-                  onClick: () => modalDispatch(showModal('ConnectCardModal')),
+                  id: 'set-reminder',
+                  title:
+                    campus === CFEPBG || campus === CFERPB
+                      ? 'Recuérdame'
+                      : 'Set a Reminder',
+                  onClick: () =>
+                    modalDispatch(
+                      showModal('SetReminder', { defaultCampus: campus })
+                    ),
                 }}
               />
             </Box>

--- a/components/LocationSingle/LocationSingle.styles.js
+++ b/components/LocationSingle/LocationSingle.styles.js
@@ -99,20 +99,14 @@ const ServiceTimeTitle = styled.h4`
 
 const ServiceTimeContainer = styled.div`
   align-items: center;
-  // background: linear-gradient(270.35deg, #0092bc -22.55%, #004f71 106.52%),
-  //   linear-gradient(90.49deg, #6bcaba -24.45%, #0092bc 118.95%);
-  // Easter 2025
-  background: #f1eb9c;
+  background: linear-gradient(270.35deg, #0092bc -22.55%, #004f71 106.52%),
+    linear-gradient(90.49deg, #6bcaba -24.45%, #0092bc 118.95%);
   border-top-left-radius: ${themeGet('radii.base')};
   border-bottom-left-radius: ${themeGet('radii.base')};
-  display: none;
+  display: flex;
   justify-content: space-around;
   padding-top: ${themeGet('space.base')};
   padding-bottom: ${themeGet('space.base')};
-
-  @media screen and (min-width: ${themeGet('breakpoints.md')}) {
-    display: flex;
-  }
 
   @media screen and (min-width: ${themeGet('breakpoints.sm')}) {
     flex-wrap: nowrap;


### PR DESCRIPTION
### About
This PR removes the additional styling from Holy Week and hides the Event banner to change the location pages back to the default view after Easter.

**⚠️DO NOT MERGE - until AFTER Easter⚠️**

### Test Instructions
* test both desktop and mobile display for Location pages.

### Screenshots
![image](https://github.com/user-attachments/assets/7d9891b1-5844-45e8-93a4-79921157c5ac)