### PR TITLE
Set a Reminder BeenToCF Attribute Update

### DIFF
--- a/components/Modals/SetReminderModal/SetAReminderForm.js
+++ b/components/Modals/SetReminderModal/SetAReminderForm.js
@@ -54,8 +54,15 @@ function SetAReminderForm(props = {}) {
   // useForm handles all of our erros and value changes
   const { values, handleSubmit, handleChange, setValues } = useForm(() => {
     const currentErrors = {};
-    let { email, phoneNumber, serviceTime, campus, firstName, lastName } =
-      values;
+    let {
+      email,
+      phoneNumber,
+      serviceTime,
+      campus,
+      firstName,
+      lastName,
+      beenToCF,
+    } = values;
 
     if (
       isEmpty(email) ||
@@ -87,6 +94,10 @@ function SetAReminderForm(props = {}) {
       currentErrors.campus = 'Please select a campus';
     }
 
+    if (isEmpty(beenToCF)) {
+      currentErrors.beenToCF = 'Please select an option';
+    }
+
     setErrors(currentErrors);
 
     if (Object.keys(currentErrors).length > 0) {
@@ -104,6 +115,7 @@ function SetAReminderForm(props = {}) {
       email: values.email || '',
       campus: values.campus || '',
       serviceTime: values.serviceTime || '',
+      beenToCF: values.beenToCF || '',
     };
 
     try {

--- a/components/Modals/SetReminderModal/StyledForm.js
+++ b/components/Modals/SetReminderModal/StyledForm.js
@@ -1,5 +1,8 @@
 import React, { useEffect } from 'react';
-import { Box, Button, Icon, Loader, Select, TextInput } from 'ui-kit';
+import { Box, Button, Icon, Loader, Radio, Select, TextInput } from 'ui-kit';
+
+const BEEN_TO_CF_YES = 'Yes';
+const BEEN_TO_CF_NO_FIRST_TIME = "No, it's my first time";
 
 const DEFAULT_FORM_LABELS = {
   title: 'Set A Reminder!',
@@ -9,6 +12,9 @@ const DEFAULT_FORM_LABELS = {
   phoneNumber: 'Phone Number',
   serviceTime: 'Service Time',
   selectServiceTime: 'Select a Service Time',
+  beenToCFQuestion: 'Have you been to Christ Fellowship before?',
+  beenToCFYesLabel: BEEN_TO_CF_YES,
+  beenToCFNoFirstTimeLabel: BEEN_TO_CF_NO_FIRST_TIME,
   submit: 'SUBMIT',
 };
 
@@ -20,6 +26,9 @@ const SPANISH_FORM_LABELS = {
   phoneNumber: 'Número de Teléfono',
   serviceTime: 'Horarios de Servicios',
   selectServiceTime: 'Selecciona una hora de servicio',
+  beenToCFQuestion: '¿Has asistido a Christ Fellowship antes?',
+  beenToCFYesLabel: 'Sí',
+  beenToCFNoFirstTimeLabel: 'No, es mi primera vez',
   submit: 'ENVIAR',
 };
 
@@ -176,6 +185,42 @@ const StyledForm = ({
             </Box>
           ) : null}
         </Box>
+      </Box>
+      <Box width="100%" mt="l" alignSelf="stretch">
+        <Box fontWeight="bold" fontSize="s" mb="s">
+          {formLabels.beenToCFQuestion}
+        </Box>
+        <Box
+          display="flex"
+          flexDirection={{ _: 'column', sm: 'row' }}
+          alignItems={{ _: 'flex-start', sm: 'center' }}
+        >
+          <Box mr={{ _: 0, sm: 's' }} mb={{ _: 's', sm: 0 }}>
+            <Radio
+              id="beenToCF-yes"
+              name="beenToCF"
+              value={BEEN_TO_CF_YES}
+              label={formLabels.beenToCFYesLabel}
+              onChange={handleChange}
+              checked={values?.beenToCF === BEEN_TO_CF_YES}
+            />
+          </Box>
+          <Box>
+            <Radio
+              id="beenToCF-no-first"
+              name="beenToCF"
+              value={BEEN_TO_CF_NO_FIRST_TIME}
+              label={formLabels.beenToCFNoFirstTimeLabel}
+              onChange={handleChange}
+              checked={values?.beenToCF === BEEN_TO_CF_NO_FIRST_TIME}
+            />
+          </Box>
+        </Box>
+        {errors?.beenToCF ? (
+          <Box as="p" color="alert" fontSize="s" mt="s">
+            {errors.beenToCF}
+          </Box>
+        ) : null}
       </Box>
       {errors?.networkError && (
         <Box display="flex" alignItems="center" color="alert" mb="s">

--- a/hooks/useSubmitSetReminder.js
+++ b/hooks/useSubmitSetReminder.js
@@ -17,6 +17,7 @@ export const SUBMIT_SET_REMINDER = gql`
     $email: String!
     $campus: String!
     $serviceTime: String!
+    $beenToCF: String!
   ) {
     submitSetReminder(
       input: [
@@ -26,6 +27,7 @@ export const SUBMIT_SET_REMINDER = gql`
         { field: "phoneNumber", value: $phoneNumber }
         { field: "campus", value: $campus }
         { field: "serviceTime", value: $serviceTime }
+        { field: "beenToCF", value: $beenToCF }
       ]
     )
   }


### PR DESCRIPTION
### About
Introduce a new "beenToCF" radio question to the Set A Reminder form (English/Spanish labels included) and surface validation for it. Persist the new field in form values and error handling, update the styled form to render two Radio options, and add the beenToCF variable/field to the GraphQL SUBMIT_SET_REMINDER mutation so the value is submitted with the request.

### Test Instructions
1. To test submission run this branch locally while running the Services GraphQL repo locally in the correct branch.
2. Ensure UI is good for mobile and desktop views.
3. Submit a Set a Reminder form and check the submission [here](https://rock.gocf.org/page/288?WorkflowTypeId=936), ensure your submission went through and it has the `BeenToCF` attribute filled.

### Screenshots
<img width="1091" height="762" alt="Screenshot 2026-05-12 at 11 44 03 AM" src="https://github.com/user-attachments/assets/18c840bc-5c75-44f9-82fe-3dda3bdec8d4" />


### Closes Tickets
[](https://christfellowshipchurch.atlassian.net/browse/CFDP-3899)