### PR TITLE
Location Service Times Translation Update

### DIFF
--- a/lib/locationData.js
+++ b/lib/locationData.js
@@ -7,14 +7,14 @@ const additionalInfoCampusData = [
     name: 'Palm Beach Gardens',
     info: [
       'Kids services take place at each service',
-      'Traducciones al español ofrecidas a las 11:45AM',
+      'Traducciones al español ofrecidas a las 11:30AM',
     ],
   },
   {
     name: 'Port St. Lucie',
     info: [
       'Kids services take place at each service',
-      'Traducciones al español ofrecidas a las 10:15AM',
+      'Traducciones al español ofrecidas a las 9:45AM',
     ],
   },
   {


### PR DESCRIPTION
### About
This PR updates the service times that have the Spanish Translations for PBG & PSL.

### Test Instructions
1. Ensure PSL Spanish translation is set to 9:45AM in the orange section under Service Times.
2. Ensure PBG Spanish translation is set to 11:30AM in the orange section under Service Times.

### Screenshots
<img width="1431" height="771" alt="Screenshot 2025-09-04 at 10 06 24 AM" src="https://github.com/user-attachments/assets/447356c8-f596-4bdd-a34c-229902c5b4b0" />

### Closes Tickets
[CFDP-3583](https://christfellowshipchurch.atlassian.net/browse/CFDP-3583)

[CFDP-3583]: https://christfellowshipchurch.atlassian.net/browse/CFDP-3583?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ