### PR TITLE
Plan a Visit

### DIFF
--- a/components/LocationSingle/LocationSingle.js
+++ b/components/LocationSingle/LocationSingle.js
@@ -26,6 +26,7 @@ import {
   headerData,
   setReminderVideos,
   setReminderData,
+  setReminderOnlineData,
   setReminderEspanolData,
   testimonials,
   thisWeekFeatureId,
@@ -137,25 +138,52 @@ function LocationSingle(props = {}) {
           <Divider bg="secondarySubdued" />
         </Box>
 
-        {/* This Week Feature */}
+        {/* This Week + Set a Reminder (Online) */}
         {campus === 'Online (CF Everywhere)' && (
-          <Box maxWidth={1100} mx="auto" width="100%" px="base" py="xl">
-            <Box
-              as="h2"
-              color="secondary"
-              width="100%"
-              textAlign="center"
-              mb="base"
-            >
-              This Week
+          <>
+            <Box maxWidth={1100} mx="auto" width="100%" px="base" py="xl">
+              <Box
+                as="h2"
+                color="secondary"
+                width="100%"
+                textAlign="center"
+                mb="base"
+              >
+                This Week
+              </Box>
+              <FeatureProvider
+                //hide normal title
+                dataOverride={{ title: '' }}
+                Component={HeroListFeature}
+                options={{ variables: { id: thisWeekFeatureId } }}
+              />
             </Box>
-            <FeatureProvider
-              //hide normal title
-              dataOverride={{ title: '' }}
-              Component={HeroListFeature}
-              options={{ variables: { id: thisWeekFeatureId } }}
-            />
-          </Box>
+            {setAReminderVideo ? (
+              <Box
+                maxWidth={{ _: 350, md: 600, lg: 800 }}
+                boxShadow="l"
+                borderRadius="xl"
+                overflow="hidden"
+                mt="xxl"
+                mx="auto"
+              >
+                <Video wistiaId={setAReminderVideo} />
+              </Box>
+            ) : null}
+            <Box width="100%" px={{ _: 'base', md: 'xl' }} pt="base" pb="xl">
+              <InfoCardList
+                {...setReminderOnlineData}
+                button={{
+                  id: 'set-reminder',
+                  title: 'Set a Reminder',
+                  onClick: () =>
+                    modalDispatch(
+                      showModal('SetReminder', { defaultCampus: campus })
+                    ),
+                }}
+              />
+            </Box>
+          </>
         )}
 
         {campus !== 'Online (CF Everywhere)' && (

--- a/components/LocationSingle/LocationSingle.js
+++ b/components/LocationSingle/LocationSingle.js
@@ -158,7 +158,7 @@ function LocationSingle(props = {}) {
           </Box>
         )}
 
-        {campus !== 'Cf Everywhere' && (
+        {campus !== 'Online (CF Everywhere)' && (
           <>
             <Box
               maxWidth={{ _: 350, md: 600, lg: 800 }}
@@ -179,8 +179,8 @@ function LocationSingle(props = {}) {
                   id: 'set-reminder',
                   title:
                     campus === CFEPBG || campus === CFERPB
-                      ? 'Recuérdame'
-                      : 'Set a Reminder',
+                      ? 'Visítanos'
+                      : 'Plan a Visit',
                   onClick: () =>
                     modalDispatch(
                       showModal('SetReminder', { defaultCampus: campus })
@@ -251,7 +251,7 @@ function LocationSingle(props = {}) {
                   : 'UniversalContentItem:ddf0d380759e8404fb6b70aa941c06f7'
               }
               buttonOverride={
-                campus !== 'Cf Everywhere' ? '/events' : '/discover'
+                campus !== 'Online (CF Everywhere)' ? '/events' : '/discover'
               }
             />
           </Box>

--- a/components/Modals/ConnectCardModal/Confirmation.js
+++ b/components/Modals/ConnectCardModal/Confirmation.js
@@ -55,7 +55,7 @@ const ConfirmationScreen = (props = {}) => {
       display="flex"
       flexDirection="column"
       alignItems="center"
-      p={props?.campus ? '' : 'l'} // Padding is only applied if campus is not provided(Not Set a Reminder)
+      p={props?.campus ? '' : 'l'} // Padding is only applied if campus is not provided (non–location flow)
       textAlign="center"
     >
       <Icon name="check" color="success" size="100" />

--- a/components/Modals/SetReminderModal/SetAReminderForm.js
+++ b/components/Modals/SetReminderModal/SetAReminderForm.js
@@ -54,8 +54,15 @@ function SetAReminderForm(props = {}) {
   // useForm handles all of our erros and value changes
   const { values, handleSubmit, handleChange, setValues } = useForm(() => {
     const currentErrors = {};
-    let { email, phoneNumber, serviceTime, campus, firstName, lastName } =
-      values;
+    let {
+      email,
+      phoneNumber,
+      serviceTime,
+      campus,
+      firstName,
+      lastName,
+      beenToCF,
+    } = values;
 
     if (
       isEmpty(email) ||
@@ -87,6 +94,10 @@ function SetAReminderForm(props = {}) {
       currentErrors.campus = 'Please select a campus';
     }
 
+    if (isEmpty(beenToCF)) {
+      currentErrors.beenToCF = 'Please select an option';
+    }
+
     setErrors(currentErrors);
 
     if (Object.keys(currentErrors).length > 0) {
@@ -104,6 +115,7 @@ function SetAReminderForm(props = {}) {
       email: values.email || '',
       campus: values.campus || '',
       serviceTime: values.serviceTime || '',
+      beenToCF: values.beenToCF || '',
     };
 
     try {

--- a/components/Modals/SetReminderModal/StyledForm.js
+++ b/components/Modals/SetReminderModal/StyledForm.js
@@ -4,8 +4,11 @@ import { Box, Button, Icon, Loader, Radio, Select, TextInput } from 'ui-kit';
 const BEEN_TO_CF_YES = 'Yes';
 const BEEN_TO_CF_NO_FIRST_TIME = "No, it's my first time";
 
+const PLAN_A_VISIT_TITLE = 'Plan a Visit!';
+const SET_A_REMINDER_TITLE = 'Set A Reminder!';
+
 const DEFAULT_FORM_LABELS = {
-  title: 'Set A Reminder!',
+  title: PLAN_A_VISIT_TITLE,
   firstName: 'First Name',
   lastName: 'Last Name',
   email: 'Email',
@@ -19,7 +22,7 @@ const DEFAULT_FORM_LABELS = {
 };
 
 const SPANISH_FORM_LABELS = {
-  title: 'Recuérdame',
+  title: 'Visítanos',
   firstName: 'Primer Nombre',
   lastName: 'Apellido',
   email: 'Correo Electrónico',
@@ -59,8 +62,16 @@ const StyledForm = ({
   campuses,
   serviceTimes,
 }) => {
-  const isSpanish = defaultUserCampus.includes('Español');
-  const formLabels = isSpanish ? SPANISH_FORM_LABELS : DEFAULT_FORM_LABELS;
+  const isSpanish = defaultUserCampus?.includes('Español');
+  const isOnlineCampus =
+    defaultUserCampus === 'Online (CF Everywhere)' ||
+    defaultUserCampus === 'Cf Everywhere';
+  const formLabels = isSpanish
+    ? SPANISH_FORM_LABELS
+    : {
+        ...DEFAULT_FORM_LABELS,
+        title: isOnlineCampus ? SET_A_REMINDER_TITLE : PLAN_A_VISIT_TITLE,
+      };
 
   useEffect(() => {
     if (!window.location.pathname.includes('set-reminder-opened')) {

--- a/components/Modals/SetReminderModal/StyledForm.js
+++ b/components/Modals/SetReminderModal/StyledForm.js
@@ -1,5 +1,8 @@
 import React, { useEffect } from 'react';
-import { Box, Button, Icon, Loader, Select, TextInput } from 'ui-kit';
+import { Box, Button, Icon, Loader, Radio, Select, TextInput } from 'ui-kit';
+
+const BEEN_TO_CF_YES = 'Yes';
+const BEEN_TO_CF_NO_FIRST_TIME = "No, it's my first time";
 
 const DEFAULT_FORM_LABELS = {
   title: 'Set A Reminder!',
@@ -9,6 +12,9 @@ const DEFAULT_FORM_LABELS = {
   phoneNumber: 'Phone Number',
   serviceTime: 'Service Time',
   selectServiceTime: 'Select a Service Time',
+  beenToCFQuestion: 'Have you been to Christ Fellowship before?',
+  beenToCFYesLabel: BEEN_TO_CF_YES,
+  beenToCFNoFirstTimeLabel: BEEN_TO_CF_NO_FIRST_TIME,
   submit: 'SUBMIT',
 };
 
@@ -20,6 +26,9 @@ const SPANISH_FORM_LABELS = {
   phoneNumber: 'Número de Teléfono',
   serviceTime: 'Horarios de Servicios',
   selectServiceTime: 'Selecciona una hora de servicio',
+  beenToCFQuestion: '¿Has asistido a Christ Fellowship antes?',
+  beenToCFYesLabel: 'Sí',
+  beenToCFNoFirstTimeLabel: 'No, es mi primera vez',
   submit: 'ENVIAR',
 };
 
@@ -176,6 +185,42 @@ const StyledForm = ({
             </Box>
           ) : null}
         </Box>
+      </Box>
+      <Box width="100%" mt="l" alignSelf="stretch">
+        <Box fontWeight="bold" fontSize="s" mb="s">
+          {formLabels.beenToCFQuestion}
+        </Box>
+        <Box
+          display="flex"
+          flexDirection={{ _: 'column', sm: 'row' }}
+          alignItems={{ _: 'flex-start', sm: 'center' }}
+        >
+          <Box mr={{ _: 0, sm: 's' }} mb={{ _: 's', sm: 0 }}>
+            <Radio
+              id="beenToCF-yes"
+              name="beenToCF"
+              value={BEEN_TO_CF_YES}
+              label={formLabels.beenToCFYesLabel}
+              onChange={handleChange}
+              checked={values?.beenToCF === BEEN_TO_CF_YES}
+            />
+          </Box>
+          <Box>
+            <Radio
+              id="beenToCF-no-first"
+              name="beenToCF"
+              value={BEEN_TO_CF_NO_FIRST_TIME}
+              label={formLabels.beenToCFNoFirstTimeLabel}
+              onChange={handleChange}
+              checked={values?.beenToCF === BEEN_TO_CF_NO_FIRST_TIME}
+            />
+          </Box>
+        </Box>
+        {errors?.beenToCF ? (
+          <Box as="p" color="alert" fontSize="s" mt="s">
+            {errors.beenToCF}
+          </Box>
+        ) : null}
       </Box>
       {errors?.networkError && (
         <Box display="flex" alignItems="center" color="alert" mb="s">

--- a/hooks/useSubmitSetReminder.js
+++ b/hooks/useSubmitSetReminder.js
@@ -17,6 +17,7 @@ export const SUBMIT_SET_REMINDER = gql`
     $email: String!
     $campus: String!
     $serviceTime: String!
+    $beenToCF: String!
   ) {
     submitSetReminder(
       input: [
@@ -26,6 +27,7 @@ export const SUBMIT_SET_REMINDER = gql`
         { field: "phoneNumber", value: $phoneNumber }
         { field: "campus", value: $campus }
         { field: "serviceTime", value: $serviceTime }
+        { field: "beenToCF", value: $beenToCF }
       ]
     )
   }

--- a/hooks/useSubmitSetReminder.js
+++ b/hooks/useSubmitSetReminder.js
@@ -4,7 +4,7 @@
  * Author: Daniel Wood
  * Created: June 18, 2022
  *
- * Hook for triggering the Set a Reminder workflow.
+ * Hook for triggering the plan-a-visit / set-a-reminder workflow.
  */
 
 import { gql, useMutation } from '@apollo/client';

--- a/lib/locationData.js
+++ b/lib/locationData.js
@@ -350,7 +350,7 @@ const headerData = [
   {
     name: 'Palm Beach Gardens',
     primaryButton: {
-      call: 'Set a Reminder',
+      call: 'Plan a Visit',
       modal: 'SetReminder',
       id: 'set-reminder',
     },
@@ -366,7 +366,7 @@ const headerData = [
   {
     name: 'Port St. Lucie',
     primaryButton: {
-      call: 'Set a Reminder',
+      call: 'Plan a Visit',
       modal: 'SetReminder',
       id: 'set-reminder',
     },
@@ -382,7 +382,7 @@ const headerData = [
   {
     name: 'Boynton Beach',
     primaryButton: {
-      call: 'Set a Reminder',
+      call: 'Plan a Visit',
       modal: 'SetReminder',
       id: 'set-reminder',
     },
@@ -398,7 +398,7 @@ const headerData = [
   {
     name: 'Belle Glade',
     primaryButton: {
-      call: 'Set a Reminder',
+      call: 'Plan a Visit',
       modal: 'SetReminder',
       id: 'set-reminder',
     },
@@ -414,7 +414,7 @@ const headerData = [
   {
     name: 'Downtown West Palm Beach',
     primaryButton: {
-      call: 'Set a Reminder',
+      call: 'Plan a Visit',
       modal: 'SetReminder',
       id: 'set-reminder',
     },
@@ -431,7 +431,7 @@ const headerData = [
     name: 'Royal Palm Beach',
     primaryButton: {
       modal: 'SetReminder',
-      call: 'Set a Reminder',
+      call: 'Plan a Visit',
       id: 'set-reminder',
     },
     backgroundVideo: {
@@ -445,7 +445,7 @@ const headerData = [
   {
     name: 'Jupiter',
     primaryButton: {
-      call: 'Set a Reminder',
+      call: 'Plan a Visit',
       modal: 'SetReminder',
       id: 'set-reminder',
     },
@@ -461,7 +461,7 @@ const headerData = [
   {
     name: 'Stuart',
     primaryButton: {
-      call: 'Set a Reminder',
+      call: 'Plan a Visit',
       modal: 'SetReminder',
       id: 'set-reminder',
     },
@@ -477,7 +477,7 @@ const headerData = [
   {
     name: 'Vero Beach',
     primaryButton: {
-      call: 'Set a Reminder',
+      call: 'Plan a Visit',
       modal: 'SetReminder',
       id: 'set-reminder',
     },
@@ -493,7 +493,7 @@ const headerData = [
   {
     name: 'Riviera Beach',
     primaryButton: {
-      call: 'Set a Reminder',
+      call: 'Plan a Visit',
       modal: 'SetReminder',
       id: 'set-reminder',
     },
@@ -509,7 +509,7 @@ const headerData = [
   {
     name: 'Boca Raton',
     primaryButton: {
-      call: 'Set a Reminder',
+      call: 'Plan a Visit',
       modal: 'SetReminder',
       id: 'set-reminder',
     },
@@ -525,7 +525,7 @@ const headerData = [
   {
     name: 'Okeechobee',
     primaryButton: {
-      call: 'Set a Reminder',
+      call: 'Plan a Visit',
       modal: 'SetReminder',
       id: 'set-reminder',
     },
@@ -541,7 +541,7 @@ const headerData = [
   {
     name: 'Trinity',
     primaryButton: {
-      call: 'Set a Reminder',
+      call: 'Plan a Visit',
       modal: 'SetReminder',
       id: 'set-reminder',
     },
@@ -557,7 +557,7 @@ const headerData = [
   {
     name: 'Westlake',
     primaryButton: {
-      call: 'Set a Reminder',
+      call: 'Plan a Visit',
       modal: 'SetReminder',
       id: 'set-reminder',
     },
@@ -585,7 +585,7 @@ const headerData = [
   {
     name: 'Christ Fellowship Español Palm Beach Gardens',
     primaryButton: {
-      call: 'Recuérdame',
+      call: 'Visítanos',
       modal: 'SetReminder',
       id: 'set-reminder',
     },
@@ -605,7 +605,7 @@ const headerData = [
   {
     name: 'Christ Fellowship Español Royal Palm Beach',
     primaryButton: {
-      call: 'Recuérdame',
+      call: 'Visítanos',
       modal: 'SetReminder',
       id: 'set-reminder',
     },
@@ -657,7 +657,7 @@ const whatToExpectVideos = {
 };
 
 const setReminderData = {
-  title: 'Set a Reminder for an Upcoming Service',
+  title: 'Plan a Visit for an Upcoming Service',
   subtitle:
     'Attending church for the first time has never been easier. We’ve created a simple way for you to schedule a visit and receive a reminder. Here’s how to do it.',
   cardColor: 'primary',

--- a/lib/locationData.js
+++ b/lib/locationData.js
@@ -682,8 +682,34 @@ const setReminderData = {
   ],
 };
 
+const setReminderOnlineData = {
+  title: 'Set a Reminder for an Upcoming Service',
+  subtitle:
+    'Attending church for the first time has never been easier. We’ve created a simple way for you to schedule a visit and receive a reminder. Here’s how to do it.',
+  cardColor: 'primary',
+  cards: [
+    {
+      title: 'Step 1',
+      description:
+        'Fill out your information and choose the online service you plan to join.',
+      icon: 'pen',
+    },
+    {
+      title: 'Step 2',
+      description: 'Receive a friendly reminder so you don’t miss the service.',
+      icon: 'notification',
+    },
+    {
+      title: 'Step 3',
+      description:
+        'Tune in this Sunday and start living the life you were created for.',
+      icon: 'bible',
+    },
+  ],
+};
+
 const setReminderEspanolData = {
-  title: 'Establece un recordatorio para el próximo servicio',
+  title: 'Planea tu visita para el próximo servicio',
   subtitle:
     'Atender a la iglesia por primera vez no es fácil. Es por esto que hemos creado una forma sencilla para que puedas programar una visita y recibir un recordatorio. Aquí te explicamos cómo hacerlo.',
   cardColor: 'primary',
@@ -786,6 +812,7 @@ export {
   setReminderVideos,
   whatToExpectVideos,
   setReminderData,
+  setReminderOnlineData,
   setReminderEspanolData,
   testimonials,
   thisWeekFeatureId,


### PR DESCRIPTION
## Summary
Adjust reminder/visit copy to distinguish in-person vs online campuses: English in-person labels now read 'Plan a Visit', Spanish labels read 'Visítanos', while online campuses retain 'Set a Reminder'. Adds isOnline checks and a computed button/heading label, threads isOnline into CTAs, and updates tests to reflect the new copy. Affected files: reminder form & modal components and tests, CTAs, connect-with-us, campus-info partial, and location-content.

## Screenshots
<img width="1511" height="667" alt="Screenshot 2026-05-13 at 4 24 57 PM" src="https://github.com/user-attachments/assets/c3de3a1d-c0ae-4b64-aaa0-bd16361c0b4a" />


## Testing
- [x] Ensure copy for buttons and title in English say "Plan a Visit" instead of "Set a Reminder" (except for Online campus, there it stays "Set a Reminder".
- [x] Ensure in Spanish it now says "Visítanos". I do not remember seeing copy for this so I translated myself, waiting on confirmation from Katie and what CFE or María want this to be.

## Tickets
[CFDP-3901](https://christfellowshipchurch.atlassian.net/browse/CFDP-3901)

## Changes Made

### New Components Added

- List any new React components created
- Include file paths and brief descriptions

### New Utilities

- List any new utility functions or helper components
- Include file paths and descriptions

### New Assets

- List any new images, animations, or other static assets
- Include file paths and descriptions

### Dependencies

- List any new dependencies added to package.json
- Include version numbers

### Route Implementation

- List any new routes or route modifications
- Include file paths and descriptions

### Key Features

- Highlight the main features implemented
- Focus on user-facing functionality
- Include any performance optimizations or accessibility improvements


[CFDP-3901]: https://christfellowshipchurch.atlassian.net/browse/CFDP-3901?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ