### PR TITLE
Hide Set a Reminder for Location Pages

### DIFF
--- a/components/LocationSingle/LocationHeader.js
+++ b/components/LocationSingle/LocationHeader.js
@@ -95,7 +95,8 @@ const LocationHeader = (props = {}) => {
               display="flex"
               justifyContent={{ _: 'space-between', sm: 'flex-start' }}
             >
-              <Button
+              {/* Set a Reminder -- HIDING FOR EASTER 2025 */}
+              {/* <Button
                 as="a"
                 id={props?.primaryButton?.id}
                 href={props?.primaryButton?.action}
@@ -114,7 +115,7 @@ const LocationHeader = (props = {}) => {
                 px={{ _: '6px', sm: '1.25rem' }}
               >
                 {props?.primaryButton?.call}
-              </Button>
+              </Button> */}
               <Button
                 as="a"
                 onClick={() =>

--- a/components/LocationSingle/LocationSingle.js
+++ b/components/LocationSingle/LocationSingle.js
@@ -158,7 +158,6 @@ function LocationSingle(props = {}) {
           </Box>
         )}
 
-        {/* Set a Reminder */}
         {campus !== 'Cf Everywhere' && (
           <>
             <Box
@@ -176,16 +175,22 @@ function LocationSingle(props = {}) {
                 {...(campus === CFEPBG || campus === CFERPB
                   ? setReminderEspanolData
                   : setReminderData)}
+                // HIDING FOR EASTER 2025
+                // button={{
+                //   id: 'set-reminder',
+                //   title:
+                //     campus === CFEPBG || campus === CFERPB
+                //       ? 'Recuérdame'
+                //       : 'Set a Reminder',
+                //   onClick: () =>
+                //     modalDispatch(
+                //       showModal('SetReminder', { defaultCampus: campus })
+                //     ),
+                // }}
                 button={{
-                  id: 'set-reminder',
-                  title:
-                    campus === CFEPBG || campus === CFERPB
-                      ? 'Recuérdame'
-                      : 'Set a Reminder',
-                  onClick: () =>
-                    modalDispatch(
-                      showModal('SetReminder', { defaultCampus: campus })
-                    ),
+                  id: 'connect-card-button',
+                  title: 'Connect',
+                  onClick: () => modalDispatch(showModal('ConnectCardModal')),
                 }}
               />
             </Box>


### PR DESCRIPTION
### About
This PR temporarily hides the Set a Reminder for Easter 2025 because the service times don't reflect this weekend.

### Test Instructions
- see that set reminder buttons are hidden/replaced on Location Single

### Screenshots
<img width="1400" alt="image" src="https://github.com/user-attachments/assets/5626c572-8296-4d47-932a-e0cef73f2973" />