### PR TITLE
Added My Groups Coach Role

### DIFF
--- a/components/GroupSingle/GroupSingle.js
+++ b/components/GroupSingle/GroupSingle.js
@@ -6,7 +6,7 @@ import { ContentLayout } from 'components';
 import { useCurrentBreakpoint, useCurrentUser, useCheckIn } from 'hooks';
 
 import { ChatConnectionProvider } from 'providers';
-import { currentUserIsLeader, transformISODates } from 'utils';
+import { currentUserIsMemberType, transformISODates } from 'utils';
 import { Box, Button, Card, Icon } from 'ui-kit';
 
 import GroupChat from './GroupChat';
@@ -19,7 +19,14 @@ function GroupSingle(props = {}) {
   const router = useRouter();
   const currentBreakpoint = useCurrentBreakpoint();
   const { currentUser } = useCurrentUser();
-  const isLeader = currentUserIsLeader(currentUser, props.data?.leaders?.edges);
+  const isLeader = currentUserIsMemberType(
+    currentUser,
+    props.data?.leaders?.edges
+  );
+  const isCoach = currentUserIsMemberType(
+    currentUser,
+    props.data?.coaches?.edges
+  );
 
   const { checkInCompleted, options, checkInCurrentUser } = useCheckIn({
     nodeId: props.data.id,
@@ -34,6 +41,9 @@ function GroupSingle(props = {}) {
       checkInCurrentUser({ optionIds: options.map(({ id }) => id) });
     }
   };
+
+  const { leaders, coaches, members } = props.data;
+  console.log({ leaders, coaches, members });
 
   // Sub-render functions for clarity
   // -----------------------------------
@@ -60,7 +70,7 @@ function GroupSingle(props = {}) {
       pb="l"
       mt={{ _: 'l', md: '0' }}
     >
-      {isLeader && (
+      {(isLeader || isCoach) && (
         <Box my="base">
           <Button
             rounded

--- a/hooks/useGroup.js
+++ b/hooks/useGroup.js
@@ -103,7 +103,7 @@ export const GROUP_FRAGMENT = gql`
     resources {
       ...GroupResourceFragment
     }
-    leaders: people(isLeader: true, first: 10) {
+    leaders: people(role: LEADER, first: 10) {
       edges {
         node {
           id
@@ -116,7 +116,20 @@ export const GROUP_FRAGMENT = gql`
       }
       totalCount
     }
-    members: people(isLeader: false, first: 10) {
+    members: people(role: MEMBER, first: 10) {
+      edges {
+        node {
+          id
+          firstName
+          lastName
+          photo {
+            uri
+          }
+        }
+      }
+      totalCount
+    }
+    coaches: people(role: COACH, first: 10) {
       edges {
         node {
           id

--- a/utils/__tests__/currentUserIsLeader.test.js
+++ b/utils/__tests__/currentUserIsLeader.test.js
@@ -1,4 +1,4 @@
-import currentUserIsLeader from '../currentUserIsLeader';
+import currentUserIsMemberType from '../currentUserIsMemberType';
 
 const leaders = [
   { node: { id: 'Leader:1234' } },
@@ -7,10 +7,10 @@ const leaders = [
 
 test('it should return true when the current user is a leader', () => {
   const currentUser = { id: 'User:1234' };
-  expect(currentUserIsLeader(currentUser, leaders)).toBe(true);
+  expect(currentUserIsMemberType(currentUser, leaders)).toBe(true);
 });
 
 test('it should return false when the current user is NOT a leader', () => {
   const currentUser = { id: 'User:4321' };
-  expect(currentUserIsLeader(currentUser, leaders)).toBe(false);
+  expect(currentUserIsMemberType(currentUser, leaders)).toBe(false);
 });

--- a/utils/currentUserIsMemberType.js
+++ b/utils/currentUserIsMemberType.js
@@ -1,6 +1,6 @@
 import find from 'lodash/find';
 
-function currentUserIsLeader(currentUser, leaders) {
+function currentUserIsMemberType(currentUser, leaders) {
   const id = _id => (!_id ? _id : _id.split(':').pop());
   const match = find(
     leaders,
@@ -9,4 +9,4 @@ function currentUserIsLeader(currentUser, leaders) {
   return match ? true : false;
 }
 
-export default currentUserIsLeader;
+export default currentUserIsMemberType;

--- a/utils/index.js
+++ b/utils/index.js
@@ -1,6 +1,6 @@
 import cleanMarkup from './cleanMarkup';
 import colorHover from './colorHover';
-import currentUserIsLeader from './currentUserIsLeader';
+import currentUserIsMemberType from './currentUserIsMemberType';
 import createMarkup from './createMarkup';
 import dateTextFormat from './dateTextFormat';
 import formatPhoneNumber from './formatPhoneNumber';
@@ -22,7 +22,7 @@ import validatePhoneNumber from './validatePhoneNumber';
 export {
   cleanMarkup,
   colorHover,
-  currentUserIsLeader,
+  currentUserIsMemberType,
   createMarkup,
   dateTextFormat,
   formatPhoneNumber,


### PR DESCRIPTION
### About

This PR introduces support for a new "Coach" role in group member logic. The changes generalize the previous `currentUserIsLeader` utility to a more flexible `currentUserIsMemberType`, allowing checks for any member type (Leader, Coach, Member). The UI and GraphQL queries are updated to support and display coaches alongside leaders and members in group contexts.

### Screenshots
<img width="1250" alt="image" src="https://github.com/user-attachments/assets/e252a666-2823-49f9-958c-2864780dedc6" />

### Test Instructions
1. Ensure you can view group pages as a user with different roles (Leader, Coach, Member).
2. Verify that both leaders and coaches see the appropriate UI elements (e.g., special buttons).
3. Check that the GraphQL queries for group data now include a `coaches` field, and that coaches are listed and counted correctly.
4. Confirm that all references to `currentUserIsLeader` have been replaced with `currentUserIsMemberType` and that functionality remains correct for leaders.

### Closes Tickets
[CFDP-3427](https://christfellowshipchurch.atlassian.net/browse/CFDP-3427)