### PR TITLE
Text Wrapping in Groups Bug Fix

### DIFF
--- a/ui-kit/GroupCard/GroupCard.styles.js
+++ b/ui-kit/GroupCard/GroupCard.styles.js
@@ -107,7 +107,7 @@ const GroupDescription = styled.p`
   -webkit-line-clamp: 3;
   -webkit-box-orient: vertical;
   overflow: hidden;
-  word-break: break-all;
+  word-break: break-word;
 
   ${system}
 `;


### PR DESCRIPTION
### About
Update GroupCard.styles.js to change word-break from break-all to break-word for the GroupDescription styled component. This prevents aggressive mid-word breaks, improving readability while keeping the existing multiline truncation (-webkit-line-clamp) and system props behavior.

### Test Instructions
1. Ensure text wrapping / word breaking is good in the group cards [here](https://web-app-v2-git-groups-card-text-102a01-christ-fellowship-church.vercel.app/groups/search).

### Screenshots
| Before | After |
|-|-|
|<img width="362" height="554" alt="Screenshot 2026-04-30 at 1 19 09 PM" src="https://github.com/user-attachments/assets/66f01f97-c0a3-485a-b4d0-c3a13a569b1c" />|<img width="357" height="543" alt="Screenshot 2026-04-30 at 1 18 16 PM" src="https://github.com/user-attachments/assets/f98c0e46-07e1-4161-94d3-44e3e848b8f3" />|


### Closes Tickets
[CFDP-3919](https://christfellowshipchurch.atlassian.net/browse/CFDP-3919)

[CFDP-3919]: https://christfellowshipchurch.atlassian.net/browse/CFDP-3919?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ